### PR TITLE
[FEATURE] Publications are now read from a yml file…

### DIFF
--- a/05_publications.md
+++ b/05_publications.md
@@ -12,7 +12,9 @@ SeqAn.
 
 If you use SeqAn in any of your academic works, please cite the latest SeqAn paper:
 
-* {% include cite.html cite="fu_mi_publications2103" %}
+<ul>
+<li>{% include cite.html cite="fu_mi_publications2103" %}</li>
+</ul>
 
 ## Publication by year
 
@@ -22,8 +24,10 @@ If you use SeqAn in any of your academic works, please cite the latest SeqAn pap
 
 ### {{ year.name }}
 
+<ul>
 {% for publication in year.items %}
-* {% include cite.html cite = publication.key %}
+<li>{% include cite.html cite = publication.key %}</li>
 {% endfor %}
+</ul>
 
 {% endfor %}

--- a/05_publications.md
+++ b/05_publications.md
@@ -12,19 +12,18 @@ SeqAn.
 
 If you use SeqAn in any of your academic works, please cite the latest SeqAn paper:
 
-* {% include cite.html cite='2017-09-12 14:16:48' %}
+* {% include cite.html cite="fu_mi_publications2103" %}
 
 ## Publication by year
 
-{%- assign publications_by_year = site.data.publications |group_by_exp: "item",
-"item.date | truncate: 4, ''" | sort: "name" | reverse -%}
+{%- assign publications_by_year = site.data.publications | group_by_exp: "item", "item.date | truncate: 4, ''" | sort: "name" | reverse -%}
 
 {% for year in publications_by_year %}
 
 ### {{ year.name }}
 
 {% for publication in year.items %}
-* {% include cite.html cite=publication.datestamp %}
+* {% include cite.html cite = publication.key %}
 {% endfor %}
 
 {% endfor %}

--- a/05_publications.md
+++ b/05_publications.md
@@ -6,24 +6,25 @@ header:
   overlay_image: http://www.seqan.de/wp-content/uploads/2016/02/apps.png
 ---
 
-On the left you have access to the archive of SeqAn-related publications. Please see [Google
+On the bottom you have access to the archive of SeqAn-related publications. Please see [Google
 Scholar](https://scholar.google.de/scholar?cites=6133524701503406018) for a complete list of applications that cite
 SeqAn.
 
 If you use SeqAn in any of your academic works, please cite the latest SeqAn paper:
 
-{% include cite.html cite="fu_mi_publications2103" %}
+* {% include cite.html cite='2017-09-12 14:16:48' %}
 
 ## Publication by year
 
-{%- assign publications_by_year = site.data.publications | group_by: "year" | sort: "name" | reverse -%}
+{%- assign publications_by_year = site.data.publications |group_by_exp: "item",
+"item.date | truncate: 4, ''" | sort: "name" | reverse -%}
 
 {% for year in publications_by_year %}
 
 ### {{ year.name }}
 
 {% for publication in year.items %}
-* {% include cite.html cite=publication.id %}
+* {% include cite.html cite=publication.datestamp %}
 {% endfor %}
 
 {% endfor %}

--- a/_apps/anise-and-basil.md
+++ b/_apps/anise-and-basil.md
@@ -1,7 +1,7 @@
 ---
 title: ANISE and BASIL
 layout: app
-cite: Holtgrewe:2015bna
+cite: '2011-06-09 13:52:15'
 contact: Manuel Holtgrewe
 categories: official
 links:

--- a/_apps/anise-and-basil.md
+++ b/_apps/anise-and-basil.md
@@ -1,7 +1,7 @@
 ---
 title: ANISE and BASIL
 layout: app
-cite: '2011-06-09 13:52:15'
+cite: fu_mi_publications1506
 contact: Manuel Holtgrewe
 categories: official
 links:

--- a/_apps/fiona.md
+++ b/_apps/fiona.md
@@ -1,0 +1,18 @@
+---
+title: Fiona, A parallel and automatic strategy for read error correction
+layout: app
+cite: '2014-08-26 14:02:44'
+contact: Marcel Schulz
+categories: official
+links:
+  download: http://packages.seqan.de/fiona/
+  source: https://github.com/seqan/seqan/tree/master/apps/fiona
+---
+
+**Motivation**: Fiona is a tool for the automatic correction of sequencing errors in reads produced by high throughput sequencing experiments. It uses an efficient implementation of suffix arrays to detect read overlaps with different seed lengths in parallel. Fiona was compared on several real datasets to state-of-the-art methods and  showed overall superior correction accuracy. It was also among the fastest. Additionaly, Fiona embarks unique characteristics which makes it a good choice over existing programs:
+
+* No parameters to set for the user. You just need to know the length of the genome!
+* Correction of both substitution and indel errors.
+* Optimal correction over a range of seed values.
+* Multicore-Parallelization using OpenMP.
+* Efficient, memory-saving implementation.

--- a/_apps/fiona.md
+++ b/_apps/fiona.md
@@ -1,7 +1,7 @@
 ---
 title: Fiona, A parallel and automatic strategy for read error correction
 layout: app
-cite: '2014-08-26 14:02:44'
+cite: fu_mi_publications1451
 contact: Marcel Schulz
 categories: official
 links:

--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -1,17 +1,11385 @@
-- id: Holtgrewe:2015bna
-  author: M. Holtgrewe, L. Kuchenbecker, and K. Reinert
-  title: Methods for the detection and assembly of novel sequence in high-throughput sequencing data.
-  journal: Bioinformatics (Oxford, England)
-  year: 2015
-  volume: 31
+---
+- date: 2017-08
+  place_of_pub: Saarbrücken/Wadern
+  subjects:
+  - G400
+  divisions:
+  - group_algbioinf
+  volume: 88
+  eprint_status: archive
+  dir: disk0/00/00/21/32
+  series: LIPICS
+  metadata_visibility: show
+  date_type: published
+  full_text_status: none
+  refereed: 'TRUE'
+  eprintid: 2132
+  title: 17th International Workshop on Algorithms in Bioinformatics (WABI 2017)
+  abstract: "This proceedings volume contains papers presented at the 17th Workshop
+    on Algorithms in Bioinformatics (WABI 2017), which was held in Boston, MA, USA
+    in conjunction with the 8th ACM Conference on Bioinformatics, Computational Biology,
+    and Health Informatics (ACM BCB) from August 21–23, 2017.\r\nThe Workshop on Algorithms
+    in Bioinformatics is an annual conference established in 2001 to cover all aspects
+    of algorithmic work in bioinformatics, computational biology, and systems biology.
+    The workshop is intended as a forum for discrete algorithms and machine-learning
+    methods that address important problems in molecular biology, that are founded
+    on sound models, that are computationally efficient, and that have been implemented
+    and tested in simulations and on real datasets. The meeting’s focus is on recent
+    research results, including significant work-in-progress, as well as identifying
+    and explore directions of future research.\r\nWABI 2017 is grateful for the support
+    of ACM-BCB in allowing us to cohost the meetings, as well as to ACM-BCB’s sponsors:
+    the Association for Computing Machinery (ACM) and ACM’s SIGBIO.\r\nIn 2017, a
+    total of 55 manuscripts were submitted to WABI from which 27 were selected for
+    presentation at the conference. This year, WABI is adopting a new proceedings
+    form, publishing the conference proceedings through the LIPIcs (Leibniz International
+    Proceedings in Informatics) proceedings series. Extended versions of selected
+    papers will be invited for publication in a thematic series in the journal Algorithms
+    for Molecular Biology (AMB), published by BioMed Central.\r\nThe 27 papers were
+    selected based on a thorough peer review, involving at least three independent
+    reviewers per submitted paper, followed by discussions among the WABI Program
+    Committee members. The selected papers cover a wide range of topics, including
+    statistical inference, phylogenetic studies, sequence and genome analysis, comparative
+    genomics, and mass spectrometry data analysis.\r\nWe thank all the authors of
+    submitted papers and the members of the WABI Program Committee and their reviewers
+    for their efforts that made this conference possible. We are also grateful to
+    the WABI Steering Committee for their help and advice. We also thank all the conference
+    participants and speakers who contribute to a great scientific program. In\r\nparticular,
+    we are indebted to the keynote speaker of the conference, Tandy Warnow, for her
+    presentation. We also thank Christopher Pockrandt for setting up the WABI webpage\r\nand
+    Umit Acar for his help with coordinating the WABI and ACM-BCB pages. Finally,
+    we thank the ACM-BCB Organizing Committee, especially Nurit Haspel and Lenore
+    Cowen,\r\nfor their hard work in making all of the local arrangements and working
+    closely with us to ensure a successful and exciting WABI and ACM-BCB."
+  editors:
+  - id:
+    name:
+      lineage:
+      family: Schwartz
+      given: Russell
+      honourific:
+  - name:
+      lineage:
+      family: Reinert
+      honourific:
+      given: Knut
+    id: knut.reinert@fu-berlin.de
+  status_changed: '2017-11-23 11:10:39'
+  userid: 132
+  type: book
+  publisher: Dagstuhl LIPIcs
+  rev_number: 7
+  related_url:
+  - url: http://nbn-resolving.de/urn:nbn:de:0030-drops-78120
+  datestamp: '2017-11-23 11:10:39'
+  pages: 394
+  lastmod: '2017-11-23 11:10:39'
+  ispublished: pub
+  isbn: 978-3-95977-050-7
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2132
+  official_url: http://www.dagstuhl.de/dagpub/978-3-95977-050-7
+- datestamp: '2017-03-03 14:40:13'
+  publication: Science
+  title: The Genome Sequence of Drosophila melanogaster
+  status_changed: '2009-03-11 11:26:43'
+  userid: 1
+  rev_number: 3
+  type: article
+  keywords: ASSEMBLY
+  lastmod: '2017-03-03 14:40:13'
+  ispublished: pub
+  uri: http://publications.imp.fu-berlin.de/id/eprint/324
+  eprint_status: archive
+  dir: disk0/00/00/03/24
+  pagerange: 2185-2195
+  date: 2000
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  volume: 287
+  refereed: 'TRUE'
+  eprintid: 324
+  number: 5461
+  item_issues_count: 0
+  metadata_visibility: show
+  full_text_status: none
+- ispublished: pub
+  lastmod: '2013-04-10 11:52:42'
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1143
+  official_url: http://dx.plos.org/10.1371/journal.pone.0040656
+  abstract: "Background: Proteases play an essential part in a variety of biological
+    processes. Beside their importance\r\nunder healthy conditions they are also known
+    to have a crucial role in complex diseases like cancer.\r\nIt was shown in the
+    last years that not only the fragments produced by proteases but also their dynamics,\r\nespecially
+    ex vivo, can serve as biomarkers. But so far, only a few approaches were taken
+    to explicitly\r\nmodel the dynamics of proteolysis in the context of mass spectrometry.\r\n\r\nResults:
+    We introduce a new concept model proteolytic processes, the degradation graph.
+    The degra-\r\ndation graph is an extension of the cleavage graph, a data structure
+    to reconstruct and visualize the\r\nproteolytic process. In contrast to previous
+    approaches we extended the model to incorporate endoproteolytic\r\nprocesses and
+    present a method to construct a degradation graph from mass spectrometry\r\ntime-series
+    data. Based on a degradation graph and the intensities extracted from the mass
+    spectra it is\r\npossible to estimate reaction rates of the underlying processes.
+    We further suggest a score to rate different\r\ndegradation graphs in their ability
+    to explain the observed data. This score is used in an iterative\r\nheuristic
+    to improve the structure of the initially constructed degradation graph.\r\n\r\nConclusion:
+    We show that the proposed method is able to recover all degraded and generated\r\npeptides,
+    the underlying reactions, and the reaction rates of proteolytic processes based
+    on mass spectrometry\r\ntime-series data. We use simulated and real data to demonstrate
+    that a given process can be\r\nreconstructed even in the presence of extensive
+    noise, isobaric signals and false identications. While the\r\nmodel is currently
+    only validated on peptide data it is also applicable to proteins, as long as the
+    necessary\r\ntime series data can be produced."
+  status_changed: '2013-04-10 11:52:42'
+  title: Inferring Proteolytic Processes from Mass Spectrometry Time Series Data Using
+    Degradation Graphs
+  publisher: Public Library of Science
+  rev_number: 18
+  type: article
+  userid: 1
+  creators:
+  - name:
+      family: Aiche
+      honourific:
+      given: S.
+      lineage:
+  - name:
+      honourific:
+      given: K.
+      family: Reinert
+      lineage:
+  - name:
+      lineage:
+      family: Schütte
+      honourific:
+      given: Ch.
+  - name:
+      lineage:
+      family: Hildebrand
+      given: D.
+      honourific:
+  - name:
+      given: H.
+      honourific:
+      family: Schlüter
+      lineage:
+  - name:
+      honourific:
+      given: T. O. F.
+      family: Conrad
+      lineage:
+  datestamp: '2012-06-11 17:28:03'
+  publication: PLoS ONE
+  related_url:
+  - type:
+    url: http://www.plosone.org/article/info%3Adoi%2F10.1371%2Fjournal.pone.0040656
+  - type: pub
+    url: http://plosone.org
+  item_issues_count: 0
+  date_type: published
+  full_text_status: none
+  metadata_visibility: show
+  number: 7
+  refereed: 'TRUE'
+  eprintid: 1143
+  date: '2012-07-17'
+  pagerange: e40656
+  volume: 7
+  divisions:
+  - group_comp-proteomics
+  - inst_math
+  - group_algbioinf
+  - inst_compsci
+  - group_biocomputing
+  subjects:
+  - G150
+  - C790
+  - G490
+  eprint_status: archive
+  issn: 1932-6203
+  dir: disk0/00/00/11/43
+- item_issues_count: 0
+  full_text_status: none
+  date_type: published
+  metadata_visibility: show
+  id_number: doi:10.1002/pmic.201400391
+  number: 8
+  refereed: 'TRUE'
+  eprintid: 1505
+  date: 2015-04
+  pagerange: 1443-1447
+  volume: 15
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  eprint_status: archive
+  issn: 16159853
+  dir: disk0/00/00/15/05
+  lastmod: '2016-11-15 14:01:31'
+  ispublished: pub
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1505
+  official_url: http://dx.doi.org/10.1002/pmic.201400391
+  abstract: 'MS-based proteomics and metabolomics are rapidly evolving research fields
+    driven by the development of novel instruments, experimental approaches, and analysis
+    methods. Monolithic analysis tools perform well on single tasks but lack the flexibility
+    to cope with the constantly changing requirements and experimental setups. Workflow
+    systems, which combine small processing tools into complex analysis pipelines,
+    allow custom-tailored and flexible data-processing workflows that can be published
+    or shared with collaborators. In this article, we present the integration of established
+    tools for computational MS from the open-source software framework OpenMS into
+    the workflow engine Konstanz Information Miner (KNIME) for the analysis of large
+    datasets and production of high-quality visualizations. We provide example workflows
+    to demonstrate combined data processing and visualization for three diverse tasks
+    in computational MS: isobaric mass tag based quantitation in complex experimental
+    setups, label-free quantitation and identification of metabolites, and quality
+    control for proteomics experiments.'
+  status_changed: '2016-11-15 14:01:31'
+  title: Workflows for automated downstream data analysis and visualization in large-scale
+    computational mass spectrometry
+  publisher: Wiley VCH
+  rev_number: 13
+  type: article
+  userid: 132
+  creators:
+  - id:
+    name:
+      lineage:
+      honourific:
+      given: S.
+      family: Aiche
+  - id:
+    name:
+      lineage:
+      given: T.
+      honourific:
+      family: Sachsenberg
+  - id:
+    name:
+      lineage:
+      honourific:
+      given: E.
+      family: Kenar
+  - id:
+    name:
+      family: Walzer
+      given: M.
+      honourific:
+      lineage:
+  - id:
+    name:
+      family: Wiswedel
+      honourific:
+      given: B.
+      lineage:
+  - name:
+      family: Kristl
+      given: T.
+      honourific:
+      lineage:
+    id:
+  - id:
+    name:
+      lineage:
+      family: Boyles
+      given: M.
+      honourific:
+  - id:
+    name:
+      lineage:
+      honourific:
+      given: A.
+      family: Duschl
+  - name:
+      family: Huber
+      honourific:
+      given: C. G.
+      lineage:
+    id:
+  - id:
+    name:
+      lineage:
+      family: Berthold
+      honourific:
+      given: M. R.
+  - name:
+      lineage:
+      family: Reinert
+      honourific:
+      given: K.
+    id: knut.reinert@fu-berlin.de
+  - id:
+    name:
+      lineage:
+      honourific:
+      given: O.
+      family: Kohlbacher
+  datestamp: '2015-02-12 12:07:57'
+  publication: PROTEOMICS
+- date: '2013-09-30'
+  place_of_pub: Berlin, Germany
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  eprint_status: archive
+  dir: disk0/00/00/14/45
+  item_issues_count: 0
+  metadata_visibility: show
+  date_type: published
+  full_text_status: public
+  institution: Freie Universität Berlin
+  eprintid: 1445
+  title: Inferring Proteolytic Processes from Mass Spectrometry Time Series Data
+  status_changed: '2014-08-20 10:50:26'
+  userid: 30
+  type: thesis
+  rev_number: 12
+  creators:
+  - name:
+      lineage:
+      given: S.
+      honourific:
+      family: Aiche
+  thesis_type: phd
+  documents:
+  - language: en
+    files:
+    - uri: http://publications.imp.fu-berlin.de/id/file/18059
+      mime_type: application/pdf
+      filesize: 3615721
+      datasetid: document
+      mtime: '2017-03-03 14:41:37'
+      fileid: 18059
+      filename: thesis_aiche_no_cv.pdf
+      objectid: 617
+    relation:
+    - uri: "/id/document/1276"
+      type: http://eprints.org/relation/hasVersion
+    - type: http://eprints.org/relation/hasVolatileVersion
+      uri: "/id/document/1276"
+    - type: http://eprints.org/relation/haspreviewThumbnailVersion
+      uri: "/id/document/1276"
+    rev_number: 4
+    security: public
+    eprintid: 1445
+    pos: 1
+    mime_type: application/pdf
+    content: published
+    uri: http://publications.imp.fu-berlin.de/id/document/617
+    main: thesis_aiche_no_cv.pdf
+    docid: 617
+    format: application/pdf
+  datestamp: '2014-08-20 10:50:26'
+  department: Mathematics and Computer Science
+  ispublished: pub
+  lastmod: '2017-03-03 14:41:37'
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1445
+- metadata_visibility: show
+  full_text_status: none
+  item_issues_count: 0
+  refereed: 'TRUE'
+  eprintid: 326
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  pagerange: 4-16
+  date: 2002
+  dir: disk0/00/00/03/26
+  eprint_status: archive
+  uri: http://publications.imp.fu-berlin.de/id/eprint/326
+  event_title: "Proceedings of the 1st European Conference on Computational Biology\t(ECCB
+    2002)"
+  lastmod: '2017-03-03 14:40:13'
+  ispublished: pub
+  userid: 1
+  type: conference_item
+  rev_number: 3
+  title: "Multiple Sequence alignment with arbitrary gap costs: Computing an\toptimal
+    solution using polyhedral combinatorics"
+  status_changed: '2009-03-11 11:26:44'
+  datestamp: '2017-03-03 14:40:13'
+  creators:
+  - name:
+      lineage:
+      family: Althaus
+      given: E.
+      honourific:
+  - name:
+      lineage:
+      given: A.
+      honourific:
+      family: Caprara
+  - name:
+      family: Lenhof
+      given: H.-P.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      family: Reinert
+      honourific:
+      given: K.
+- ispublished: pub
+  lastmod: '2017-03-03 14:40:13'
+  uri: http://publications.imp.fu-berlin.de/id/eprint/325
+  creators:
+  - name:
+      family: Althaus
+      given: E.
+      honourific:
+      lineage:
+  - name:
+      family: Caprara
+      given: A.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      given: H.-P.
+      honourific:
+      family: Lenhof
+  - name:
+      honourific:
+      given: K.
+      family: Reinert
+      lineage:
+  publication: Mathematical Programming
+  datestamp: '2017-03-03 14:40:13'
+  status_changed: '2009-03-11 11:26:44'
+  title: A Branch-and-Cut Algorithm for Multiple Sequence Alignment
+  type: article
+  rev_number: 3
+  userid: 1
+  number: 105
+  refereed: 'TRUE'
+  eprintid: 325
+  item_issues_count: 0
+  full_text_status: none
+  metadata_visibility: show
+  eprint_status: archive
+  dir: disk0/00/00/03/25
+  date: 2006
+  pagerange: 387-425
+  subjects:
+  - G400
+  divisions:
+  - group_algbioinf
+- volume: 9
+  subjects:
+  - G430
+  - C
+  divisions:
+  - group_algbioinf
+  place_of_pub: Los Alamitos, CA, USA
+  pagerange: 385-394
+  date: 2012-03
+  dir: disk0/00/00/10/47
+  eprint_status: archive
+  date_type: published
+  full_text_status: none
+  id_number: http://doi.ieeecomputersociety.org/10.1109/TCBB.2011.59
+  metadata_visibility: show
+  item_issues_count: 0
+  number: 2
+  eprintid: 1047
+  refereed: 'TRUE'
+  type: article
+  publisher: 'IEEE Computer Society Press '
+  rev_number: 13
+  userid: 132
+  abstract: Peptide sequencing from mass spectrometry data is a key step in proteome
+    research. Especially de novo sequencing, the identification of a peptide from
+    its spectrum alone, is still a challenge even for state-of-the-art algorithmic
+    approaches. In this paper we present ANTILOPE, a new fast and flexible approach
+    based on mathematical programming. It builds on the spectrum graph model and works
+    with a variety of scoring schemes. ANTILOPE combines Lagrangian relaxation for
+    solving an integer linear programming formulation with an adaptation of Yen’s
+    k shortest paths algorithm. It shows a significant improvement in running time
+    compared to mixed integer optimization and performs at the same speed like other
+    state-of-the-art tools. We also implemented a generic probabilistic scoring scheme
+    that can be trained automatically for a dataset of annotated spectra and is independent
+    of the mass spectrometer type. Evaluations on benchmark data show that ANTILOPE
+    is competitive to the popular state-of-the-art programs PepNovo and NovoHMM both
+    in terms of run time and accuracy. Furthermore, it offers increased flexibility
+    in the number of considered ion types. ANTILOPE will be freely available as part
+    of the open source proteomics library OpenMS.
+  status_changed: '2012-05-16 13:55:44'
+  title: Antilope - A Lagrangian Relaxation Approach to the de novo Peptide Sequencing
+    Problem
+  publication: 'IEEE/ACM Transactions on Computational Biology and Bioinformatics
+    (TCBB) '
+  datestamp: '2011-03-29 13:34:32'
+  creators:
+  - name:
+      family: Andreotti
+      honourific:
+      given: S.
+      lineage:
+  - name:
+      lineage:
+      family: Klau
+      honourific:
+      given: G. W.
+  - name:
+      lineage:
+      family: Reinert
+      given: K.
+      honourific:
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1047
+  ispublished: pub
+  lastmod: '2012-05-16 13:55:44'
+  note: 'doi: 10.1109/TCBB.2011.59'
+  official_url: http://doi.ieeecomputersociety.org/10.1109/TCBB.2011.59
+- official_url: http://www.ncbi.nlm.nih.gov/pubmed/24000925
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1454
+  ispublished: pub
+  lastmod: '2014-09-24 09:33:53'
+  datestamp: '2014-09-24 08:36:24'
+  publication: Journal of Computational Biology
+  creators:
+  - name:
+      given: S.
+      honourific:
+      family: Andreotti
+      lineage:
+  - name:
+      family: Reinert
+      honourific:
+      given: K.
+      lineage:
+  - name:
+      family: Canzar
+      honourific:
+      given: S.
+      lineage:
+  userid: 30
+  rev_number: 12
+  type: article
+  title: 'The duplication-loss small phylogeny problem: from cherries to trees.'
+  abstract: Abstract The reconstruction of the history of evolutionary genome-wide
+    events among a set of related organisms is of great biological interest since
+    it can help to reveal the genomic basis of phenotypes. The sequencing of whole
+    genomes faciliates the study of gene families that vary in size through duplication
+    and loss events, like transfer RNA. However, a high sequence similarity often
+    does not allow one to distinguish between orthologs and paralogs. Previous methods
+    have addressed this difficulty by taking into account flanking regions of members
+    of a family independently. We go one step further by inferring the order of genes
+    of (a set of) families for ancestral genomes by considering the order of these
+    genes on sequenced genomes. We present a novel branch-and-cut algorithm to solve
+    the two species small phylogeny problem in the evolutionary model of duplications
+    and losses. On average, our implementation, DupLoCut, improves the running time
+    of a recently proposed method in the experiments on six Vibrionaceae lineages
+    by a factor of Ã¢&lt;88&gt;Â¼200. Besides the mere improvement in running time,
+    the efficiency of our approach allows us to extend our model from cherries of
+    a species tree, that is, subtrees with two leaves, to the median of three species
+    setting. Being able to determine the median of three species is of key importance
+    to one of the most common approaches to ancestral reconstruction, and our experiments
+    show that its repeated computation considerably reduces the number of duplications
+    and losses along the tree both on simulated instances comprising 128 leaves and
+    a set of Bacillus genomes. Furthermore, in our simulations we show that a reduction
+    in cost goes hand in hand with an improvement of the predicted ancestral genomes.
+    Finally, we prove that the small phylogeny problem in the duplication-loss model
+    is NP-complete already for two species.
+  status_changed: '2014-09-24 09:33:53'
+  eprintid: 1454
+  refereed: 'TRUE'
+  number: 9
+  metadata_visibility: show
+  full_text_status: none
+  item_issues_count: 0
+  dir: disk0/00/00/14/54
+  eprint_status: archive
+  divisions:
+  - group_algbioinf
+  subjects:
+  - C
+  - G
+  volume: 20
+  date: 2013-09
+  pagerange: 643-59
+- userid: 132
+  rev_number: 13
+  publisher: Elsevier
+  type: article
+  title: In-depth analysis of protein inference algorithms using multiple search engines
+    and well-defined metrics
+  abstract: 'In mass spectrometry-based shotgun proteomics, protein identifications
+    are usually the desired result. However, most of the analytical methods are based
+    on the identification of reliable peptides and not the direct identification of
+    intact proteins. Thus, assembling peptides identified from tandem mass spectra
+    into a list of proteins, referred to as protein inference, is a critical step
+    in proteomics research. Currently, different protein inference algorithms and
+    tools are available for the proteomics community. Here, we evaluated five software
+    tools for protein inference (PIA, ProteinProphet, Fido, ProteinLP, MSBayesPro)
+    using three popular database search engines: Mascot, X!Tandem, and MS-GF +. All
+    the algorithms were evaluated using a highly customizable KNIME workflow using
+    four different public datasets with varying complexities (different sample preparation,
+    species and analytical instruments). We defined a set of quality control metrics
+    to evaluate the performance of each combination of search engines, protein inference
+    algorithm, and parameters on each dataset. We show that the results for complex
+    samples vary not only regarding the actual numbers of reported protein groups
+    but also concerning the actual composition of groups. Furthermore, the robustness
+    of reported proteins when using databases of differing complexities is strongly
+    dependant on the applied inference algorithm. Finally, merging the identifications
+    of multiple search engines does not necessarily increase the number of reported
+    proteins, but does increase the number of peptides per protein and thus can generally
+    be recommended.'
+  status_changed: '2017-01-12 10:08:32'
+  datestamp: '2016-08-31 09:06:41'
+  publication: Journal of Proteomics
+  creators:
+  - name:
+      family: Audain
+      given: Enrique
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      family: Uszkoreit
+      honourific:
+      given: Julian
+  - name:
+      lineage:
+      family: Sachsenberg
+      honourific:
+      given: Timo
+  - name:
+      family: Pfeuffer
+      honourific:
+      given: Julianus
+      lineage:
+  - name:
+      family: Liang
+      honourific:
+      given: Xiao
+      lineage:
+  - name:
+      honourific:
+      given: Henning
+      family: Hermjakob
+      lineage:
+  - name:
+      given: Aniel
+      honourific:
+      family: Sanchez
+      lineage:
+  - name:
+      family: Eisenacher
+      honourific:
+      given: Martin
+      lineage:
+  - name:
+      lineage:
+      family: Reinert
+      given: Knut
+      honourific:
+  - name:
+      lineage:
+      family: Tabb
+      honourific:
+      given: David L.
+  - name:
+      lineage:
+      honourific:
+      given: Oliver
+      family: Kohlbacher
+  - name:
+      lineage:
+      family: Perez-Riverol
+      given: Yasset
+      honourific:
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1939
+  ispublished: pub
+  lastmod: '2017-01-12 10:08:32'
+  official_url: http://dx.doi.org/10.1016/j.jprot.2016.08.002
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  volume: 150
+  date: '2017-01-06'
+  pagerange: 170-182
+  dir: disk0/00/00/19/39
+  issn: 18743919
+  eprint_status: archive
+  metadata_visibility: show
+  id_number: doi:10.1016/j.jprot.2016.08.002
+  full_text_status: none
+  date_type: published
+  item_issues_count: 0
+  refereed: 'TRUE'
+  eprintid: 1939
+- rev_number: 3
+  publisher: Wiley-Eastern
+  type: book_section
+  userid: 1
+  status_changed: '2009-03-11 11:26:45'
+  title: Mass Spectrometry and Computational Proteomics
+  datestamp: '2017-03-03 14:40:13'
+  creators:
+  - name:
+      honourific:
+      given: V.
+      family: Bafna
+      lineage:
+  - name:
+      lineage:
+      family: Reinert
+      given: K.
+      honourific:
+  uri: http://publications.imp.fu-berlin.de/id/eprint/327
+  ispublished: pub
+  lastmod: '2017-03-03 14:40:13'
+  book_title: Encyclopedia of Genetics, Genomics, Proteomics and Bioinformatics
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  date: 2005
+  dir: disk0/00/00/03/27
+  eprint_status: archive
+  full_text_status: none
+  metadata_visibility: show
+  item_issues_count: 0
+  eprintid: 327
+  refereed: 'TRUE'
+- creators:
+  - name:
+      honourific:
+      given: J. A.
+      family: Bailey
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: Z.
+      family: Gu
+  - name:
+      lineage:
+      family: Clark
+      honourific:
+      given: R. A.
+  - name:
+      honourific:
+      given: K.
+      family: Reinert
+      lineage:
+  - name:
+      family: Samonte
+      honourific:
+      given: R. V.
+      lineage:
+  - name:
+      lineage:
+      family: Schwartz
+      given: S. S.
+      honourific:
+  - name:
+      lineage:
+      given: M. D.
+      honourific:
+      family: Adams
+  - name:
+      lineage:
+      given: E. W.
+      honourific:
+      family: Myers
+  - name:
+      lineage:
+      honourific:
+      given: P.
+      family: Li
+  - name:
+      given: E. E.
+      honourific:
+      family: Eichler
+      lineage:
+  datestamp: '2017-03-03 14:40:13'
+  publication: Science
+  title: Recent Segmental Duplications in the Human Genome
+  status_changed: '2009-03-11 11:26:45'
+  userid: 1
+  type: article
+  rev_number: 3
+  ispublished: pub
+  lastmod: '2017-03-03 14:40:13'
+  uri: http://publications.imp.fu-berlin.de/id/eprint/328
+  eprint_status: archive
+  dir: disk0/00/00/03/28
+  date: 2002
+  pagerange: 1003-1007
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  volume: 297
+  refereed: 'TRUE'
+  eprintid: 328
+  item_issues_count: 0
+  metadata_visibility: show
+  full_text_status: none
+- monograph_type: technical_report
+  datestamp: '2009-04-14 14:41:05'
+  creators:
+  - name:
+      honourific:
+      given: G.
+      family: Baudis
+      lineage:
+  - name:
+      family: Gröpl
+      given: C.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      family: Hougardy
+      given: S.
+      honourific:
+  - name:
+      family: Nierhoff
+      honourific:
+      given: T.
+      lineage:
+  - name:
+      honourific:
+      given: H.-J.
+      family: Prömel
+      lineage:
+  userid: 1
+  rev_number: 3
+  type: monograph
+  title: Approximating Minimum Spanning Sets in Hypergraphs and Polymatroids
+  status_changed: '2009-03-11 11:26:46'
+  keywords: "Hypergraphs, set systems, and designs, Steiner trees, Approximation\talgorithms,
+    Colouring, packing and covering, Combinatorial optimization,\r\n\tGraph algorithms"
+  uri: http://publications.imp.fu-berlin.de/id/eprint/329
+  note: "This paper was already accepted for ICALP 2000 but we did not present\tit
+    since later we were informed that the main result had already\r\n\tbeen proven
+    in a different way."
+  lastmod: '2009-04-14 14:41:05'
+  ispublished: pub
+  dir: disk0/00/00/03/29
+  eprint_status: archive
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  date: 2000
+  institution: Humboldt-University Berlin
+  refereed: 'TRUE'
+  eprintid: 329
+  metadata_visibility: show
+  full_text_status: none
+  item_issues_count: 0
+- date: 2008
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  eprint_status: archive
+  dir: disk0/00/00/03/31
+  item_issues_count: 0
+  full_text_status: none
+  metadata_visibility: show
+  eprintid: 331
+  refereed: 'TRUE'
+  status_changed: '2009-03-11 11:26:47'
+  title: "An Exact Mathematical Programming Approach to Multiple RNA Sequence-Structure\tAlignment."
+  type: article
+  rev_number: 3
+  userid: 1
+  creators:
+  - name:
+      family: Bauer
+      given: M.
+      honourific:
+      lineage:
+  - name:
+      family: Klau
+      given: G. W.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      family: Reinert
+      honourific:
+      given: K.
+  datestamp: '2009-08-20 09:47:13'
+  publication: Algorithmic Operations Research
+  ispublished: pub
+  lastmod: '2009-08-20 09:47:13'
+  note: to appear
+  uri: http://publications.imp.fu-berlin.de/id/eprint/331
+- type: conference_item
+  rev_number: 3
+  userid: 1
+  status_changed: '2009-03-11 11:26:49'
+  title: "Fast and Accurate Structural RNA Alignment by Progressive Lagrangian\tRelaxation"
+  datestamp: '2017-03-03 14:40:13'
+  creators:
+  - name:
+      lineage:
+      given: M.
+      honourific:
+      family: Bauer
+  - name:
+      given: G. W.
+      honourific:
+      family: Klau
+      lineage:
+  - name:
+      given: K.
+      honourific:
+      family: Reinert
+      lineage:
+  uri: http://publications.imp.fu-berlin.de/id/eprint/334
+  event_title: "Proceedings of the 1st International Symposium on Computational Life\tScience
+    (CompLife-05)"
+  lastmod: '2017-03-03 14:40:13'
+  ispublished: pub
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  pagerange: 217-228
+  date: 2005
+  dir: disk0/00/00/03/34
+  eprint_status: archive
+  full_text_status: none
+  metadata_visibility: show
+  item_issues_count: 0
+  refereed: 'TRUE'
+  eprintid: 334
+- dir: disk0/00/00/03/33
+  eprint_status: archive
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  pagerange: 303-314
+  date: 2005
+  eprintid: 333
+  refereed: 'TRUE'
+  metadata_visibility: show
+  full_text_status: none
+  item_issues_count: 0
+  datestamp: '2017-03-03 14:40:13'
+  creators:
+  - name:
+      given: M.
+      honourific:
+      family: Bauer
+      lineage:
+  - name:
+      family: Klau
+      honourific:
+      given: G. W.
+      lineage:
+  - name:
+      given: K.
+      honourific:
+      family: Reinert
+      lineage:
+  userid: 1
+  rev_number: 3
+  type: conference_item
+  title: Multiple Structural RNA Alignment with Lagrangian Relaxation
+  status_changed: '2009-03-11 11:26:48'
+  event_title: Proceedings of the 5th Workshop on Algorithms Bioinformatics (WABI-05)
+  uri: http://publications.imp.fu-berlin.de/id/eprint/333
+  lastmod: '2017-03-03 14:40:13'
+  ispublished: pub
+- refereed: 'TRUE'
+  eprintid: 330
+  item_issues_count: 0
+  series: LNCS 3341
+  full_text_status: none
+  metadata_visibility: show
+  eprint_status: archive
+  dir: disk0/00/00/03/30
+  date: 2004
+  pagerange: 113-125
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  lastmod: '2017-03-03 14:40:13'
+  ispublished: pub
+  event_title: "Proceedings of the 15th International Symposium, ISAAC 2004, Hong\tKong"
+  uri: http://publications.imp.fu-berlin.de/id/eprint/330
+  creators:
+  - name:
+      lineage:
+      family: Bauer
+      honourific:
+      given: M.
+  - name:
+      lineage:
+      given: G. W.
+      honourific:
+      family: Klau
+  datestamp: '2017-03-03 14:40:13'
+  status_changed: '2009-03-11 11:26:47'
+  title: Structural Alignment of Two RNA Sequences with Lagrangian Relaxation
+  type: conference_item
+  publisher: Springer Verlag
+  rev_number: 3
+  userid: 1
+- creators:
+  - name:
+      family: Bauer
+      given: M.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: G. W.
+      family: Klau
+  - name:
+      lineage:
+      given: K.
+      honourific:
+      family: Reinert
+  datestamp: '2017-03-03 14:40:13'
+  publication: BMC Bioinformatics
+  status_changed: '2009-03-11 11:26:48'
+  title: "Accurate multiple sequence-structure alignment of RNA sequences using\tcombinatorial
+    optimization."
+  rev_number: 3
+  type: article
+  userid: 1
+  lastmod: '2017-03-03 14:40:13'
+  ispublished: pub
+  uri: http://publications.imp.fu-berlin.de/id/eprint/332
+  eprint_status: archive
+  dir: disk0/00/00/03/32
+  date: 2007-07
+  pagerange: 271
+  volume: 8
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  number: 1
+  eprintid: 332
+  refereed: 'TRUE'
+  item_issues_count: 0
+  full_text_status: none
+  metadata_visibility: show
+- eprint_status: archive
+  issn: 1999-4893
+  dir: disk0/00/00/04/50
+  date: 2009
+  pagerange: 692-709
+  volume: 2
+  subjects:
+  - G
+  divisions:
+  - group_algbioinf
+  number: 2
+  eprintid: 450
+  refereed: 'TRUE'
+  item_issues_count: 0
+  full_text_status: none
+  date_type: published
+  id_number: 10.3390/a2020692
+  metadata_visibility: show
+  creators:
+  - name:
+      given: R. A.
+      honourific:
+      family: Bauer
+      lineage:
+    id: ra.bauer@fu-berlin.de
+  - id:
+    name:
+      honourific:
+      given: K.
+      family: Rother
+      lineage:
+  - id:
+    name:
+      lineage:
+      family: Moor
+      honourific:
+      given: P.
+  - name:
+      lineage:
+      family: Reinert
+      given: K.
+      honourific:
+    id:
+  - name:
+      lineage:
+      family: Steinke
+      given: T.
+      honourific:
+    id:
+  - id:
+    name:
+      honourific:
+      given: J. M.
+      family: Bujnicki
+      lineage:
+  - id:
+    name:
+      lineage:
+      given: R.
+      honourific:
+      family: Preissner
+  datestamp: '2009-04-03 08:57:21'
+  publication: Algorithms and Molecular Sciences
+  status_changed: '2009-10-28 12:51:35'
+  abstract: "This work presents a generalized approach for the fast structural alignment
+    \r\nof thousands of macromolecular structures. The method uses string representations
+    of a macromolecular structure and a hash table that stores n-grams of a certain
+    size for searching. \r\nTo this end, macromolecular structure-to-string translators
+    were implemented for protein and RNA structures. A query against the index is
+    performed in two hierarchical steps to unite speed and precision. In the ﬁrst
+    step the query structure is translated into n-grams, and all target structures
+    containing these n-grams are retrieved from the hash table. In the second \r\nstep
+    all corresponding n-grams of the query and each target structure are subsequently
+    aligned, and after each alignment a score is calculated based on the matching
+    n-grams of query and target. The extendable framework enables the user to query
+    and structurally align thousands of protein and RNA structures on a commodity
+    machine and is available as \r\nopen source from http://la jolla.sf.net. "
+  title: Fast Structural Alignment of Biomolecules Using a Hash Table, N-Grams and
+    String Descriptors
+  type: article
+  publisher: MDPI
+  rev_number: 12
+  userid: 29
+  official_url: http://www.mdpi.com/1999-4893/2/2/692
+  lastmod: '2010-09-01 13:28:41'
+  ispublished: pub
+  uri: http://publications.imp.fu-berlin.de/id/eprint/450
+- datestamp: '2011-04-29 12:38:12'
+  publication: Methods in molecular biology (Clifton, N.J.)
+  creators:
+  - name:
+      given: C.
+      honourific:
+      family: Bielow
+      lineage:
+  - name:
+      family: Gröpl
+      given: C.
+      honourific:
+      lineage:
+  - name:
+      family: Kohlbacher
+      given: O.
+      honourific:
+      lineage:
+  - name:
+      given: K.
+      honourific:
+      family: Reinert
+      lineage:
+  userid: 30
+  type: book_section
+  publisher: Humana Press
+  rev_number: 11
+  title: Bioinformatics for qualitative and quantitative proteomics.
+  status_changed: '2011-04-29 12:38:12'
+  abstract: Mass spectrometry is today a key analytical technique to elucidate the
+    amount and content of proteins expressed in a certain cellular context. The degree
+    of automation in proteomics has yet to reach that of genomic techniques, but even
+    current technologies make a manual inspection of the data infeasible. This article
+    addresses the key algorithmic problems bioinformaticians face when handling modern
+    proteomic samples and shows common solutions to them. We provide examples on how
+    algorithms can be combined to build relatively complex analysis pipelines, point
+    out certain pitfalls and aspects worth considering and give a list of current
+    state-of-the-art tools.
+  official_url: http://www.ncbi.nlm.nih.gov/pubmed/21370091
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1067
+  book_title: Bioinformatics for Omics Data Methods and Protocols
+  lastmod: '2011-04-29 12:38:12'
+  ispublished: pub
+  dir: disk0/00/00/10/67
+  eprint_status: archive
+  divisions:
+  - group_algbioinf
+  subjects:
+  - C
+  - G
+  volume: 719
+  pagerange: 331-49
+  date: 2011-01
+  eprintid: 1067
+  refereed: 'FALSE'
+  metadata_visibility: show
+  full_text_status: none
+  item_issues_count: 0
+- official_url: http://pubs.acs.org/doi/abs/10.1021/pr100177k
+  uri: http://publications.imp.fu-berlin.de/id/eprint/895
+  note: online publication complete, printed publication to be expected
+  ispublished: pub
+  lastmod: '2010-09-01 13:25:48'
+  publication: J. Proteome Res.
+  datestamp: '2010-04-14 11:06:56'
+  creators:
+  - name:
+      honourific:
+      given: C.
+      family: Bielow
+      lineage:
+    id: bielow@mi.fu-berlin.de
+  - id:
+    name:
+      honourific:
+      given: S.
+      family: Ruzek
+      lineage:
+  - id:
+    name:
+      family: Huber
+      honourific:
+      given: C.
+      lineage:
+  - id: knut.reinert@fu-berlin.de
+    name:
+      family: Reinert
+      given: K.
+      honourific:
+      lineage:
+  userid: 168
+  publisher: ACS Publications
+  rev_number: 10
+  type: article
+  title: Optimal Decharging and Clustering of Charge Ladders Generated in ESI−MS
+  abstract: In electrospray ionization mass spectrometry (ESI−MS), peptide and protein
+    ions are usually observed in multiple charge states. Moreover, adduction of the
+    multiply charged species with other ions frequently results in quite complex signal
+    patterns for a single analyte, which significantly complicates the derivation
+    of quantitative information from the mass spectra. Labeling strategies targeting
+    the MS1 level further aggravate this situation, as multiple biological states
+    such as healthy or diseased must be represented simultaneously. We developed an
+    integer linear programming (ILP) approach, which can cluster signals belonging
+    to the same peptide or protein. The algorithm is general in that it models all
+    possible shifts of signals along the m/z axis. These shifts can be induced by
+    different charge states of the compound, the presence of adducts (e.g., potassium
+    or sodium), and/or a fixed mass label (e.g., from ICAT or nicotinic acid labeling),
+    or any combination of the above. We show that our approach can be used to infer
+    more features in labeled data sets, correct wrong charge assignments even in high-resolution
+    MS, improve mass precision, and cluster charged species in different charge states
+    and several adduct types.
+  status_changed: '2010-04-14 11:06:56'
+  eprintid: 895
+  refereed: 'TRUE'
+  number: 5
+  id_number: 10.1021/pr100177k
+  metadata_visibility: show
+  date_type: published
+  full_text_status: none
+  item_issues_count: 0
+  dir: disk0/00/00/08/95
+  issn: 1535-3893
+  eprint_status: archive
+  subjects:
+  - G400
+  divisions:
+  - group_algbioinf
+  volume: 9
+  pagerange: 2688-2695
+  date: '2010-03-04'
+- dir: disk0/00/00/14/44
+  eprint_status: archive
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  date: '2012-10-29'
+  place_of_pub: Berlin, Germany
+  institution: Freie Universität Berlin
+  eprintid: 1444
+  metadata_visibility: show
+  date_type: published
+  full_text_status: public
+  item_issues_count: 0
+  documents:
+  - formatdesc: Thesis (without CV)
+    content: published
+    mime_type: application/pdf
+    uri: http://publications.imp.fu-berlin.de/id/document/616
+    docid: 616
+    main: thesis_noCV.pdf
+    format: application/pdf
+    security: public
+    eprintid: 1444
+    pos: 1
+    rev_number: 4
+    language: en
+    files:
+    - fileid: 18031
+      objectid: 616
+      filename: thesis_noCV.pdf
+      datasetid: document
+      mtime: '2017-03-03 14:41:36'
+      mime_type: application/pdf
+      uri: http://publications.imp.fu-berlin.de/id/file/18031
+      filesize: 4488171
+    relation:
+    - uri: "/id/document/1275"
+      type: http://eprints.org/relation/hasVolatileVersion
+    - type: http://eprints.org/relation/haspreviewThumbnailVersion
+      uri: "/id/document/1275"
+    - type: http://eprints.org/relation/hasVersion
+      uri: "/id/document/1275"
+  thesis_type: phd
+  datestamp: '2014-08-20 09:50:37'
+  creators:
+  - name:
+      lineage:
+      given: C.
+      honourific:
+      family: Bielow
+  userid: 30
+  type: thesis
+  rev_number: 10
+  title: Quantification and Simulation of Liquid Chromatography-Mass Spectrometry
+    Data
+  abstract: "Computational mass spectrometry is a fast evolving field that has attracted
+    increased attention over the last couple of years.\r\nThe performance of software
+    solutions determines the success of analysis to a great extent. New algorithms
+    are required to reflect new experimental procedures and deal with new instrument
+    generations.\r\n\r\nOne essential component of algorithm development is the validation
+    (as well as comparison) of software on a broad range of\r\ndata sets. This requires
+    a gold standard (or so-called ground truth), which is usually obtained by manual
+    annotation of a real data set.\r\nComprehensive manually annotated public data
+    sets for mass spectrometry data are labor-intensive to produce and their quality
+    strongly depends on \r\nthe skill of the human expert. Some parts of the data
+    may even be impossible to annotate due to high levels of noise or other ambiguities.\r\nFurthermore,
+    manually annotated data is usually not available for all steps in a typical computational
+    analysis pipeline.\r\nWe thus developed the most comprehensive simulation software
+    to date, which allows to generate multiple levels of ground truth\r\nand features
+    a plethora of settings to reflect experimental conditions and instrument settings.\r\nThe
+    simulator is used to generate several distinct types of data. The data are subsequently
+    employed to evaluate existing algorithms.\r\nAdditionally, we employ simulation
+    to determine the influence of instrument attributes and sample complexity on the
+    ability of\r\nalgorithms to recover information. The results give valuable hints
+    on how to optimize experimental setups.\r\n\r\nFurthermore, this thesis introduces
+    two quantitative approaches, namely a decharging algorithm based on integer linear
+    programming \r\nand a new workflow for identification of differentially expressed
+    proteins for a large in vitro study on toxic compounds.\r\nDecharging infers the
+    uncharged mass of a peptide (or protein) by clustering all its charge variants.
+    The latter occur frequently under certain experimental conditions.\r\nWe employ
+    simulation to show that decharging is robust against missing values even for high
+    complexity data and that the algorithm outperforms\r\nother solutions in terms
+    of mass accuracy and run time on real data.\r\nThe last part of this thesis deals
+    with a new state-of-the-art workflow for protein quantification based on isobaric
+    tags for relative and absolute quantitation (iTRAQ). We devise\r\na new approach
+    to isotope correction, propose an experimental design, introduce new metrics of
+    iTRAQ data quality, and\r\nconfirm putative properties of iTRAQ data using a novel
+    approach.\r\n\r\nAll tools developed as part of this thesis are implemented in
+    OpenMS, a C++ library for computational mass spectrometry."
+  status_changed: '2014-08-20 09:50:37'
+  official_url: http://www.diss.fu-berlin.de/diss/receive/FUDISS_thesis_000000040013
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1444
+  department: Mathematics and Computer Science
+  lastmod: '2017-03-03 14:41:36'
+  ispublished: pub
+- eprintid: 1066
+  refereed: 'TRUE'
+  number: 7
+  metadata_visibility: show
+  id_number: 10.1021/pr200155f
+  date_type: published
+  full_text_status: public
+  item_issues_count: 0
+  dir: disk0/00/00/10/66
+  eprint_status: archive
+  subjects:
+  - G
+  divisions:
+  - group_comp-proteomics
+  - group_algbioinf
+  - group_biocomputing
+  volume: 10
+  pagerange: 2922-2929
+  date: 2011-07
+  official_url: http://dx.doi.org/10.1021/pr200155f
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1066
+  lastmod: '2017-03-03 14:41:04'
+  ispublished: pub
+  documents:
+  - rev_number: 4
+    language: en
+    files:
+    - objectid: 470
+      filename: pr200155f.pdf
+      fileid: 12627
+      mtime: '2017-03-03 14:41:04'
+      datasetid: document
+      filesize: 926401
+      uri: http://publications.imp.fu-berlin.de/id/file/12627
+      mime_type: application/pdf
+    relation:
+    - uri: "/id/document/1186"
+      type: http://eprints.org/relation/hasVersion
+    - uri: "/id/document/1186"
+      type: http://eprints.org/relation/haspreviewThumbnailVersion
+    - uri: "/id/document/1186"
+      type: http://eprints.org/relation/hasVolatileVersion
+    format: application/pdf
+    content: published
+    mime_type: application/pdf
+    uri: http://publications.imp.fu-berlin.de/id/document/470
+    main: pr200155f.pdf
+    docid: 470
+    eprintid: 1066
+    pos: 1
+    security: public
+  datestamp: '2011-04-29 10:33:41'
+  publication: Journal of Proteome Research
+  creators:
+  - name:
+      lineage:
+      given: C.
+      honourific:
+      family: Bielow
+  - name:
+      lineage:
+      given: S.
+      honourific:
+      family: Aiche
+  - name:
+      lineage:
+      family: Andreotti
+      given: S.
+      honourific:
+  - name:
+      lineage:
+      family: Reinert
+      honourific:
+      given: K.
+  userid: 30
+  type: article
+  rev_number: 16
+  title: 'MSSimulator: Simulation of Mass Spectrometry Data'
+  status_changed: '2011-11-28 09:09:08'
+  abstract: Mass spectrometry coupled to liquid chromatography (LC-MS and LC-MS/MS)
+    is commonly used to analyze the protein content of biological samples in large
+    scale studies, enabling quantitation and identification of proteins and peptides
+    using a wide range of experimental protocols, algorithms, and statistical models
+    to analyze the data. Currently it is difficult to compare the plethora of algorithms
+    for these tasks. So far, curated benchmark data exists for peptide identification
+    algorithms but data that represents a ground truth for the evaluation of LC-MS
+    data is limited. Hence there have been attempts to simulate such data in a controlled
+    fashion to evaluate and compare algorithms. We present MSSimulator, a simulation
+    software for LC-MS and LC-MS/MS experiments. Starting from a list of proteins
+    from a FASTA file,the simulation will perform in-silico digestion, retention time
+    prediction,  ionization filtering, and raw signal simulation (including MS/MS),
+    while providing many options to change the properties of the resultingdata like
+    elution profile shape, resolution and sampling rate. Several protocols for SILAC,
+    iTRAQ or MS(E) are available, in addition to the usual label-free approach, making
+    MSSimulator the most comprehensive simulator for LC-MS and LC-MS/MS data.
+- official_url: http://www.siam.org/proceedings/alenex/2010/alenex10.php
+  ispublished: pub
+  lastmod: '2010-09-01 13:33:56'
+  uri: http://publications.imp.fu-berlin.de/id/eprint/926
+  creators:
+  - name:
+      lineage:
+      family: Birn
+      given: M.
+      honourific:
+    id: marcelbirn@gmx.de
+  - name:
+      lineage:
+      honourific:
+      given: M.
+      family: Holtgrewe
+    id: holtgrewe@ira.uka.de
+  - id: 'sanders@kit.edu '
+    name:
+      lineage:
+      honourific:
+      given: P.
+      family: Sanders
+  - id: 'singler@kit.edu '
+    name:
+      family: Singler
+      honourific:
+      given: J.
+      lineage:
+  datestamp: '2010-08-23 12:48:49'
+  publication: 2010 Proceedings of the Twelfth Workshop on Algorithm Engineering and
+    Experiments (ALENEX)
+  abstract: We present a simple randomized data structure for two-dimensional point
+    sets that allows fast nearest neighbor queries in many cases. An implementation
+    outperforms several previous implementations for commonly used benchmarks.
+  status_changed: '2010-08-23 12:48:49'
+  title: Simple and Fast Nearest Neighbor Search
+  publisher: ACM SIAM
+  type: article
+  rev_number: 8
+  userid: 167
+  refereed: 'TRUE'
+  eprintid: 926
+  item_issues_count: 0
+  full_text_status: none
+  date_type: published
+  metadata_visibility: show
+  eprint_status: archive
+  dir: disk0/00/00/09/26
+  date: 2010
+  pagerange: 43-54
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+- userid: 1
+  type: monograph
+  rev_number: 3
+  title: "Efficient ordering of state variables and transition relation partitions\tin
+    symbolic model checking"
+  status_changed: '2009-03-11 11:26:49'
+  datestamp: '2009-04-14 14:44:15'
+  monograph_type: technical_report
+  creators:
+  - name:
+      lineage:
+      given: M.
+      honourific:
+      family: Block
+  - name:
+      family: Gröpl
+      honourific:
+      given: C.
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: H.
+      family: Preuss
+  - name:
+      given: H. J.
+      honourific:
+      family: Prömel
+      lineage:
+  - name:
+      family: Srivastav
+      honourific:
+      given: A.
+      lineage:
+  uri: http://publications.imp.fu-berlin.de/id/eprint/335
+  lastmod: '2009-04-14 14:44:15'
+  ispublished: pub
+  keywords: "Randomized algorithms and probabilistic analysis, VLSI-Design and\tlayout,
+    Binary Decision Diagrams, Hardware verification, Local search\r\n\tand metaheuristics"
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  date: 1997
+  dir: disk0/00/00/03/35
+  eprint_status: archive
+  metadata_visibility: show
+  full_text_status: none
+  item_issues_count: 0
+  refereed: 'TRUE'
+  eprintid: 335
+  institution: Humboldt-Universität zu Berlin
+- eprintid: 336
+  refereed: 'TRUE'
+  metadata_visibility: show
+  full_text_status: none
+  item_issues_count: 0
+  dir: disk0/00/00/03/36
+  eprint_status: archive
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  volume: B54Ak
+  pagerange: 15 pages
+  date: 2007
+  place_of_pub: Taormina
+  keywords: "Three-Connected Planar Graph, Cnet, Planar Graph, Enumeration, Random\tgraphs,
+    Random Generation, Dynamic Programming, Graph Theory"
+  uri: http://publications.imp.fu-berlin.de/id/eprint/336
+  lastmod: '2009-04-14 14:18:17'
+  ispublished: pub
+  publication: Séminaire Lotharingien de Combinatoire
+  datestamp: '2009-04-14 14:18:17'
+  creators:
+  - name:
+      family: Bodirsky
+      honourific:
+      given: M.
+      lineage:
+  - name:
+      given: C.
+      honourific:
+      family: Gröpl
+      lineage:
+  - name:
+      family: Johannsen
+      honourific:
+      given: D.
+      lineage:
+  - name:
+      family: Kang
+      given: M.
+      honourific:
+      lineage:
+  userid: 1
+  rev_number: 3
+  type: article
+  title: A direct decomposition of 3-connected planar graphs
+  status_changed: '2009-03-11 11:26:50'
+- creators:
+  - name:
+      lineage:
+      given: M.
+      honourific:
+      family: Bodirsky
+  - name:
+      lineage:
+      family: Gröpl
+      given: C.
+      honourific:
+  - name:
+      lineage:
+      family: Johannsen
+      honourific:
+      given: D.
+  - name:
+      lineage:
+      given: M.
+      honourific:
+      family: Kang
+  datestamp: '2009-04-14 14:32:56'
+  title: A direct decomposition of 3-connected planar graphs
+  status_changed: '2009-03-11 11:26:50'
+  userid: 1
+  type: conference_item
+  rev_number: 3
+  keywords: "Three-Connected Planar Graph, Cnet, Planar Graph, Enumeration, Random\tgraphs,
+    Random Generation, Dynamic Programming, Graph Theory"
+  ispublished: pub
+  lastmod: '2009-04-14 14:32:56'
+  uri: http://publications.imp.fu-berlin.de/id/eprint/337
+  event_title: "Proceedings of the 17th Annual International Conference on Formal\tPower
+    Series and Algebraic Combinatorics (FPSAC05)"
+  eprint_status: archive
+  dir: disk0/00/00/03/37
+  date: 2005
+  place_of_pub: Taormina
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  eprintid: 337
+  refereed: 'TRUE'
+  item_issues_count: 0
+  metadata_visibility: show
+  full_text_status: none
+- title: Decomposing, Counting, and Generating Unlabeled Cubic Planar Graphs
+  status_changed: '2009-03-11 11:26:53'
+  abstract: "We present an expected polynomial time algorithm to generate an unlabeled\tconnected
+    cubic planar graph uniformly at random. We first consider\r\n\trooted cubic planar
+    graphs, i.e., we count connected cubic planar\r\n\tgraphs up to isomorphisms that
+    fix a certain directed edge. Based\r\n\ton decompositions along the connectivity
+    structure, we derive recurrence\r\n\tformulas for counting the exact number of
+    rooted cubic planar graphs.\r\n\tThis leads to 3-connected planar graphs, which
+    have a unique embedding\r\n\ton the sphere; but special care has to be taken for
+    rooted graphs\r\n\tthat have a sense-reversing automorphism. Therefore we introduce\r\n\tthe
+    concept of colored networks, which stand in bijective correspondence\r\n\tto rooted
+    graphs with given symmetries. Colored networks can again\r\n\tbe decomposed along
+    their connectivity structure. For rooted 3-connected\r\n\tcubic planar graphs
+    embedded in the plane, we switch to the dual\r\n\tand count rooted triangulations.
+    All these numbers can be evaluated\r\n\tin polynomial time by dynamic programming.
+    We can use them to generate\r\n\trooted cubic planar graphs uniformly at random.
+    To generate connected\r\n\tcubic planar graphs without a root uniformly at random,
+    we apply\r\n\trejection sampling and obtain an expected polynomial time algorithm."
+  userid: 1
+  type: conference_item
+  rev_number: 3
+  creators:
+  - name:
+      lineage:
+      family: Bodirsky
+      honourific:
+      given: M.
+  - name:
+      lineage:
+      given: C.
+      honourific:
+      family: Gröpl
+  - name:
+      lineage:
+      honourific:
+      given: M.
+      family: Kang
+  datestamp: '2009-04-14 14:36:27'
+  lastmod: '2009-04-14 14:36:27'
+  ispublished: pub
+  event_title: "European Conference on Combinatorics, Graph Theory, and Applications\tEUROCOMB'03
+    Prague"
+  uri: http://publications.imp.fu-berlin.de/id/eprint/342
+  keywords: "Cubic Planar Graph, Planar Graph, Cubic Graph, Enumeration, Random\tgraphs,
+    Random Generation, Dynamic Programming, Graph Theory"
+  date: 2003
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  eprint_status: archive
+  dir: disk0/00/00/03/42
+  item_issues_count: 0
+  metadata_visibility: show
+  full_text_status: none
+  refereed: 'TRUE'
+  eprintid: 342
+- refereed: 'TRUE'
+  eprintid: 339
+  number: 3
+  metadata_visibility: show
+  full_text_status: none
+  item_issues_count: 0
+  dir: disk0/00/00/03/39
+  eprint_status: archive
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  volume: 379
+  date: 2007
+  pagerange: 377-386
+  keywords: "Labeled planar graph, Enumeration, Decomposition, Sampling algorithm,\tDynamic
+    programming, Graph theory"
+  official_url: http://www.sciencedirect.com/science/article/B6V1G-4N4PY45-5/2 /4c06fbabe635c3a288cbf0427e0b395d
+  uri: http://publications.imp.fu-berlin.de/id/eprint/339
+  lastmod: '2009-04-14 14:19:26'
+  ispublished: pub
+  datestamp: '2009-04-14 14:19:26'
+  publication: Theoretical Computer Science
+  creators:
+  - name:
+      honourific:
+      given: M.
+      family: Bodirsky
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: C.
+      family: Gröpl
+  - name:
+      lineage:
+      given: M.
+      honourific:
+      family: Kang
+  userid: 1
+  type: article
+  rev_number: 3
+  title: Generating labeled planar graphs uniformly at random
+  status_changed: '2009-03-11 11:26:52'
+  abstract: "We present a deterministic polynomial time algorithm to sample a labeled\tplanar
+    graph uniformly at random. Our approach uses recursive formulae\r\n\tfor the exact
+    number of labeled planar graphs with n vertices and\r\n\tm edges, based on a decomposition
+    into 1-, 2-, and 3-connected components.\r\n\tWe can then use known sampling algorithms
+    and counting formulae for\r\n\t3-connected planar graphs."
+- datestamp: '2009-04-14 14:37:56'
+  creators:
+  - name:
+      family: Bodirsky
+      given: M.
+      honourific:
+      lineage:
+  - name:
+      family: Gröpl
+      given: C.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: M.
+      family: Kang
+  userid: 1
+  rev_number: 3
+  publisher: Springer Verlag
+  type: conference_item
+  title: Generating labeled planar graphs uniformly at random
+  abstract: "We present an expected polynomial time algorithm to generate a labeled\tplanar
+    graph uniformly at random. To generate the planar graphs,\r\n\twe derive recurrence
+    formulas that count all such graphs with n vertices\r\n\tand m edges, based on
+    a decomposition into 1-, 2-, and 3-connected\r\n\tcomponents. For 3-connected
+    graphs we apply a recent random generation\r\n\talgorithm by Schaeffer and a counting
+    formula by Mullin and Schellenberg."
+  status_changed: '2009-03-11 11:26:53'
+  keywords: "Planar Graph, Enumeration, Random graphs, Random Generation, Dynamic\tProgramming,
+    Graph Theory"
+  uri: http://publications.imp.fu-berlin.de/id/eprint/341
+  event_title: Proceedings of ICALP 2003
+  note: "Appeared 2008 in Theoretical Computer Science. { The download is\tthe journal
+    submission &lt;br&gt; From time to time we receive requests\r\n\tfor source code,
+    so here it is: See the files BGK03b.README and GBK03b.tar.bz2\r\n\t}"
+  lastmod: '2009-04-14 14:37:56'
+  ispublished: pub
+  dir: disk0/00/00/03/41
+  eprint_status: archive
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  date: 2003
+  pagerange: 1095-1107
+  eprintid: 341
+  refereed: 'TRUE'
+  number: 2719
+  metadata_visibility: show
+  full_text_status: none
+  series: Lecture Notes in Computer Science
+  item_issues_count: 0
+- ispublished: pub
+  lastmod: '2009-04-14 14:13:28'
+  uri: http://publications.imp.fu-berlin.de/id/eprint/338
+  title: Generating unlabeled connected cubic planar graphs uniformly at random
+  status_changed: '2009-03-11 11:26:51'
+  abstract: "We present an expected polynomial time algorithm to generate an unlabeled\tconnected
+    cubic planar graph uniformly at random. We first consider\r\n\trooted connected
+    cubic planar graphs, i.e., we count connected cubic\r\n\tplanar graphs up to isomorphisms
+    that fix a certain directed edge.\r\n\tBased on decompositions along the connectivity
+    structure, we derive\r\n\trecurrence formulas for the exact number of rooted cubic
+    planar graphs.\r\n\tThis leads to rooted 3-connected cubic planar graphs, which
+    have\r\n\ta unique embedding on the sphere. Special care has to be taken for\r\n\trooted
+    graphs that have a sense-reversing automorphism. Therefore\r\n\twe introduce the
+    concept of colored networks, which stand in bijective\r\n\tcorrespondence to rooted
+    3-connected cubic planar graphs with given\r\n\tsymmetries. Colored networks can
+    again be decomposed along the connectivity\r\n\tstructure. For rooted 3-connected
+    cubic planar graphs embedded in\r\n\tthe plane, we switch to the dual and count
+    rooted triangulations.\r\n\tSince all these numbers can be evaluated in polynomial
+    time using\r\n\tdynamic programming, rooted connected cubic planar graphs can
+    be\r\n\tgenerated uniformly at random in polynomial time by inverting the\r\n\tdecomposition
+    along the connectivity structure. To generate connected\r\n\tcubic planar graphs
+    without a root uniformly at random, we apply\r\n\trejection sampling and obtain
+    an expected polynomial time algorithm"
+  userid: 1
+  rev_number: 3
+  type: article
+  creators:
+  - name:
+      honourific:
+      given: M.
+      family: Bodirsky
+      lineage:
+  - name:
+      lineage:
+      family: Gröpl
+      honourific:
+      given: C.
+  - name:
+      lineage:
+      family: Kang
+      given: M.
+      honourific:
+  publication: Random Structures and Algorithms
+  datestamp: '2009-04-14 14:13:28'
+  item_issues_count: 0
+  metadata_visibility: show
+  full_text_status: none
+  refereed: 'TRUE'
+  eprintid: 338
+  number: 2
+  date: 2008
+  pagerange: 157-180
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  volume: 32
+  eprint_status: archive
+  dir: disk0/00/00/03/38
+- refereed: 'TRUE'
+  eprintid: 340
+  item_issues_count: 0
+  full_text_status: none
+  metadata_visibility: show
+  eprint_status: archive
+  dir: disk0/00/00/03/40
+  date: 2005
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  keywords: "Planar Graph, Enumeration, Random graphs, Random Generation, Graph\tTheory"
+  ispublished: pub
+  lastmod: '2010-09-01 13:43:09'
+  uri: http://publications.imp.fu-berlin.de/id/eprint/340
+  event_title: "Proceedings of the 16th Annual International Symposium on Algorithms\tand
+    Computation (ISAAC05)"
+  creators:
+  - name:
+      lineage:
+      family: Bodirsky
+      given: M.
+      honourific:
+  - name:
+      lineage:
+      given: C.
+      honourific:
+      family: Gröpl
+  - name:
+      family: Kang
+      honourific:
+      given: M.
+      lineage:
+  datestamp: '2010-09-01 13:43:09'
+  status_changed: '2009-03-11 11:26:52'
+  title: Sampling Unlabeled Biconnected Planar Graphs
+  type: conference_item
+  rev_number: 3
+  userid: 1
+- datestamp: '2017-03-03 14:40:13'
+  creators:
+  - name:
+      family: Bradford
+      honourific:
+      given: P. G.
+      lineage:
+  - name:
+      lineage:
+      given: K.
+      honourific:
+      family: Reinert
+  type: conference_item
+  rev_number: 3
+  userid: 1
+  status_changed: '2009-03-11 11:26:54'
+  title: Lower Bounds for Row Minima Searching
+  event_title: "Proceedings of the 23rd International Colloquium on Automata, Languages,\tand
+    Programming 1996 (ICALP-96), LNCS 1099"
+  uri: http://publications.imp.fu-berlin.de/id/eprint/343
+  ispublished: pub
+  lastmod: '2017-03-03 14:40:13'
+  dir: disk0/00/00/03/43
+  eprint_status: archive
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  pagerange: 454-465
+  date: 1996
+  refereed: 'TRUE'
+  eprintid: 343
+  full_text_status: none
+  metadata_visibility: show
+  item_issues_count: 0
+- datestamp: '2019-08-29 10:32:18'
+  publication: Frontiers in Microbiology
+  creators:
+  - name:
+      lineage:
+      honourific:
+      given: Anne
+      family: Busch
+  - name:
+      lineage:
+      honourific:
+      given: Prasad
+      family: Thomas
+  - name:
+      given: Eric
+      honourific:
+      family: Zuchantke
+      lineage:
+  - name:
+      given: Holger
+      honourific:
+      family: Brendebach
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: Kerstin
+      family: Neubert
+  - name:
+      lineage:
+      family: Gruetzke
+      given: Josephine
+      honourific:
+  - name:
+      given: Sascha
+      honourific:
+      family: Al Dahouk
+      lineage:
+  - name:
+      lineage:
+      given: Martin
+      honourific:
+      family: Peters
+  - name:
+      honourific:
+      given: Helmut
+      family: Hotzel
+      lineage:
+  - name:
+      lineage:
+      family: Neubauer
+      given: Heinrich
+      honourific:
+  - name:
+      honourific:
+      given: Herbert
+      family: Tomaso
+      lineage:
+  type: article
+  rev_number: 5
+  userid: 132
+  abstract: Francisella (F.) tularensis is a highly virulent, Gram-negative bacterial
+    pathogen and the causative agent of the zoonotic disease tularemia. Here, we generated,
+    analyzed and characterized a high quality circular genome sequence of the F. tularensis
+    subsp. holarctica strain 12T0050 that caused fatal tularemia in a hare. Besides
+    the genomic structure, we focused on the analysis of oriC, unique to the Francisella
+    genus and regulating replication in and outside hosts and the first report on
+    genomic DNA methylation of a Francisella strain. The high quality genome was used
+    to establish and evaluate a diagnostic whole genome sequencing pipeline. A genotyping
+    strategy for F. tularensis was developed using various bioinformatics tools for
+    genotyping. Additionally, whole genome sequences of F. tularensis subsp. holarctica
+    isolates isolated in the years 2008–2015 in Germany were generated. A phylogenetic
+    analysis allowed to determine the genetic relatedness of these isolates and confirmed
+    the highly conserved nature of F. tularensis subsp. holarctica.
+  status_changed: '2019-08-29 10:32:18'
+  title: 'Revisiting Francisella tularensis subsp. holarctica, Causative Agent of
+    Tularemia in Germany With Bioinformatics: New Insights in Genome Structure, DNA
+    Methylation and Comparative Phylogenetic Analysis'
+  official_url: http://doi.org/10.3389/fmicb.2018.00344
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2374
+  ispublished: pub
+  lastmod: '2019-08-29 10:32:18'
+  issn: 1664-302X
+  dir: disk0/00/00/23/74
+  eprint_status: archive
+  volume: 9
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  date: '2018-03-13'
+  eprintid: 2374
+  refereed: 'TRUE'
+  date_type: published
+  full_text_status: none
+  id_number: doi:10.3389/fmicb.2018.00344
+  metadata_visibility: show
+- refereed: 'TRUE'
+  eprintid: 1132
+  number: 4
+  metadata_visibility: show
+  full_text_status: none
+  date_type: published
+  item_issues_count: 0
+  dir: disk0/00/00/11/32
+  issn: 1545-4963
+  eprint_status: archive
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  volume: 8
+  pagerange: 976-986
+  date: 2011-07
+  official_url: http://www.computer.org/csdl/trans/tb/2011/04/ttb2011040976.html
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1132
+  ispublished: pub
+  lastmod: '2012-05-16 14:17:03'
+  related_url:
+  - type: pub
+    url: http://www.computer.org/portal/web/tcbb
+  publication: 'IEEE/ACM Transactions on Computational Biology and Bioinformatics '
+  datestamp: '2012-04-10 14:19:34'
+  creators:
+  - id:
+    name:
+      honourific:
+      given: S.
+      family: Böcker
+      lineage:
+  - id: birte.kehr@fu-berlin.de
+    name:
+      lineage:
+      honourific:
+      given: B.
+      family: Kehr
+  - name:
+      lineage:
+      family: Rasche
+      given: F.
+      honourific:
+    id:
+  userid: 132
+  rev_number: 12
+  publisher: IEEE computer society, TCBB
+  type: article
+  title: Determination of Glycan Structure from Tandem Mass Spectra
+  abstract: Glycans are molecules made from simple sugars that form complex tree structures.
+    Glycans constitute one of the most important protein modifications and identification
+    of glycans remains a pressing problem in biology. Unfortunately, the structure
+    of glycans is hard to predict from the genome sequence of an organism. In this
+    paper, we consider the problem of deriving the topology of a glycan solely from
+    tandem mass spectrometry (MS) data. We study, how to generate glycan tree candidates
+    that sufficiently match the sample mass spectrum, avoiding the combinatorial explosion
+    of glycan structures. Unfortunately, the resulting problem is known to be computationally
+    hard. We present an efficient exact algorithm for this problem based on fixed-parameter
+    algorithmics that can process a spectrum in a matter of seconds. We also report
+    some preliminary results of our method on experimental data, combining it with
+    a preliminary candidate evaluation scheme. We show that our approach is fast in
+    applications, and that we can reach very well de novo identification results.
+    Finally, we show how to count the number of glycan topologies for a fixed size
+    or a fixed mass. We generalize this result to count the number of (labeled) trees
+    with bounded out degree, improving on results obtained using Pólya's enumeration
+    theorem.
+  status_changed: '2012-05-16 14:17:03'
+- item_issues_count: 0
+  date_type: published
+  full_text_status: none
+  id_number: doi:10.1186/s13059-015-0865-0
+  metadata_visibility: show
+  number: 1
+  eprintid: 1830
+  refereed: 'TRUE'
+  date: '2016-01-30'
+  volume: 17
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  eprint_status: archive
+  issn: 1474-760X
+  dir: disk0/00/00/18/30
+  lastmod: '2016-11-15 13:54:32'
+  ispublished: pub
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1830
+  official_url: http://dx.doi.org/10.1186/s13059-015-0865-0
+  abstract: We present CIDANE, a novel framework for genome-based transcript reconstruction
+    and quantification from RNA-seq reads. CIDANE assembles transcripts efficiently
+    with significantly higher sensitivity and precision than existing tools. Its algorithmic
+    core not only reconstructs transcripts ab initio, but also allows the use of the
+    growing annotation of known splice sites, transcription start and end sites, or
+    full-length transcripts, which are available for most model organisms. CIDANE
+    supports the integrated analysis of RNA-seq and additional gene-boundary data
+    and recovers splice junctions that are invisible to other methods. CIDANE is available
+    at http://​ccb.​jhu.​edu/​software/​cidane/​.
+  status_changed: '2016-11-15 13:54:32'
+  title: 'CIDANE: comprehensive isoform discovery and abundance estimation'
+  publisher: BioMed Central, Springer Science+Business Media
+  rev_number: 10
+  type: article
+  userid: 132
+  creators:
+  - name:
+      family: Canzar
+      honourific:
+      given: S.
+      lineage:
+    id:
+  - id:
+    name:
+      lineage:
+      family: Andreotti
+      given: S.
+      honourific:
+  - id:
+    name:
+      lineage:
+      given: D.
+      honourific:
+      family: Weese
+  - id: knut.reinert@fu-berlin.de
+    name:
+      lineage:
+      given: K.
+      honourific:
+      family: Reinert
+  - id:
+    name:
+      lineage:
+      given: G. W.
+      honourific:
+      family: Klau
+  publication: Genome Biology
+  datestamp: '2016-02-25 12:27:42'
+- id_number: doi:10.7717/peerj.3138
+  metadata_visibility: show
+  date_type: published
+  full_text_status: none
+  eprintid: 2119
+  refereed: 'TRUE'
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  volume: 5
+  pagerange: e3138
+  date: '2017-03-28'
+  dir: disk0/00/00/21/19
+  issn: 2167-8359
+  eprint_status: archive
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2119
+  ispublished: pub
+  lastmod: '2017-10-12 13:01:44'
+  official_url: http://doi.org/10.7717/peerj.3138
+  userid: 132
+  rev_number: 5
+  type: article
+  title: 'SLIMM: species level identification of microorganisms from metagenomes'
+  abstract: Identification and quantification of microorganisms is a significant step
+    in studying the alpha and beta diversities within and between microbial communities
+    respectively. Both identification and quantification of a given microbial community
+    can be carried out using whole genome shotgun sequences with less bias than when
+    using 16S-rDNA sequences. However, shared regions of DNA among reference genomes
+    and taxonomic units pose a significant challenge in assigning reads correctly
+    to their true origins. The existing microbial community profiling tools commonly
+    deal with this problem by either preparing signature-based unique references or
+    assigning an ambiguous read to its least common ancestor in a taxonomic tree.
+    The former method is limited to making use of the reads which can be mapped to
+    the curated regions, while the latter suffer from the lack of uniquely mapped
+    reads at lower (more specific) taxonomic ranks. Moreover, even if the tools exhibited
+    good performance in calling the organisms present in a sample, there is still
+    room for improvement in determining the correct relative abundance of the organisms.
+    We present a new method Species Level Identification of Microorganisms from Metagenomes
+    (SLIMM) which addresses the above issues by using coverage information of reference
+    genomes to remove unlikely genomes from the analysis and subsequently gain more
+    uniquely mapped reads to assign at lower ranks of a taxonomic tree. SLIMM is based
+    on a few, seemingly easy steps which when combined create a tool that outperforms
+    state-of-the-art tools in run-time and memory usage while being on par or better
+    in computing quantitative and qualitative information at species-level.
+  status_changed: '2017-10-12 13:01:44'
+  datestamp: '2017-10-12 13:01:44'
+  publication: PeerJ
+  creators:
+  - name:
+      lineage:
+      family: Dadi
+      given: Temesgen Hailemariam
+      honourific:
+  - name:
+      lineage:
+      family: Renard
+      given: Bernhard Y.
+      honourific:
+  - name:
+      lineage:
+      honourific:
+      given: Lothar H.
+      family: Wieler
+  - name:
+      lineage:
+      given: Torsten
+      honourific:
+      family: Semmler
+  - name:
+      lineage:
+      honourific:
+      given: Knut
+      family: Reinert
+- datestamp: '2018-11-08 11:49:07'
+  publication: Bioinformatics
+  creators:
+  - name:
+      lineage:
+      family: Dadi
+      honourific:
+      given: Temesgen Hailemariam
+  - name:
+      lineage:
+      given: Enrico
+      honourific:
+      family: Siragusa
+  - name:
+      lineage:
+      family: Piro
+      honourific:
+      given: Vitor C
+  - name:
+      family: Andrusch
+      given: Andreas
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      family: Seiler
+      honourific:
+      given: Enrico
+  - name:
+      honourific:
+      given: Bernhard Y
+      family: Renard
+      lineage:
+  - name:
+      honourific:
+      given: Knut
+      family: Reinert
+      lineage:
+  userid: 132
+  rev_number: 5
+  type: article
+  title: 'DREAM-Yara: an exact read mapper for very large databases with short update
+    time'
+  abstract: "Motivation\r\n\r\nMapping-based approaches have become limited in their
+    application to very large sets of references since computing an FM-index for very
+    large databases (e.g. >10 GB) has become a bottleneck. This affects many analyses
+    that need such index as an essential step for approximate matching of the NGS
+    reads to reference databases. For instance, in typical metagenomics analysis,
+    the size of the reference sequences has become prohibitive to compute a single
+    full-text index on standard machines. Even on large memory machines, computing
+    such index takes about 1 day of computing time. As a result, updates of indices
+    are rarely performed. Hence, it is desirable to create an alternative way of indexing
+    while preserving fast search times.\r\n\r\nResults\r\n\r\nTo solve the index construction
+    and update problem we propose the DREAM (Dynamic seaRchablE pArallel coMpressed
+    index) framework and provide an implementation. The main contributions are the
+    introduction of an approximate search distributor via a novel use of Bloom filters.
+    We combine several Bloom filters to form an interleaved Bloom filter and use this
+    new data structure to quickly exclude reads for parts of the databases where they
+    cannot match. This allows us to keep the databases in several indices which can
+    be easily rebuilt if parts are updated while maintaining a fast search time. The
+    second main contribution is an implementation of DREAM-Yara a distributed version
+    of a fully sensitive read mapper under the DREAM framework.\r\n\r\nAvailability
+    and implementation: \r\nhttps://gitlab.com/pirovc/dream_yara/"
+  status_changed: '2018-11-08 11:49:07'
+  official_url: http://doi.org/10.1093/bioinformatics/bty567
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2282
+  lastmod: '2018-11-08 11:49:07'
+  ispublished: pub
+  dir: disk0/00/00/22/82
+  issn: 1367-4803
+  eprint_status: archive
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  volume: 34
+  date: '2018-09-08'
+  pagerange: i766-i772
+  eprintid: 2282
+  refereed: 'TRUE'
+  number: 17
+  id_number: doi:10.1093/bioinformatics/bty567
+  metadata_visibility: show
+  full_text_status: none
+  date_type: published
+- ispublished: pub
+  lastmod: '2017-03-03 14:40:19'
+  uri: http://publications.imp.fu-berlin.de/id/eprint/455
+  official_url: http://www.biomedcentral.com/1471-2105/9/11
+  abstract: BACKGROUND:The use of novel algorithmic techniques is pivotal to many
+    important problems in life science. For example the sequencing of the human genome
+    [1] would not have been possible without advanced assembly algorithms. However,
+    owing to the high speed of technological progress and the urgent need for bioinformatics
+    tools, there is a widening gap between state-of-the-art algorithmic techniques
+    and the actual algorithmic components of tools that are in widespread use.RESULTS:To
+    remedy this trend we propose the use of SeqAn, a library of efficient data types
+    and algorithms for sequence analysis in computational biology. SeqAn comprises
+    implementations of existing, practical state-of-the-art algorithmic components
+    to provide a sound basis for algorithm testing and development. In this paper
+    we describe the design and content of SeqAn and demonstrate its use by giving
+    two examples. In the first example we show an application of SeqAn as an experimental
+    platform by comparing different exact string matching algorithms. The second example
+    is a simple version of the well-known MUMmer tool rewritten in SeqAn. Results
+    indicate that our implementation is very efficient and versatile to use.CONCLUSION:We
+    anticipate that SeqAn greatly simplifies the rapid development of new bioinformatics
+    tools by providing a collection of readily usable, well-designed algorithmic components
+    which are fundamental for the field of sequence analysis. This leverages not only
+    the implementation of new algorithms, but also enables a sound analysis and comparison
+    of existing algorithms.
+  status_changed: '2009-04-15 07:21:49'
+  title: SeqAn -- An efficient, generic C++ library for sequence analysis
+  rev_number: 11
+  type: article
+  userid: 30
+  creators:
+  - name:
+      family: Döring
+      honourific:
+      given: A.
+      lineage:
+  - name:
+      lineage:
+      given: D.
+      honourific:
+      family: Weese
+  - name:
+      given: T.
+      honourific:
+      family: Rausch
+      lineage:
+  - name:
+      honourific:
+      given: K.
+      family: Reinert
+      lineage:
+  datestamp: '2009-04-15 07:21:49'
+  publication: BMC Bioinformatics
+  documents:
+  - security: public
+    pos: 1
+    eprintid: 455
+    uri: http://publications.imp.fu-berlin.de/id/document/237
+    docid: 237
+    main: BMC_Bioinformatics_2008_DöringAn_efficient_generic_C++_library.pdf
+    mime_type: application/pdf
+    format: application/pdf
+    relation:
+    - type: http://eprints.org/relation/haspreviewThumbnailVersion
+      uri: "/id/document/1021"
+    - uri: "/id/document/1021"
+      type: http://eprints.org/relation/hasVolatileVersion
+    - uri: "/id/document/1021"
+      type: http://eprints.org/relation/hasVersion
+    files:
+    - mime_type: application/pdf
+      uri: http://publications.imp.fu-berlin.de/id/file/5656
+      filesize: 565980
+      fileid: 5656
+      objectid: 237
+      filename: BMC_Bioinformatics_2008_DöringAn_efficient_generic_C++_library.pdf
+      datasetid: document
+      mtime: '2017-03-03 14:40:19'
+    language: en
+    rev_number: 3
+  item_issues_count: 0
+  full_text_status: public
+  date_type: published
+  metadata_visibility: show
+  number: 1
+  refereed: 'TRUE'
+  eprintid: 455
+  pagerange: 11
+  date: 2008
+  volume: 9
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  dir: disk0/00/00/04/55
+- uri: http://publications.imp.fu-berlin.de/id/eprint/792
+  ispublished: pub
+  lastmod: '2010-09-01 13:04:47'
+  official_url: http://bioinformatics.oxfordjournals.org/cgi/content/full/26/1/123
+  rev_number: 18
+  publisher: Oxford University Press
+  type: article
+  userid: 30
+  status_changed: '2010-08-23 12:05:14'
+  abstract: 'Motivation: Deep sequencing has become the method of choice for determining
+    the small RNA content of a cell. Mapping the sequenced reads onto their reference
+    genome serves as the basis for all further analyses, namely for identification
+    and quantification. A method frequently used is Mega BLAST followed by several
+    filtering steps, even though it is slow and inefficient for this task. Also, none
+    of the currently available short read aligners has established itself for the
+    particular task of small RNA mapping.  Results: We present MicroRazerS, a tool
+    optimized for mapping small RNAs onto a reference genome. It is an order of magnitude
+    faster than Mega BLAST and comparable in speed to other short read mapping tools.
+    In addition, it is more sensitive and easy to handle and adjust.  Availability:
+    MicroRazerS is part of the SeqAn C++ library and can be downloaded from http://www.seqan.de/projects/MicroRazerS.html.  Contact:
+    emde@inf.fu-berlin.de, grunert@molgen.mpg.de'
+  title: 'MicroRazerS: Rapid alignment of small RNA reads'
+  publication: Bioinformatics
+  datestamp: '2009-11-10 13:22:54'
+  related_url:
+  - url: http://bioinformatics.oxfordjournals.org/cgi/content/abstract/btp601v1
+  - url: http://bioinformatics.oxfordjournals.org/cgi/content/short/26/1/123
+  creators:
+  - name:
+      lineage:
+      honourific:
+      given: A.-K.
+      family: Emde
+  - name:
+      family: Grunert
+      given: M.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      given: D.
+      honourific:
+      family: Weese
+  - name:
+      family: Reinert
+      honourific:
+      given: K.
+      lineage:
+  - name:
+      given: S. R.
+      honourific:
+      family: Sperling
+      lineage:
+  date_type: published
+  full_text_status: none
+  id_number: 'doi:10.1093/bioinformatics/btp601 '
+  metadata_visibility: show
+  item_issues_count: 0
+  number: 1
+  eprintid: 792
+  refereed: 'TRUE'
+  volume: 26
+  divisions:
+  - group_algbioinf
+  subjects:
+  - C
+  - G
+  date: '2010-01-01'
+  pagerange: 123-124
+  issn: 1367-4803
+  dir: disk0/00/00/07/92
+  eprint_status: archive
+- official_url: http://bioinformatics.oxfordjournals.org/content/28/5/619
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1160
+  lastmod: '2017-03-03 14:41:14'
+  ispublished: pub
+  documents:
+  - format: application/pdf
+    docid: 516
+    uri: http://publications.imp.fu-berlin.de/id/document/516
+    main: 2012_Emde_Detecting_genomic_indel_variants_with_exact_breakpoints_in_single-_and_paired-end_sequencing_data_using_SplazerS-1.pdf
+    mime_type: application/pdf
+    formatdesc: Original Paper
+    pos: 2
+    eprintid: 1160
+    security: public
+    rev_number: 4
+    relation:
+    - uri: "/id/document/1227"
+      type: http://eprints.org/relation/hasVersion
+    - uri: "/id/document/1227"
+      type: http://eprints.org/relation/haspreviewThumbnailVersion
+    - uri: "/id/document/1227"
+      type: http://eprints.org/relation/hasVolatileVersion
+    language: en
+    files:
+    - objectid: 516
+      filename: 2012_Emde_Detecting_genomic_indel_variants_with_exact_breakpoints_in_single-_and_paired-end_sequencing_data_using_SplazerS-1.pdf
+      fileid: 14191
+      mtime: '2017-03-03 14:41:14'
+      datasetid: document
+      filesize: 575317
+      uri: http://publications.imp.fu-berlin.de/id/file/14191
+      mime_type: application/pdf
+  datestamp: '2012-09-12 08:40:15'
+  publication: Bioinformatics
+  creators:
+  - name:
+      lineage:
+      given: A.-K.
+      honourific:
+      family: Emde
+  - name:
+      lineage:
+      family: Schulz
+      honourific:
+      given: M. H.
+  - name:
+      family: Weese
+      given: D.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      family: Sun
+      given: R.
+      honourific:
+  - name:
+      family: Vingron
+      given: M.
+      honourific:
+      lineage:
+  - name:
+      given: V. M.
+      honourific:
+      family: Kalscheuer
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: S. A.
+      family: Haas
+  - name:
+      given: K.
+      honourific:
+      family: Reinert
+      lineage:
+  userid: 30
+  type: article
+  publisher: Oxford University Press
+  rev_number: 18
+  title: Detecting genomic indel variants with exact breakpoints in single- and paired-end
+    sequencing data using SplazerS
+  abstract: "Motivation: The reliable detection of genomic variation in resequencing
+    data is still a major challenge, especially for variants larger than a few base
+    pairs. Sequencing reads crossing boundaries of structural variation carry the
+    potential for their identification, but are difficult to map.\r\n\r\nResults:
+    Here we present a method for ‘split’ read mapping, where prefix and suffix match
+    of a read may be interrupted by a longer gap in the read-to-reference alignment.
+    We use this method to accurately detect medium-sized insertions and long deletions
+    with precise breakpoints in genomic resequencing data. Compared with alternative
+    split mapping methods, SplazerS significantly improves sensitivity for detecting
+    large indel events, especially in variant-rich regions. Our method is robust in
+    the presence of sequencing errors as well as alignment errors due to genomic mutations/divergence,
+    and can be used on reads of variable lengths. Our analysis shows that SplazerS
+    is a versatile tool applicable to unanchored or single-end as well as anchored
+    paired-end reads. In addition, application of SplazerS to targeted resequencing
+    data led to the interesting discovery of a complete, possibly functional gene
+    retrocopy variant.\r\n\r\nAvailability: SplazerS is available from http://www.seqan.de/projects/
+    splazers."
+  status_changed: '2012-09-12 08:40:15'
+  eprintid: 1160
+  refereed: 'TRUE'
+  number: 5
+  metadata_visibility: show
+  id_number: 10.1093/bioinformatics/bts019
+  date_type: published
+  full_text_status: public
+  item_issues_count: 0
+  dir: disk0/00/00/11/60
+  eprint_status: archive
+  divisions:
+  - group_algbioinf
+  subjects:
+  - C
+  - G
+  volume: 28
+  date: '2012-01-11'
+  pagerange: 619-627
+- dir: disk0/00/00/03/45
+  eprint_status: archive
+  volume: 4532
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  date: 2007
+  pagerange: 119-129
+  pres_type: paper
+  refereed: 'TRUE'
+  eprintid: 345
+  full_text_status: none
+  metadata_visibility: show
+  event_type: workshop
+  item_issues_count: 0
+  series: Lecture Notes in Computer Science
+  datestamp: '2009-03-11 16:59:59'
+  creators:
+  - name:
+      lineage:
+      family: Fasulo
+      given: D.
+      honourific:
+  - name:
+      honourific:
+      given: A.-K.
+      family: Emde
+      lineage:
+  - name:
+      lineage:
+      family: Wang
+      honourific:
+      given: L.-Y.
+  - name:
+      lineage:
+      honourific:
+      given: N. J.
+      family: Edwards
+  rev_number: 6
+  publisher: Springer Verlag
+  type: conference_item
+  userid: 1
+  abstract: "Mass spectrometry (MS) is becoming a popular approach for quantifying\tthe
+    protein composition of complex samples. A great challenge for\r\n\tcomparative
+    proteomic profiling is to match corresponding peptide\r\n\tfeatures from different
+    experiments to ensure that the same protein\r\n\tintensities are correctly identified.
+    Multi-dimensional data acquisition\r\n\tfrom liquid-chromatography mass spectrometry
+    (LC-MS) makes the alignment\r\n\tproblem harder. We propose a general paradigm
+    for aligning peptide\r\n\tfeatures using a bounded error model. Our method is
+    tolerant of imperfect\r\n\tmeasurements, missing peaks, and extraneous peaks.
+    It can handle\r\n\tan arbitrary number of dimensions of separation, and is very
+    fast\r\n\tin practice even for large data sets. Finally, its parameters are\r\n\tintuitive
+    and we describe a heuristic for estimating them automatically.\r\n\tWe demonstrate
+    results on single- and multi-dimensional data."
+  status_changed: '2009-03-11 11:26:55'
+  title: Alignment of Mass Spectrometry Data by Clique Finding and Optimization
+  official_url: http://www.springerlink.com/content/h716314047k25505
+  uri: http://publications.imp.fu-berlin.de/id/eprint/345
+  event_title: Systems Biology and Computational Proteomics
+  lastmod: '2010-09-01 13:22:04'
+  ispublished: pub
+- full_text_status: none
+  metadata_visibility: show
+  item_issues_count: 0
+  number: 18
+  eprintid: 346
+  refereed: 'TRUE'
+  volume: 19
+  divisions:
+  - group_algbioinf
+  date: 2003-12
+  pagerange: 2442-2447
+  dir: disk0/00/00/03/46
+  eprint_status: archive
+  uri: http://publications.imp.fu-berlin.de/id/eprint/346
+  ispublished: pub
+  lastmod: '2009-04-14 14:35:22'
+  official_url: http://dx.doi.org/10.1093/bioinformatics/btg343
+  keywords: algorithm, proteomics, statistics
+  rev_number: 3
+  type: article
+  userid: 1
+  abstract: "Motivation: The Dictionary of Interfaces in Proteins (DIP) is a database\tcollecting
+    the 3D structure of interacting parts of proteins that\r\n\tare called patches.
+    It serves as a repository, in which patches similar\r\n\tto given query patches
+    can be found. The computation of the similarity\r\n\tof two patches is time consuming
+    and traversing the entire DIP requires\r\n\tsome hours. In this work we address
+    the question of how the patches\r\n\tsimilar to a given query can be identified
+    by scanning only a small\r\n\tpart of DIP. The answer to this question requires
+    the investigation\r\n\tof the distribution of the similarity of patches. Results:
+    The score\r\n\tvalues describing the similarity of two patches can roughly be
+    divided\r\n\tinto three ranges that correspond to different levels of spatial\r\n\tsimilarity.
+    Interestingly, the two iso-score lines separating the\r\n\tthree classes can be
+    determined by two different approaches. Applying\r\n\ta concept of the theory
+    of random graphs reveals significant structural\r\n\tproperties of the data in
+    DIP. These can be used to accelerate scanning\r\n\tthe DIP for patches similar
+    to a given query. Searches for very similar\r\n\tpatches could be accelerated
+    by a factor of more than 25. Patches\r\n\twith a medium similarity could be found
+    10 times faster than by brute-force\r\n\tsearch. 10.1093/bioinformatics/btg343"
+  status_changed: '2009-03-11 11:26:55'
+  title: "Accelerating screening of 3D protein data with a graph theoretical\tapproach"
+  publication: Bioinformatics
+  datestamp: '2009-04-14 14:35:22'
+  creators:
+  - name:
+      honourific:
+      given: C.
+      family: Frömmel
+      lineage:
+  - name:
+      lineage:
+      family: Gille
+      given: Ch.
+      honourific:
+  - name:
+      family: Goede
+      honourific:
+      given: A.
+      lineage:
+  - name:
+      family: Gröpl
+      given: C.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      family: Hougardy
+      honourific:
+      given: S.
+  - name:
+      lineage:
+      honourific:
+      given: T.
+      family: Nierhoff
+  - name:
+      lineage:
+      family: Preissner
+      given: R.
+      honourific:
+  - name:
+      honourific:
+      given: M.
+      family: Thimm
+      lineage:
+- divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  date: 2010
+  place_of_pub: Boca Raton, USA
+  dir: disk0/00/00/08/25
+  eprint_status: archive
+  metadata_visibility: show
+  date_type: published
+  full_text_status: none
+  series: 'Chapman & Hall/CRC Mathematical & Computational Biology '
+  item_issues_count: 0
+  refereed: 'FALSE'
+  eprintid: 825
+  number: 1
+  userid: 132
+  rev_number: 11
+  publisher: CRC Press
+  type: book
+  title: Biological Sequence Analysis using the SeqAn C++ Library
+  status_changed: '2010-03-04 12:10:11'
+  abstract: "Before the SeqAn project, there was clearly a lack of available implementations
+    in sequence analysis, even for standard tasks. Implementations of needed algorithmic
+    components were either unavailable or hard to access in third-party monolithic
+    software products. Addressing these concerns, the developers of SeqAn created
+    a comprehensive, easy-to-use, open source C++ library of efficient algorithms
+    and data structures for the analysis of biological sequences. Written by the founders
+    of this project, Biological Sequence Analysis Using the SeqAn C++ Library covers
+    the SeqAn library, its documentation, and the supporting infrastructure.\r\n\r\n\r\nThe
+    first part of the book describes the general library design. It introduces biological
+    sequence analysis problems, discusses the benefit of using software libraries,
+    summarizes the design principles and goals of SeqAn, details the main programming
+    techniques used in SeqAn, and demonstrates the application of these techniques
+    in various examples. Focusing on the components provided by SeqAn, the second
+    part explores basic functionality, sequence data structures, alignments, pattern
+    and motif searching, string indices, and graphs. The last part illustrates applications
+    of SeqAn to genome alignment, consensus sequence in assembly projects, suffix
+    array construction, and more.\r\n\r\n\r\nThis handy book describes a user-friendly
+    library of efficient data types and algorithms for sequence analysis in computational
+    biology. SeqAn enables not only the implementation of new algorithms, but also
+    the sound analysis and comparison of existing algorithms.\r\n"
+  datestamp: '2010-03-04 12:10:11'
+  creators:
+  - id: andreas.doering@mdc-berlin.de
+    name:
+      lineage:
+      honourific:
+      given: A.
+      family: Gogol-Döring
+  - name:
+      family: Reinert
+      honourific:
+      given: K.
+      lineage:
+    id: knut.reinert@fu-berlin.de
+  isbn: 9781420076233
+  uri: http://publications.imp.fu-berlin.de/id/eprint/825
+  pages: 311
+  lastmod: '2010-09-01 13:26:25'
+  ispublished: pub
+  official_url: http://crcpress.com/product/isbn/9781420076233
+- full_text_status: none
+  date_type: published
+  metadata_visibility: show
+  id_number: doi:10.1093/infdis/jix567
+  number: 9
+  eprintid: 2283
+  refereed: 'TRUE'
+  volume: 217
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  pagerange: 1442-1452
+  date: '2018-05-01'
+  issn: 0022-1899
+  dir: disk0/00/00/22/83
+  eprint_status: archive
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2283
+  lastmod: '2018-11-08 11:52:57'
+  ispublished: pub
+  official_url: http://doi.org/10.1093/infdis/jix567
+  type: article
+  rev_number: 5
+  userid: 132
+  status_changed: '2018-11-08 11:52:57'
+  abstract: Spontaneous outbreaks of Clostridium difficile infection (CDI) occur in
+    neonatal piglets, but the predisposing factors are largely not known. To study
+    the conditions for C. difficile colonization and CDI development, 48 neonatal
+    piglets were moved into isolators, fed bovine milk–based formula, and infected
+    with C. difficile 078. Analyses included clinical scoring; measurement of the
+    fecal C. difficile burden, toxin B level, and calprotectin level; and postmortem
+    histopathological analysis of colon specimens. Controls were noninfected suckling
+    piglets. Fecal specimens from suckling piglets, formula-fed piglets, and formula-fed,
+    C. difficile–infected piglets were used for metagenomics analysis. High background
+    levels of C. difficile and toxin were detected in formula-fed piglets prior to
+    infection, while suckling piglets carried about 3-fold less C. difficile, and
+    toxin was not detected. Toxin level in C. difficile–challenged animals correlated
+    positively with C. difficile and calprotectin levels. Postmortem signs of CDI
+    were absent in suckling piglets, whereas mesocolonic edema and gas-filled distal
+    small intestines and ceca, cellular damage, and reduced expression of claudins
+    were associated with animals from the challenge trials. Microbiota in formula-fed
+    piglets was enriched with Escherichia, Shigella, Streptococcus, Enterococcus,
+    and Ruminococcus species. Formula-fed piglets were predisposed to C. difficile
+    colonization earlier as compared to suckling piglets. Infection with a hypervirulent
+    C. difficile ribotype did not aggravate the symptoms of infection. Sow-offspring
+    association and consumption of porcine milk during early life may be crucial for
+    the control of C. difficile expansion in piglets.
+  title: Formula Feeding Predisposes Neonatal Piglets to Clostridium difficile Gut
+    Infection
+  publication: The Journal of Infectious Diseases
+  datestamp: '2018-11-08 11:52:57'
+  creators:
+  - name:
+      family: Grześkowiak
+      given: Łukasz
+      honourific:
+      lineage:
+  - name:
+      given: Beatriz
+      honourific:
+      family: Martínez-Vallespín
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: Temesgen H
+      family: Dadi
+  - name:
+      lineage:
+      given: Judith
+      honourific:
+      family: Radloff
+  - name:
+      lineage:
+      family: Amasheh
+      honourific:
+      given: Salah
+  - name:
+      lineage:
+      honourific:
+      given: Femke-Anouska
+      family: Heinsen
+  - name:
+      honourific:
+      given: Andre
+      family: Franke
+      lineage:
+  - name:
+      given: Knut
+      honourific:
+      family: Reinert
+      lineage:
+  - name:
+      lineage:
+      given: Wilfried
+      honourific:
+      family: Vahjen
+  - name:
+      honourific:
+      given: Jürgen
+      family: Zentek
+      lineage:
+  - name:
+      given: Robert
+      honourific:
+      family: Pieper
+      lineage:
+- official_url: http://www.dagstuhl.de/05471/
+  note: "Extended abstract for talk given at Dagstuhl Seminar 05471 on Computational\tProteomics,
+    20.-25. November 2005"
+  lastmod: '2009-04-14 14:26:41'
+  ispublished: pub
+  uri: http://publications.imp.fu-berlin.de/id/eprint/347
+  event_title: Computational Proteomics
+  creators:
+  - name:
+      family: Gröpl
+      honourific:
+      given: C.
+      lineage:
+  datestamp: '2009-04-14 14:26:41'
+  title: An Algorithm for Feature Finding in LC/MS Raw Data
+  status_changed: '2009-03-11 11:26:56'
+  userid: 1
+  rev_number: 3
+  publisher: Dagstuhl Online Publication Server (DROPS)
+  type: conference_item
+  refereed: 'TRUE'
+  eprintid: 347
+  item_issues_count: 0
+  metadata_visibility: show
+  full_text_status: none
+  eprint_status: archive
+  dir: disk0/00/00/03/47
+  date: 2005
+  subjects:
+  - G400
+  divisions:
+  - group_algbioinf
+- divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  date: 2003
+  dir: disk0/00/00/03/48
+  eprint_status: archive
+  full_text_status: none
+  metadata_visibility: show
+  item_issues_count: 0
+  eprintid: 348
+  refereed: 'TRUE'
+  type: other
+  rev_number: 3
+  userid: 1
+  status_changed: '2009-03-11 11:26:56'
+  title: Algorithmen in der Bioinformatik
+  datestamp: '2009-04-14 14:36:34'
+  creators:
+  - name:
+      lineage:
+      family: Gröpl
+      given: C.
+      honourific:
+  uri: http://publications.imp.fu-berlin.de/id/eprint/348
+  ispublished: pub
+  lastmod: '2009-04-14 14:36:34'
+  note: "Skript zu meiner Vorlesung im Wintersemester 2002/03 am Institut\tfür Informatik
+    der Humboldt-Universität zu Berlin"
+- official_url: http://dochost.rz.hu-berlin.de/dissertationen/informatik/groepl-clemens
+  keywords: "Binary decision diagram, Boolean function, probabilistic analysis,\tShannon
+    effect"
+  ispublished: unpub
+  lastmod: '2009-04-14 14:41:14'
+  uri: http://publications.imp.fu-berlin.de/id/eprint/349
+  creators:
+  - name:
+      lineage:
+      given: C.
+      honourific:
+      family: Gröpl
+  datestamp: '2009-04-14 14:41:14'
+  thesis_type: phd
+  status_changed: '2009-03-11 11:26:57'
+  abstract: "(deutsche Zusammenfassung siehe unten)&lt;p&gt; Binary Decision Diagrams\t(BDDs)
+    are a data structure for Boolean functions which are also\r\n\tknown as branching
+    programs. In ordered binary decision diagrams\r\n\t(OBDDs), the tests have to
+    obey a fixed variable ordering. In free\r\n\tbinary decision diagrams (FBDDs),
+    each variable can be tested at\r\n\tmost once. The efficiency of new variants
+    of the BDD concept is usually\r\n\tdemonstrated with spectacular (worst-case)
+    examples. We pursue another\r\n\tapproach and compare the representation sizes
+    of almost all Boolean\r\n\tfunctions. Whereas I. Wegener proved that for `most'
+    values of n\r\n\tthe expected OBDD size of a random Boolean function of n variables\r\n\tis
+    equal to the worst-case size up to terms of lower order, we show\r\n\tthat this
+    is not the case for n within intervals of constant length\r\n\taround the values
+    n = 2h + h. Furthermore, ranges of n exist for\r\n\twhich minimal FBDDs are almost
+    always at least a constant factor\r\n\tsmaller than minimal OBDDs. Our main theorems
+    have doubly exponentially\r\n\tsmall probability bounds (in n). We also investigate
+    the evolution\r\n\tof random OBDDs and their worst-case size, revealing an oscillating\r\n\tbehaviour
+    that explains why certain results cannot be improved in\r\n\tgeneral. &lt;p&gt;
+    &lt;b&gt;Zusammenfassung:&lt;/b&gt;&lt;p&gt; Binary Decision Diagrams\r\n\t(BDDs)
+    sind eine Datenstruktur für Boolesche Funktionen, die\r\n\tauch unter dem Namen
+    branching program bekannt ist. In ordered binary\r\n\tdecision diagrams (OBDDs)
+    müssen die Tests einer festen Variablenordnung\r\n\tgenügen. In free binary decision
+    diagrams (FBDDs) darf jede Variable\r\n\thöchstens einmal getestet werden. Die
+    Effizienz neuer Varianten\r\n\tdes BDD-Konzepts wird gewöhnlich anhand spektakulärer
+    (worst-case)\r\n\tBeispiele aufgezeigt. Wir verfolgen einen anderen Ansatz und
+    vergleichen\r\n\tdie Darstellungsgrößen für fast alle Booleschen Funktionen.\r\n\tWährend
+    I. Wegener bewiesen hat, daß für die `meisten'\r\n\tn die erwartete OBDD-Größe
+    einer zufälligen Booleschen\r\n\tFunktion von n Variablen gleich der worst-case
+    Größe bis\r\n\tauf Terme kleinerer Ordnung ist, zeigen wir daß dies nicht der\r\n\tFall
+    ist für n innerhalb von Intervallen konstanter Länge\r\n\tum die Werte n = 2h
+    + h. Ferner gibt es Bereiche von n, in denen\r\n\tminimale FBDDs fast immer um
+    mindestens einen konstanten Faktor kleiner\r\n\tsind als minimale OBDDs. Unsere
+    Hauptsätze ha ben doppelt exponentielle\r\n\tWahrschein- lichkeitsschranken (in
+    n). Außerdem untersuchen wir\r\n\tdie Entwicklung zufälliger OBDDs und ihrer worst-case
+    Größe\r\n\tund decken dabei ein oszillierendes Verhalten auf, das erklärt,\r\n\twarum
+    gewisse Aussagen im allgemeinen nicht verstärkt werden\r\n\tkönnen. &lt;p&gt;Schlagwörter:&lt;p&gt;
+    Binäres Entscheidungsdiagramm,\r\n\tBoolesche Funktion,probabilistische Analyse,
+    Shannon Effekt."
+  title: Binary Decision Diagrams for Random Boolean Functions
+  rev_number: 3
+  type: thesis
+  userid: 1
+  eprintid: 349
+  refereed: 'TRUE'
+  institution: Humboldt-Universität zu Berlin
+  item_issues_count: 0
+  full_text_status: none
+  metadata_visibility: show
+  eprint_status: archive
+  dir: disk0/00/00/03/49
+  date: 1999
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+- keywords: Approximation algorithms, Colouring, packing and covering
+  uri: http://publications.imp.fu-berlin.de/id/eprint/350
+  lastmod: '2009-04-14 14:43:52'
+  ispublished: unpub
+  thesis_type: masters
+  datestamp: '2009-04-14 14:43:52'
+  creators:
+  - name:
+      honourific:
+      given: C.
+      family: Gröpl
+      lineage:
+  userid: 1
+  rev_number: 3
+  type: thesis
+  title: "Über Approximationsalgorithmen zur Färbung k-färbbarer\tGraphen, die vektorchromatische
+    Zahl und andere Varianten der vartheta-Funktion"
+  status_changed: '2009-03-11 11:26:57'
+  refereed: 'TRUE'
+  eprintid: 350
+  institution: Rheinische Friedrich-Wilhelms-Universität Bonn
+  metadata_visibility: show
+  full_text_status: none
+  item_issues_count: 0
+  dir: disk0/00/00/03/50
+  eprint_status: archive
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  date: 1996-01
+  place_of_pub: Forschungsinstitut für Diskrete Mathematik
+- keywords: mass spectrometry, proteomics, open source software
+  ispublished: pub
+  lastmod: '2010-09-01 13:38:57'
+  note: http://mbi.osu.edu/2004/workshops2004.html
+  uri: http://publications.imp.fu-berlin.de/id/eprint/351
+  creators:
+  - name:
+      lineage:
+      honourific:
+      given: C.
+      family: Gröpl
+  - name:
+      lineage:
+      honourific:
+      given: A.
+      family: Hildebrandt
+  - name:
+      honourific:
+      given: E.
+      family: Lange
+      lineage:
+  - name:
+      lineage:
+      given: S.
+      honourific:
+      family: Lövenich
+  - name:
+      lineage:
+      family: Sturm
+      honourific:
+      given: M.
+  datestamp: '2009-03-11 16:53:50'
+  status_changed: '2009-03-11 11:26:58'
+  title: OpenMS - Software for Mass Spectrometry
+  rev_number: 4
+  type: other
+  userid: 1
+  eprintid: 351
+  refereed: 'TRUE'
+  item_issues_count: 0
+  full_text_status: none
+  metadata_visibility: show
+  eprint_status: archive
+  dir: disk0/00/00/03/51
+  date: 2005
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+- uri: http://publications.imp.fu-berlin.de/id/eprint/352
+  note: http://www.hupo2005.com/
+  ispublished: pub
+  lastmod: '2010-09-01 13:40:54'
+  keywords: mass spectrometry, proteomics, open source software
+  userid: 1
+  rev_number: 3
+  type: other
+  title: OpenMS - a generic open source framework for HPLC/MS-based proteomics
+  status_changed: '2009-03-11 11:26:59'
+  datestamp: '2010-09-01 13:40:54'
+  creators:
+  - name:
+      given: C.
+      honourific:
+      family: Gröpl
+      lineage:
+  - name:
+      honourific:
+      given: A.
+      family: Hildebrandt
+      lineage:
+  - name:
+      honourific:
+      given: E.
+      family: Lange
+      lineage:
+  - name:
+      lineage:
+      given: M.
+      honourific:
+      family: Sturm
+  metadata_visibility: show
+  full_text_status: none
+  item_issues_count: 0
+  refereed: 'TRUE'
+  eprintid: 352
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  date: 2005
+  dir: disk0/00/00/03/52
+  eprint_status: archive
+- creators:
+  - name:
+      family: Gröpl
+      honourific:
+      given: C.
+      lineage:
+  - name:
+      honourific:
+      given: S.
+      family: Hougardy
+      lineage:
+  - name:
+      lineage:
+      given: T.
+      honourific:
+      family: Nierhoff
+  - name:
+      given: H.-J.
+      honourific:
+      family: Prömel
+      lineage:
+  datestamp: '2009-04-14 14:39:16'
+  status_changed: '2009-03-11 11:26:59'
+  editors:
+  - name:
+      honourific:
+      given: X.
+      family: Cheng
+      lineage:
+  - name:
+      honourific:
+      given: D. Z.
+      family: Du
+      lineage:
+  title: Approximation Algorithms for the Steiner Tree Problem in Graphs
+  publisher: Kluwer Academic Publishers
+  rev_number: 3
+  type: book_section
+  userid: 1
+  keywords: "Approximation algorithms, Combinatorial optimization, Graph algorithms,\tSteiner
+    trees"
+  ispublished: pub
+  lastmod: '2009-04-14 14:39:16'
+  note: Survey article with new proofs
+  book_title: Steiner Trees in Industry
+  uri: http://publications.imp.fu-berlin.de/id/eprint/353
+  eprint_status: archive
+  dir: disk0/00/00/03/53
+  date: 2001
+  pagerange: 235-279
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  refereed: 'TRUE'
+  eprintid: 353
+  item_issues_count: 0
+  full_text_status: none
+  metadata_visibility: show
+- series: LNCS
+  item_issues_count: 0
+  metadata_visibility: show
+  full_text_status: none
+  refereed: 'TRUE'
+  eprintid: 355
+  date: 2001
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  eprint_status: archive
+  dir: disk0/00/00/03/55
+  ispublished: pub
+  lastmod: '2009-04-14 14:40:07'
+  uri: http://publications.imp.fu-berlin.de/id/eprint/355
+  event_title: "Proceedings of the 27th International Workshop on Graph-Theoretic\tConcepts
+    in Computer Science (2001)"
+  keywords: "Steiner trees, Approximation algorithms, Combinatorial optimization,\tGraph
+    algorithms, Hypergraphs, set systems, and designs"
+  title: "Lower bounds for approximation algorithms for the Steiner tree\tproblem"
+  status_changed: '2009-03-11 11:27:00'
+  abstract: "The Steiner tree problem asks for a shortest subgraph connecting a\tgiven
+    set of terminals in a graph. It is known to be APX-complete,\r\n\twhich means
+    that no polynomial time approximation scheme can exist\r\n\tfor this problem,
+    unless P=NP. Currently, the best approximation\r\n\talgorithm for the Steiner
+    tree problem has a performance ratio of\r\n\t<span class='mathrm'>1.55</span>,
+    whereas the corresponding lower bound is smaller than <span class='mathrm'>1.01</span>.\r\n\tIn
+    this paper, we provide for several Steiner tree approximation\r\n\talgorithms
+    lower bounds on their performance ratio that are much\r\n\tlarger. For two algorithms
+    that solve the Steiner tree problem on\r\n\tquasi-bipartite instances, we even
+    prove lower bounds that match\r\n\tthe upper bounds. Quasi-bipartite instances
+    are of special interest,\r\n\tas currently all known lower bound reductions for
+    the Steiner tree\r\n\tproblem in graphs produce such instances."
+  userid: 1
+  publisher: Springer Verlag
+  type: conference_item
+  rev_number: 3
+  creators:
+  - name:
+      honourific:
+      given: C.
+      family: Gröpl
+      lineage:
+  - name:
+      lineage:
+      family: Hougardy
+      given: S.
+      honourific:
+  - name:
+      family: Nierhoff
+      given: T.
+      honourific:
+      lineage:
+  - name:
+      given: H.-J.
+      honourific:
+      family: Prömel
+      lineage:
+  datestamp: '2009-04-14 14:40:07'
+- keywords: Steiner trees, Graph algorithms, Approximation algorithms
+  uri: http://publications.imp.fu-berlin.de/id/eprint/354
+  lastmod: '2009-04-14 14:39:09'
+  ispublished: pub
+  publication: Information Processing Letters
+  datestamp: '2009-04-14 14:39:09'
+  creators:
+  - name:
+      lineage:
+      given: C.
+      honourific:
+      family: Gröpl
+  - name:
+      lineage:
+      given: S.
+      honourific:
+      family: Hougardy
+  - name:
+      family: Nierhoff
+      honourific:
+      given: T.
+      lineage:
+  - name:
+      honourific:
+      given: H.-J.
+      family: Prömel
+      lineage:
+  userid: 1
+  type: article
+  rev_number: 3
+  title: Steiner trees in uniformly quasi-bipartite graphs
+  status_changed: '2009-03-11 11:27:00'
+  abstract: "The area of approximation algorithms for the Steiner tree problem\tin
+    graphs has seen continuous progress over the last years. Currently\r\n\tthe best
+    approximation algorithm has a performance ratio of 1.550.\r\n\tThis is still far
+    away from 1.0074, the largest known lower bound\r\n\ton the achievable performance
+    ratio. As all instances resulting from\r\n\tknown lower bound reductions are uniformly
+    quasi-bipartite, it is\r\n\tinteresting whether this special case can be approximated
+    better\r\n\tthan the general case. We present an approximation algorithm with\r\n\tperformance
+    ratio 73/60 &lt; 1.217 for the uniformly quasi-bipartite\r\n\tcase. This improves
+    on the previously known ratio of 1.279 of Robins\r\n\tand Zelikovsky. We use a
+    new method of analysis that combines ideas\r\n\tfrom the greedy algorithm for
+    set cover with a matroid-style exchange\r\n\targument to model the connectivity
+    constraint. As a consequence,\r\n\twe are able to provide a tight instance."
+  refereed: 'TRUE'
+  eprintid: 354
+  metadata_visibility: show
+  full_text_status: none
+  item_issues_count: 0
+  dir: disk0/00/00/03/54
+  eprint_status: archive
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  volume: 83
+  date: 2002
+  pagerange: 195-200
+- eprintid: 356
+  refereed: 'TRUE'
+  metadata_visibility: show
+  full_text_status: none
+  item_issues_count: 0
+  dir: disk0/00/00/03/56
+  eprint_status: archive
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  date: 2002
+  uri: http://publications.imp.fu-berlin.de/id/eprint/356
+  ispublished: pub
+  lastmod: '2009-04-14 14:37:28'
+  datestamp: '2009-04-14 14:37:28'
+  creators:
+  - name:
+      lineage:
+      family: Gröpl
+      given: C.
+      honourific:
+  - name:
+      honourific:
+      given: S.
+      family: Hougardy
+      lineage:
+  - name:
+      lineage:
+      family: Nierhoff
+      honourific:
+      given: T.
+  - name:
+      honourific:
+      given: H.-J.
+      family: Prömel
+      lineage:
+  - name:
+      lineage:
+      family: Thimm
+      honourific:
+      given: M.
+  userid: 1
+  type: other
+  rev_number: 3
+  title: Approximationsalgorithmen für das Steinerbaumproblem in Graphen
+  status_changed: '2009-03-11 11:27:01'
+- dir: disk0/00/00/03/58
+  eprint_status: archive
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  pagerange: 151-163
+  date: 2005
+  refereed: 'TRUE'
+  eprintid: 358
+  full_text_status: none
+  metadata_visibility: show
+  item_issues_count: 0
+  datestamp: '2009-04-14 14:27:04'
+  creators:
+  - name:
+      family: Gröpl
+      honourific:
+      given: C.
+      lineage:
+  - name:
+      lineage:
+      given: E.
+      honourific:
+      family: Lange
+  - name:
+      lineage:
+      given: K.
+      honourific:
+      family: Reinert
+  - name:
+      lineage:
+      family: Sturm
+      honourific:
+      given: M.
+  - name:
+      lineage:
+      family: Huber
+      honourific:
+      given: Ch.
+  - name:
+      family: Mayr
+      honourific:
+      given: B. M.
+      lineage:
+  - name:
+      lineage:
+      given: C. L.
+      honourific:
+      family: Klein
+  type: conference_item
+  rev_number: 3
+  userid: 1
+  status_changed: '2009-03-11 11:27:02'
+  abstract: "HPLC-ESI-MS is rapidly becoming an established standard method for\tshotgun
+    proteomics. Currently, its major drawbacks are twofold: quantification\r\n\tis
+    mostly limited to relative quantification and the large amount\r\n\tof data produced
+    by every individual experiment can make manual analysis\r\n\tquite difficult.
+    Here we present a new, combined experimental and\r\n\talgorithmic approach to
+    absolutely quantify proteins from samples\r\n\twith unprecedented precision. We
+    apply the method to the analysis\r\n\tof myoglobin in human blood serum, which
+    is an important diagnostic\r\n\tmarker for myocardial infarction. Our approach
+    was able to determine\r\n\tthe absolute amount of myoglobin in a serum sample
+    through a series\r\n\tof standard addition experiments with a relative error of
+    2.5 percent.\r\n\tCompared to a manual analysis of the same dataset we could improve\r\n\tthe
+    precision and conduct it in a fraction of the time needed for\r\n\tthe manual
+    analysis. We anticipate that our automatic quantitation\r\n\tmethod will facilitate
+    further absolute or relative quantitation\r\n\tof even more complex peptide samples.
+    The algorithm was developed\r\n\tusing our publically available software framework
+    OpenMS (www.openms.de)."
+  title: "Algorithms for the automated absolute quantification of diagnostic\tmarkers
+    in complex proteomics samples"
+  event_title: "Proceedings of the 1st International Symposium on Computational Life\tScience
+    (CompLife05)"
+  uri: http://publications.imp.fu-berlin.de/id/eprint/358
+  lastmod: '2009-04-14 14:27:04'
+  ispublished: pub
+- keywords: Binary Decision Diagrams
+  ispublished: pub
+  lastmod: '2009-04-14 14:40:13'
+  uri: http://publications.imp.fu-berlin.de/id/eprint/361
+  creators:
+  - name:
+      lineage:
+      family: Gröpl
+      honourific:
+      given: C.
+  - name:
+      given: H.-J.
+      honourific:
+      family: Prömel
+      lineage:
+  - name:
+      lineage:
+      family: Srivastav
+      given: A.
+      honourific:
+  publication: Information Processing Letters
+  datestamp: '2009-04-14 14:40:13'
+  title: On the Evolution of the Worst-Case OBDD Size
+  abstract: "We prove matching lower and upper bounds on the worst-case OBDD size\tof
+    a Boolean function, revealing an interesting ocillating behaviour."
+  status_changed: '2009-03-11 11:27:04'
+  userid: 1
+  rev_number: 3
+  type: article
+  eprintid: 361
+  refereed: 'TRUE'
+  item_issues_count: 0
+  metadata_visibility: show
+  full_text_status: none
+  eprint_status: archive
+  dir: disk0/00/00/03/61
+  pagerange: 1-7
+  date: 2001
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  volume: 77
+- userid: 1
+  rev_number: 3
+  type: article
+  title: Ordered binary decision diagrams and the Shannon effect
+  abstract: "We investigate the size and structure of ordered binary decision diagrams\t(OBDDs)
+    for random Boolean functions. It was known that for most\r\n\tvalues of n, the
+    expected OBDD size of a random Boolean function\r\n\twith n variables is equal
+    to the worst-case size up to terms of lower\r\n\torder. Such a phenomenon is generally
+    called strong Shannon effect.\r\n\tHere we show that the strong Shannon effect
+    is not valid for all\r\n\tn. Instead it undergoes a certain periodic `phase transition':
+    If\r\n\tn lies within intervals of constant width around the values n = 2h\r\n\t+
+    h, then the strong Shannon effect does not hold, whereas it does\r\n\thold outside
+    these intervals. Our analysis provides doubly exponential\r\n\tprobability bounds
+    and generalises to ordered Kronecker functional\r\n\tdecision diagrams (OKFDDs). "
+  status_changed: '2009-03-11 11:27:03'
+  datestamp: '2009-04-14 14:35:30'
+  publication: Discrete Applied Mathematics
+  creators:
+  - name:
+      lineage:
+      family: Gröpl
+      given: C.
+      honourific:
+  - name:
+      given: H.-J.
+      honourific:
+      family: Prömel
+      lineage:
+  - name:
+      honourific:
+      given: A.
+      family: Srivastav
+      lineage:
+  uri: http://publications.imp.fu-berlin.de/id/eprint/360
+  ispublished: pub
+  lastmod: '2009-04-14 14:35:30'
+  keywords: "VLSI-Design and layout, Binary Decision Diagrams, Graph theory (other),\tHardware
+    verification, Probability theory, Random graphs, Randomized\r\n\talgorithms and
+    probabilistic analysis, Theoretical computer science\r\n\t(other)"
+  subjects:
+  - G400
+  divisions:
+  - group_algbioinf
+  volume: 142
+  pagerange: 67-85
+  date: 2004
+  dir: disk0/00/00/03/60
+  eprint_status: archive
+  metadata_visibility: show
+  full_text_status: none
+  item_issues_count: 0
+  eprintid: 360
+  refereed: 'TRUE'
+- creators:
+  - name:
+      honourific:
+      given: C.
+      family: Gröpl
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: H.-J.
+      family: Prömel
+  - name:
+      lineage:
+      family: Srivastav
+      honourific:
+      given: A.
+  datestamp: '2009-04-14 14:42:04'
+  editors:
+  - name:
+      lineage:
+      honourific:
+      given: D.
+      family: Korb
+  - name:
+      lineage:
+      family: Meinel
+      given: Ch.
+      honourific:
+  - name:
+      family: Morvan
+      honourific:
+      given: M.
+      lineage:
+  status_changed: '2009-03-11 11:27:03'
+  title: "Size and Structure of Random Ordered Binary Decision Diagrams (Extended\tAbstract)"
+  publisher: Springer Verlag
+  type: conference_item
+  rev_number: 3
+  userid: 1
+  keywords: VLSI-Design and layout, Hardware verification, Random graphs
+  lastmod: '2009-04-14 14:42:04'
+  ispublished: pub
+  event_title: STACS 98
+  uri: http://publications.imp.fu-berlin.de/id/eprint/359
+  eprint_status: archive
+  dir: disk0/00/00/03/59
+  place_of_pub: Berlin, Heidelberg, New York
+  date: 1998
+  pagerange: 238-248
+  subjects:
+  - G400
+  divisions:
+  - group_algbioinf
+  number: 1373
+  refereed: 'TRUE'
+  eprintid: 359
+  item_issues_count: 0
+  series: Lecture Notes in Computer Science
+  full_text_status: none
+  metadata_visibility: show
+- dir: disk0/00/00/03/63
+  eprint_status: archive
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  volume: 1367
+  pagerange: 161-177
+  date: 1998
+  eprintid: 363
+  refereed: 'TRUE'
+  metadata_visibility: show
+  full_text_status: none
+  series: Lecture Notes in Computer Science
+  item_issues_count: 0
+  datestamp: '2009-04-14 14:42:14'
+  creators:
+  - name:
+      given: C.
+      honourific:
+      family: Gröpl
+      lineage:
+  - name:
+      family: Skutella
+      given: M.
+      honourific:
+      lineage:
+  userid: 1
+  type: book_section
+  publisher: Springer
+  rev_number: 3
+  title: Parallel Repetition of MIP(2,1) Systems
+  status_changed: '2009-03-11 11:27:05'
+  editors:
+  - name:
+      honourific:
+      given: E. W.
+      family: Mayr
+      lineage:
+  - name:
+      honourific:
+      given: H.-J.
+      family: Prömel
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: A.
+      family: Steger
+  keywords: "Theoretical computer science (other), Approximation algorithms, PCP\tand
+    non-approximability"
+  uri: http://publications.imp.fu-berlin.de/id/eprint/363
+  note: The book grow out of a Dagstuhl Seminar, April 21-25, 1997
+  book_title: Lectures on Proof Verification and Approximation Algorithms
+  lastmod: '2009-04-14 14:42:14'
+  ispublished: pub
+- type: conference_item
+  rev_number: 3
+  userid: 1
+  status_changed: '2009-03-11 11:27:06'
+  title: Segment Match refinment and applications
+  datestamp: '2017-03-03 14:40:14'
+  creators:
+  - name:
+      family: Halpern
+      given: A. L.
+      honourific:
+      lineage:
+  - name:
+      honourific:
+      given: D. H.
+      family: Huson
+      lineage:
+  - name:
+      given: K.
+      honourific:
+      family: Reinert
+      lineage:
+  event_title: Proceedings of the 2nd Workshop on Algorithms Bioinformatics (WABI-02)
+  uri: http://publications.imp.fu-berlin.de/id/eprint/364
+  lastmod: '2017-03-03 14:40:14'
+  ispublished: pub
+  subjects:
+  - G400
+  divisions:
+  - group_algbioinf
+  pagerange: 126-139
+  date: 2002
+  dir: disk0/00/00/03/64
+  eprint_status: archive
+  full_text_status: none
+  metadata_visibility: show
+  item_issues_count: 0
+  eprintid: 364
+  refereed: 'TRUE'
+- volume: 30
+  divisions:
+  - group_algbioinf
+  date: 2014-09
+  pagerange: i349-i355
+  dir: disk0/00/00/14/53
+  eprint_status: archive
+  full_text_status: none
+  metadata_visibility: show
+  item_issues_count: 0
+  number: 17
+  refereed: 'TRUE'
+  eprintid: 1453
+  rev_number: 13
+  publisher: Oxford University Press
+  type: article
+  userid: 29
+  status_changed: '2016-11-15 14:03:47'
+  abstract: "MOTIVATION:Next-generation sequencing technologies produce unprecedented
+    amounts of data, leading to completely new research fields. One of these is metagenomics,
+    the study of large-size DNA samples containing a multitude of diverse organisms.
+    A key problem in metagenomics is to functionally and taxonomically classify the
+    sequenced DNA, to which end the well-known BLAST program is usually used. But
+    BLAST has dramatic resource requirements at metagenomic scales of data, imposing
+    a high financial or technical burden on the researcher. Multiple attempts have
+    been made to overcome these limitations and  present a viable alternative to BLAST.RESULTS:In
+    this work we present Lambda, our own alternative for BLAST in the context of sequence
+    classification. In our tests, Lambda often outperforms the best tools at reproducing
+    BLAST's results and is the fastest compared with the current state of the art
+    at comparable levels of sensitivity.\r\nAVAILABILITY AND IMPLEMENTATION:Lambda
+    was implemented in the SeqAn open-source C++ library for sequence analysis and
+    is publicly available for download at http://www.seqan.de/projects/lambda.\r\nCONTACT:hannes.hauswedell@fu-berlin.de\r\nSUPPLEMENTARY
+    INFORMATION:Supplementary data are available at Bioinformatics online."
+  title: 'Lambda: the local aligner for massive biological data'
+  datestamp: '2014-09-23 18:00:01'
+  publication: Bioinformatics (Oxford, England)
+  creators:
+  - name:
+      lineage:
+      given: H.
+      honourific:
+      family: Hauswedell
+  - name:
+      given: J.
+      honourific:
+      family: Singer
+      lineage:
+  - name:
+      family: Reinert
+      honourific:
+      given: K.
+      lineage:
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1453
+  lastmod: '2016-11-15 14:03:47'
+  ispublished: pub
+  official_url: http://bioinformatics.oxfordjournals.org/content/30/17/i349.full
+- lastmod: '2011-06-27 13:44:14'
+  ispublished: pub
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1072
+  official_url: http://dx.doi.org/10.1186/1471-2105-12-210
+  status_changed: '2011-06-27 13:44:14'
+  abstract: "Background\r\nSecond generation sequencing technologies yield DNA sequence
+    data at ultra high-throughput. Common to most biological applications is a mapping
+    of the reads to an almost identical or highly similar reference genome. The assessment
+    of the quality of read mapping results is not straightforward and has not been
+    formalized so far. Hence, it has not been easy to compare different read mapping
+    approaches in a unified way and to determine which program is the best for what
+    task.\r\n\r\nResults\r\nWe present a new benchmark method, called Rabema (Read
+    Alignment BEnchMArk), for read mappers. It consists of a strict definition of
+    the read mapping problem and of tools to evaluate the result of arbitrary read
+    mappers supporting the SAM output format.\r\n\r\nConclusions\r\nWe show the usefulness
+    of the benchmark program by performing a comparison of popular read mappers. The
+    tools supporting the benchmark are licensed under the GPL and available from http://www.seqan.de/projects/rabema.html."
+  title: A Novel And Well-Defined Benchmarking Method For Second Generation Read Mapping
+  type: article
+  publisher: BioMed Central
+  rev_number: 12
+  userid: 167
+  creators:
+  - id: holtgrewe@mi.fu-berlin.de
+    name:
+      lineage:
+      honourific:
+      given: M.
+      family: Holtgrewe
+  - name:
+      lineage:
+      family: Emde
+      given: A.-K.
+      honourific:
+    id:
+  - name:
+      family: Weese
+      honourific:
+      given: D.
+      lineage:
+    id:
+  - name:
+      honourific:
+      given: K.
+      family: Reinert
+      lineage:
+    id:
+  publication: BMC Bioinformatics
+  datestamp: '2011-06-09 13:52:15'
+  item_issues_count: 0
+  date_type: published
+  full_text_status: none
+  metadata_visibility: show
+  id_number: 10.1186/1471-2105-12-210
+  number: 120
+  refereed: 'TRUE'
+  eprintid: 1072
+  date: '2011-05-26'
+  volume: 12
+  subjects:
+  - C700
+  - G400
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  issn: 1471-2105
+  dir: disk0/00/00/10/72
+- lastmod: '2016-02-25 11:13:53'
+  ispublished: pub
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1506
+  official_url: http://dx.doi.org/10.1093/bioinformatics/btv051
+  title: Methods for the Detection and Assembly of Novel Sequence in High-Throughput
+    Sequencing Data
+  status_changed: '2016-02-25 11:13:53'
+  abstract: "Motivation: \r\nLarge insertions of novel sequence are an important type
+    of structural variants. Previous studies used traditional de novo assemblers for
+    assembling non-mapping high-throughput sequencing (HTS) or capillary reads and
+    then tried to anchor them in the reference using paired read information.\r\n\r\nResults:
+    \r\nWe present approaches for detecting insertion breakpoints and targeted assembly
+    of large insertions from HTS paired data: BASIL and ANISE. On near identity repeats
+    that are hard for assemblers, ANISE employs a repeat resolution step. This results
+    in far better reconstructions than obtained by the compared methods. On simulated
+    data, we found our insert assembler to be competitive with the de novo assemblers
+    ABYSS and SGA while yielding already anchored inserted sequence as opposed to
+    unanchored contigs as from ABYSS/SGA. On real-world data, we detected novel sequence
+    in a human individual and thoroughly validated the assembled sequence. ANISE was
+    found to be superior to the competing tool MindTheGap on both simulated and real-world
+    data.\r\n\r\nAvailability and implementation: ANISE and BASIL are available for
+    download at http://www.seqan.de/projects/herbarium under a permissive open source
+    license. \r\n\r\nContact: manuel.holtgrewe@fu-berlin.de or knut.reinert@fu-berlin.de"
+  userid: 132
+  type: article
+  rev_number: 14
+  creators:
+  - name:
+      lineage:
+      family: Holtgrewe
+      given: M.
+      honourific:
+  - name:
+      given: L.
+      honourific:
+      family: Kuchenbecker
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: K.
+      family: Reinert
+  datestamp: '2015-02-16 13:41:21'
+  publication: Bioinformatics
+  item_issues_count: 0
+  metadata_visibility: show
+  id_number: doi:10.1093/bioinformatics/btv051
+  date_type: published
+  full_text_status: none
+  refereed: 'TRUE'
+  eprintid: 1506
   number: 12
-  pages: 1904-1912
-  doi: 10.1093/bioinformatics/btv051
-- id: fu_mi_publications2103
-  author: K. Reinert, T. H. Dadi, M. Ehrhardt, H. Hauswedell, S. Mehringer, R. Rahn, J. Kim, C. Pockrandt, J. Winkler, E. Siragusa, G. Urgese, and D. Weese
-  title: "The SeqAn C++ template library for efficient sequence analysis: A resource for programmers"
-  journal: Journal of Biotechnology
-  year: 2017
+  date: 2015
+  pagerange: 1904-1912
+  subjects:
+  - G400
+  divisions:
+  - group_algbioinf
+  volume: 31
+  eprint_status: archive
+  dir: disk0/00/00/15/06
+  issn: 1367-4803
+- uri: http://publications.imp.fu-berlin.de/id/eprint/930
+  lastmod: '2010-09-01 13:33:27'
+  ispublished: pub
+  official_url: http://ieeexplore.ieee.org/xpl/freeabs_all.jsp?arnumber=5470485
+  userid: 167
+  type: article
+  rev_number: 7
+  title: Engineering a scalable high quality graph partitioner
+  abstract: We describe an approach to parallel graph partitioning that scales to
+    hundreds of processors and produces a high solution quality. For example, for
+    many instances from Walshaw's benchmark collection we improve the best known partitioning.
+    We use the well known framework of multi-level graph partitioning. All components
+    are implemented by scalable parallel algorithms. Quality improvements compared
+    to previous systems are due to better prioritization of edges to be contracted,
+    better approximation algorithms for identifying matchings, better local search
+    heuristics, and perhaps most notably, a parallelization of the FM local search
+    algorithm that works more locally than previous approaches.
+  status_changed: '2010-08-23 12:49:46'
+  publication: 2010 IEEE International Symposium on Parallel & Distributed Processing
+    (IPDPS)
+  datestamp: '2010-08-23 12:49:46'
+  creators:
+  - name:
+      family: Holtgrewe
+      honourific:
+      given: M.
+      lineage:
+    id: holtgrewe@ira.uka.de
+  - id: sanders@kit.edu
+    name:
+      honourific:
+      given: P.
+      family: Sanders
+      lineage:
+  - id: c_schulz@ira.uka.de
+    name:
+      family: Schulz
+      given: C.
+      honourific:
+      lineage:
+  id_number: '10.1109/IPDPS.2010.5470485 '
+  metadata_visibility: show
+  date_type: published
+  full_text_status: none
+  item_issues_count: 0
+  refereed: 'TRUE'
+  eprintid: 930
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  date: 2010-04
+  pagerange: 1-12
+  dir: disk0/00/00/09/30
+  issn: '1530-2075 '
+  eprint_status: archive
+- uri: http://publications.imp.fu-berlin.de/id/eprint/962
+  lastmod: '2017-03-03 14:40:55'
+  ispublished: pub
+  datestamp: '2011-10-08 13:21:08'
+  publication: Technical Report FU Berlin
+  documents:
+  - relation:
+    - uri: "/id/document/1165"
+      type: http://eprints.org/relation/hasVersion
+    - type: http://eprints.org/relation/haspreviewThumbnailVersion
+      uri: "/id/document/1165"
+    - type: http://eprints.org/relation/hasVolatileVersion
+      uri: "/id/document/1165"
+    language: en
+    files:
+    - uri: http://publications.imp.fu-berlin.de/id/file/11200
+      mime_type: application/pdf
+      filesize: 338345
+      fileid: 11200
+      objectid: 509
+      filename: mason201009.pdf
+      datasetid: document
+      mtime: '2017-03-03 14:40:55'
+    rev_number: 4
+    pos: 2
+    eprintid: 962
+    security: public
+    format: application/pdf
+    main: mason201009.pdf
+    uri: http://publications.imp.fu-berlin.de/id/document/509
+    docid: 509
+    mime_type: application/pdf
+    content: submitted
+  creators:
+  - id: manuel.holtgrewe@fu-berlin.de
+    name:
+      lineage:
+      family: Holtgrewe
+      honourific:
+      given: M.
+  type: article
+  rev_number: 19
+  userid: 167
+  status_changed: '2011-10-08 14:32:15'
+  abstract: We present a read simulator software for Illumina, 454 and Sanger reads.
+    Its features include position specific error rates and base quality values. For
+    Illumina reads, we give a comprehensive analysis with empirical data for the error
+    and quality model. For the other technologies, we use models from the literature.
+    It has been written with performance in mind and can sample reads from large genomes.
+    The C++ source code is extensible, and freely available under the GPL/LGPL.
+  title: Mason – A Read Simulator for Second Generation Sequencing Data
+  refereed: 'FALSE'
+  eprintid: 962
+  full_text_status: public
+  metadata_visibility: show
+  item_issues_count: 0
+  dir: disk0/00/00/09/62
+  eprint_status: archive
+  subjects:
+  - G400
+  divisions:
+  - group_algbioinf
+  date: 2010-10
+- creators:
+  - id: jialu.hu@fu-berlin.de
+    name:
+      given: J.
+      honourific:
+      family: Hu
+      lineage:
+  - name:
+      honourific:
+      given: B.
+      family: Kehr
+      lineage:
+    id:
+  - name:
+      lineage:
+      honourific:
+      given: K.
+      family: Reinert
+    id: knut.reinert@fu-berlin.de
+  publication: Bioinformatics
+  datestamp: '2014-03-18 15:26:45'
+  title: 'NetCoffee: a fast and accurate global alignment approach to identify functionally
+    conserved proteins in multiple networks'
+  abstract: "Motivation: Owing to recent advancements in high-throughput technologies,
+    protein–protein interaction networks of more and more species become available
+    in public databases. The question of how to identify functionally conserved proteins
+    across species attracts a lot of attention in computational biology. Network alignments
+    provide a systematic way to solve this problem. However, most existing alignment
+    tools encounter limitations in tackling this problem. Therefore, the demand for
+    faster and more efficient alignment tools is growing.\r\n\r\nResults: We present
+    a fast and accurate algorithm, NetCoffee, which allows to find a global alignment
+    of multiple protein–protein interaction networks. NetCoffee searches for a global
+    alignment by maximizing a target function using simulated annealing on a set of
+    weighted bipartite graphs that are constructed using a triplet approach similar
+    to T-Coffee. To assess its performance, NetCoffee was applied to four real datasets.
+    Our results suggest that NetCoffee remedies several limitations of previous algorithms,
+    outperforms all existing alignment tools in terms of speed and nevertheless identifies
+    biologically meaningful alignments.\r\n\r\nAvailability: The source code and data
+    are freely available for download under the GNU GPL v3 license at https://code.google.com/p/netcoffee/. "
+  status_changed: '2014-08-19 14:46:18'
+  userid: 132
+  publisher: Oxford University Press
+  type: article
+  rev_number: 9
+  official_url: http://bioinformatics.oxfordjournals.org/cgi/doi/10.1093/bioinformatics/btt715
+  ispublished: pub
+  lastmod: '2014-08-19 14:46:18'
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1399
+  eprint_status: archive
+  dir: disk0/00/00/13/99
+  issn: 1367-4803
+  pagerange: 540-548
+  date: '2014-02-15'
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  volume: 30
+  eprintid: 1399
+  refereed: 'TRUE'
+  number: 4
+  item_issues_count: 0
+  metadata_visibility: show
+  id_number: 'doi: 10.1093/bioinformatics/btt715'
+  date_type: published
+  full_text_status: none
+- official_url: http://bioinformatics.oxfordjournals.org/cgi/doi/10.1093/bioinformatics/btu652
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1457
+  ispublished: pub
+  lastmod: '2016-11-15 14:02:23'
+  datestamp: '2014-10-12 19:16:09'
+  publication: Bioinformatics
+  creators:
+  - name:
+      lineage:
+      family: Hu
+      honourific:
+      given: J.
+  - name:
+      lineage:
+      family: Reinert
+      given: K.
+      honourific:
+  userid: 29
+  publisher: Oxford University Press
+  rev_number: 16
+  type: article
+  title: 'LocalAli: An Evolutionary-based Local Alignment Approach to Identify Functionally
+    Conserved Modules in Multiple Networks.'
+  abstract: "MOTIVATION:Sequences and protein interaction data are of significance
+    to understand the underlying molecular mechanism of organisms. Local network alignment
+    is one of key systematic ways for predicting protein functions, identifying functional
+    modules, and understanding the phylogeny from these data. Most of currently existing
+    tools, however, encounter their limitations which are mainly concerned with scoring
+    scheme, speed and scalability. Therefore, there are growing demands for sophisticated
+    network evolution models and efficient local alignment algorithms.\r\nRESULTS:We
+    developed a fast and scalable local network alignment tool so-called LocalAli
+    for the identification of functionally conserved modules in multiple networks.
+    In this algorithm, we firstly proposed a new framework to reconstruct the evolution
+    history of conserved modules based on a maximum-parsimony evolutionary model.
+    By relying on this model, LocalAli facilitates interpretation of resulting local
+    alignments in terms of conserved modules which have been evolved from a common
+    ancestral module through a series of evolutionary events. A meta-heuristic method
+    simulated annealing was used to search for the optimal or near-optimal inner nodes
+    (i.e. ancestral modules) of the evolutionary tree. To evaluate the performance
+    and the statistical significance, LocalAli were tested on a total of 26 real datasets
+    and 1040 randomly generated datasets. The results suggest that LocalAli outperforms
+    all existing algorithms in terms of coverage, consistency and scalability, meanwhile
+    retains a high precision in the identification of functionally coherent subnetworks.\r\n\r\nAVAILABILITY:The
+    source code and test datasets are freely available for download under the GNU
+    GPL v3 license at https://code.google.com/p/localali/.\r\n\r\nCONTACT:jialu.hu@fu-berlin.de
+    or knut.reinert@fu-berlin.de."
+  status_changed: '2016-11-15 14:02:22'
+  refereed: 'TRUE'
+  eprintid: 1457
+  number: 1
+  metadata_visibility: show
+  id_number: 'doi: 10.1093/bioinformatics/btu652'
+  date_type: published
+  full_text_status: none
+  item_issues_count: 0
+  dir: disk0/00/00/14/57
+  issn: 1367-4803
+  eprint_status: archive
+  divisions:
+  - group_algbioinf
+  subjects:
+  - C100
+  - G400
+  volume: 30
+  pagerange: 363-372
+  date: 2015
+- dir: disk0/00/00/03/65
+  eprint_status: archive
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  date: 2001
+  pagerange: 294-306
+  refereed: 'TRUE'
+  eprintid: 365
+  metadata_visibility: show
+  full_text_status: none
+  item_issues_count: 0
+  datestamp: '2017-03-03 14:40:14'
+  creators:
+  - name:
+      lineage:
+      honourific:
+      given: D. H.
+      family: Huson
+  - name:
+      honourific:
+      given: A. L.
+      family: Halpern
+      lineage:
+  - name:
+      honourific:
+      given: Z.
+      family: Lai
+      lineage:
+  - name:
+      lineage:
+      given: E. W.
+      honourific:
+      family: Myers
+  - name:
+      given: K.
+      honourific:
+      family: Reinert
+      lineage:
+  - name:
+      family: Sutton
+      honourific:
+      given: G. G.
+      lineage:
+  userid: 1
+  type: conference_item
+  rev_number: 3
+  title: Comparing Assemblies using Fragments and Mate-pairs
+  status_changed: '2009-03-11 11:27:06'
+  uri: http://publications.imp.fu-berlin.de/id/eprint/365
+  event_title: Proceedings of the 1st Workshop on Algorithms Bioinformatics (WABI-01)
+  lastmod: '2017-03-03 14:40:14'
+  ispublished: pub
+- datestamp: '2017-03-03 14:40:14'
+  creators:
+  - name:
+      lineage:
+      family: Huson
+      given: D. H.
+      honourific:
+  - name:
+      lineage:
+      given: K.
+      honourific:
+      family: Reinert
+  - name:
+      lineage:
+      family: Kravitz
+      given: S. A.
+      honourific:
+  - name:
+      lineage:
+      family: Remington
+      honourific:
+      given: "K.\tA."
+  - name:
+      lineage:
+      family: Delcher
+      given: A. L.
+      honourific:
+  - name:
+      given: I. M.
+      honourific:
+      family: Dew
+      lineage:
+  - name:
+      family: Flanigan
+      honourific:
+      given: M. J.
+      lineage:
+  - name:
+      honourific:
+      given: A. L.
+      family: Halpern
+      lineage:
+  - name:
+      lineage:
+      given: Z.
+      honourific:
+      family: Lai
+  - name:
+      honourific:
+      given: C. M.
+      family: Mobarry
+      lineage:
+  - name:
+      lineage:
+      given: G. G.
+      honourific:
+      family: Sutton
+  - name:
+      lineage:
+      family: Myers
+      given: E. W.
+      honourific:
+  userid: 1
+  type: conference_item
+  rev_number: 3
+  title: Design of a compartmentalized Shotgun Assembler for the Human Genome
+  status_changed: '2009-03-11 11:27:07'
+  uri: http://publications.imp.fu-berlin.de/id/eprint/366
+  event_title: "Proceedings of the Ninth International Conference on Intelligent\tSystems
+    for Molecular Biology (ISMB-01)"
+  ispublished: pub
+  lastmod: '2017-03-03 14:40:14'
+  dir: disk0/00/00/03/66
+  eprint_status: archive
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  date: 2001
+  pagerange: 132-139
+  eprintid: 366
+  refereed: 'TRUE'
+  metadata_visibility: show
+  full_text_status: none
+  item_issues_count: 0
+- divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  volume: 49
+  date: 2002
+  pagerange: 603-615
+  dir: disk0/00/00/03/67
+  eprint_status: archive
+  metadata_visibility: show
+  full_text_status: none
+  item_issues_count: 0
+  refereed: 'TRUE'
+  eprintid: 367
+  number: 5
+  userid: 1
+  type: article
+  rev_number: 3
+  title: The Greedy Path-Merging Algorithm for Sequence Assembly
+  status_changed: '2009-03-11 11:27:08'
+  datestamp: '2017-03-03 14:40:14'
+  publication: Journal of the ACM
+  creators:
+  - name:
+      lineage:
+      given: D. H.
+      honourific:
+      family: Huson
+  - name:
+      given: K.
+      honourific:
+      family: Reinert
+      lineage:
+  - name:
+      family: Myers
+      given: E. W.
+      honourific:
+      lineage:
+  uri: http://publications.imp.fu-berlin.de/id/eprint/367
+  ispublished: pub
+  lastmod: '2017-03-03 14:40:14'
+- type: conference_item
+  rev_number: 3
+  userid: 1
+  status_changed: '2009-03-11 11:27:08'
+  title: The Greedy Path-Merging Algorithm for Sequence Assembly
+  datestamp: '2017-03-03 14:40:14'
+  creators:
+  - name:
+      family: Huson
+      given: D. H.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      family: Reinert
+      honourific:
+      given: K.
+  - name:
+      given: E. W.
+      honourific:
+      family: Myers
+      lineage:
+  uri: http://publications.imp.fu-berlin.de/id/eprint/368
+  event_title: "Proceedings of the Fifth Annual International Conference on Computational\tMolecular
+    Biology (RECOMB-01)"
+  ispublished: pub
+  lastmod: '2017-03-03 14:40:14'
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  date: 2001
+  pagerange: 157-163
+  dir: disk0/00/00/03/68
+  eprint_status: archive
+  full_text_status: none
+  metadata_visibility: show
+  item_issues_count: 0
+  refereed: 'TRUE'
+  eprintid: 368
+- uri: http://publications.imp.fu-berlin.de/id/eprint/935
+  ispublished: pub
+  lastmod: '2010-11-18 13:44:27'
+  official_url: http://dx.doi.org/10.1371/journal.ppat.1000985
+  type: article
+  rev_number: 11
+  userid: 132
+  abstract: Adeno-associated virus type 2 (AAV) is known to establish latency by preferential
+    integration in human chromosome 19q13.42. The AAV non-structural protein Rep appears
+    to target a site called AAVS1 by simultaneously binding to Rep-binding sites (RBS)
+    present on the AAV genome and within AAVS1. In the absence of Rep, as is the case
+    with AAV vectors, chromosomal integration is rare and random. For a genome-wide
+    survey of wildtype AAV integration a linker-selection-mediated (LSM)-PCR strategy
+    was designed to retrieve AAV-chromosomal junctions. DNA sequence determination
+    revealed wildtype AAV integration sites scattered over the entire human genome.
+    The bioinformatic analysis of these integration sites compared to those of rep-deficient
+    AAV vectors revealed a highly significant overrepresentation of integration events
+    near to consensus RBS. Integration hotspots included AAVS1 with 10% of total events.
+    Novel hotspots near consensus RBS were identified on chromosome 5p13.3 denoted
+    AAVS2 and on chromsome 3p24.3 denoted AAVS3. AAVS2 displayed seven independent
+    junctions clustered within only 14 bp of a consensus RBS which proved to bind
+    Rep in vitro similar to the RBS in AAVS3. Expression of Rep in the presence of
+    rep-deficient AAV vectors shifted targeting preferences from random integration
+    back to the neighbourhood of consensus RBS at hotspots and numerous additional
+    sites in the human genome. In summary, targeted AAV integration is not as specific
+    for AAVS1 as previously assumed. Rather, Rep targets AAV to integrate into open
+    chromatin regions in the reach of various, consensus RBS homologues in the human
+    genome.
+  status_changed: '2010-11-18 13:44:27'
+  title: Integration Preferences of Wildtype AAV-2 for Consensus Rep-Binding Sites
+    at Numerous Loci in the Human Genome
+  datestamp: '2010-08-26 11:10:39'
+  publication: PLoS Pathogens
+  creators:
+  - name:
+      lineage:
+      family: Hüser
+      given: D.
+      honourific:
+    id:
+  - name:
+      given: A.
+      honourific:
+      family: Gogol-Döring
+      lineage:
+    id:
+  - name:
+      family: Lutter
+      given: T.
+      honourific:
+      lineage:
+    id:
+  - name:
+      lineage:
+      family: Weger
+      given: S.
+      honourific:
+    id:
+  - id:
+    name:
+      given: K.
+      honourific:
+      family: Winter
+      lineage:
+  - id:
+    name:
+      lineage:
+      family: Hammer
+      given: E.-M.
+      honourific:
+  - name:
+      given: T.
+      honourific:
+      family: Cathomen
+      lineage:
+    id:
+  - name:
+      given: K.
+      honourific:
+      family: Reinert
+      lineage:
+    id: knut.reinert@fu-berlin.de
+  - name:
+      given: R.
+      honourific:
+      family: Heilbronn
+      lineage:
+    id:
+  date_type: published
+  full_text_status: none
+  id_number: doi:10.1371/journal.ppat.1000985
+  metadata_visibility: show
+  item_issues_count: 0
+  number: 7
+  refereed: 'TRUE'
+  eprintid: 935
+  volume: 6
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  pagerange: e1000985
+  date: '2010-07-08'
+  issn: 1553-7374
+  dir: disk0/00/00/09/35
+  eprint_status: archive
+- userid: 1
+  rev_number: 3
+  type: article
+  title: Whole-genome shotgun assembly and comparison of human genome assemblies
+  status_changed: '2009-03-11 11:27:09'
+  datestamp: '2017-03-03 14:40:14'
+  publication: Proceedings of the national academy of science (PNAS)
+  creators:
+  - name:
+      family: Istrail
+      given: S.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      given: G. G.
+      honourific:
+      family: Sutton
+  - name:
+      honourific:
+      given: L.
+      family: Florea
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: C. M.
+      family: Mobarry
+  - name:
+      lineage:
+      honourific:
+      given: R.
+      family: Lippert
+  - name:
+      family: Walenz
+      given: B.
+      honourific:
+      lineage:
+  - name:
+      family: Shatkay
+      honourific:
+      given: H.
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: Ian
+      family: Dew
+  - name:
+      family: Miller
+      given: J. R.
+      honourific:
+      lineage:
+  - name:
+      family: Flanigan
+      honourific:
+      given: M. J.
+      lineage:
+  - name:
+      lineage:
+      family: Edwards
+      honourific:
+      given: N. J.
+  - name:
+      lineage:
+      honourific:
+      given: R.
+      family: Bolanos
+  - name:
+      lineage:
+      family: Fasulo
+      honourific:
+      given: D.
+  - name:
+      honourific:
+      given: B. V.
+      family: Halldorsson
+      lineage:
+  - name:
+      family: Hannenhalli
+      honourific:
+      given: S.
+      lineage:
+  - name:
+      family: Turner
+      honourific:
+      given: R. J.
+      lineage:
+  - name:
+      lineage:
+      given: S.
+      honourific:
+      family: Yooseph
+  - name:
+      lineage:
+      honourific:
+      given: Fu
+      family: Lu
+  - name:
+      given: D. R.
+      honourific:
+      family: Nusskern
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: B. C.
+      family: Shue
+  - name:
+      lineage:
+      honourific:
+      given: X. H.
+      family: Zheng
+  - name:
+      given: F.
+      honourific:
+      family: Zhong
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: A. L.
+      family: Delcher
+  - name:
+      lineage:
+      honourific:
+      given: D. H.
+      family: Huson
+  - name:
+      lineage:
+      family: Kravitz
+      honourific:
+      given: S. A.
+  - name:
+      lineage:
+      honourific:
+      given: L.
+      family: Mouchard
+  - name:
+      lineage:
+      family: Reinert
+      given: K.
+      honourific:
+  - name:
+      honourific:
+      given: K. A.
+      family: Remington
+      lineage:
+  - name:
+      lineage:
+      family: Clark
+      given: A. G.
+      honourific:
+  - name:
+      lineage:
+      honourific:
+      given: M. S.
+      family: Waterman
+  - name:
+      family: Eichler
+      given: E. E.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      family: Adams
+      honourific:
+      given: M. D.
+  - name:
+      lineage:
+      family: Hunkapillar
+      given: M. W.
+      honourific:
+  - name:
+      given: E. W.
+      honourific:
+      family: Myers
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: J. C.
+      family: Venter
+  uri: http://publications.imp.fu-berlin.de/id/eprint/369
+  ispublished: pub
+  lastmod: '2017-03-03 14:40:14'
+  subjects:
+  - G400
+  divisions:
+  - group_algbioinf
+  volume: 101
+  date: 2004
+  pagerange: 1916-1921
+  dir: disk0/00/00/03/69
+  eprint_status: archive
+  metadata_visibility: show
+  full_text_status: none
+  item_issues_count: 0
+  refereed: 'TRUE'
+  eprintid: 369
+  number: 7
+- number: 7
+  refereed: 'TRUE'
+  eprintid: 1396
+  date_type: published
+  full_text_status: none
+  id_number: 'doi: 10.1021/pr300187f'
+  metadata_visibility: show
+  item_issues_count: 0
+  issn: 1535-3893
+  dir: disk0/00/00/13/96
+  eprint_status: archive
+  volume: 11
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  pagerange: 3914-3920
+  date: '2012-07-06'
+  official_url: http://pubs.acs.org/doi/abs/10.1021/pr300187f
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1396
+  lastmod: '2014-03-18 14:13:29'
+  ispublished: pub
+  datestamp: '2014-03-18 14:13:29'
+  publication: J. Proteome Res.
+  creators:
+  - name:
+      honourific:
+      given: J.
+      family: Junker
+      lineage:
+    id:
+  - name:
+      family: Bielow
+      given: C.
+      honourific:
+      lineage:
+    id:
+  - id:
+    name:
+      lineage:
+      family: Bertsch
+      given: A.
+      honourific:
+  - name:
+      honourific:
+      given: M.
+      family: Sturm
+      lineage:
+    id:
+  - name:
+      family: Reinert
+      honourific:
+      given: K.
+      lineage:
+    id: knut.reinert@fu-berlin.de
+  - id:
+    name:
+      lineage:
+      family: Kohlbacher
+      given: O.
+      honourific:
+  type: article
+  publisher: ACS Publications
+  rev_number: 10
+  userid: 132
+  status_changed: '2014-03-18 14:13:29'
+  abstract: Mass spectrometry coupled to high-performance liquid chromatography (HPLC-MS)
+    is evolving more quickly than ever. A wide range of different instrument types
+    and experimental setups are commonly used. Modern instruments acquire huge amounts
+    of data, thus requiring tools for an efficient and automated data analysis. Most
+    existing software for analyzing HPLC-MS data is monolithic and tailored toward
+    a specific application. A more flexible alternative consists of pipeline-based
+    tool kits allowing the construction of custom analysis workflows from small building
+    blocks, e.g., the Trans Proteomics Pipeline (TPP) or The OpenMS Proteomics Pipeline
+    (TOPP). One drawback, however, is the hurdle of setting up complex workflows using
+    command line tools. We present TOPPAS, The OpenMS Proteomics Pipeline ASsistant,
+    a graphical user interface (GUI) for rapid composition of HPLC-MS analysis workflows.
+    Workflow construction reduces to simple drag-and-drop of analysis tools and adding
+    connections in between. Integration of external tools into these workflows is
+    possible as well. Once workflows have been developed, they can be deployed in
+    other workflow management systems or batch processing systems in a fully automated
+    fashion. The implementation is portable and has been tested under Windows, Mac
+    OS X, and Linux. TOPPAS is open-source software and available free of charge at
+    http://www.OpenMS.de/TOPPAS .
+  title: 'TOPPAS: a graphical workflow editor for the analysis of high-throughput
+    proteomics data'
+- eprintid: 2004
+  refereed: 'TRUE'
+  number: 1
+  metadata_visibility: show
+  id_number: doi:10.1186/s13073-016-0383-z
+  date_type: published
+  full_text_status: none
+  item_issues_count: 0
+  dir: disk0/00/00/20/04
+  issn: 1756-994X
+  eprint_status: archive
+  subjects:
+  - G400
+  divisions:
+  - group_algbioinf
+  volume: 8
+  date: '2016-12-13'
+  official_url: http://dx.doi.org/10.1186/s13073-016-0383-z
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2004
+  lastmod: '2017-01-12 09:36:57'
+  ispublished: pub
+  publication: Genome Medicine
+  datestamp: '2017-01-12 09:36:57'
+  creators:
+  - name:
+      lineage:
+      family: Jäger
+      given: Marten
+      honourific:
+  - name:
+      lineage:
+      family: Schubach
+      given: Max
+      honourific:
+  - name:
+      honourific:
+      given: Tomasz
+      family: Zemojtel
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: Knut
+      family: Reinert
+  - name:
+      family: Church
+      honourific:
+      given: Deanna M.
+      lineage:
+  - name:
+      given: Peter N.
+      honourific:
+      family: Robinson
+      lineage:
+  userid: 132
+  rev_number: 7
+  publisher: BioMed Central (Springer Nature)
+  type: article
+  title: Alternate-locus aware variant calling in whole genome sequencing
+  status_changed: '2017-01-12 09:36:57'
+  abstract: "\r\nBackground\r\n\r\nThe last two human genome assemblies have extended
+    the previous linear golden-path paradigm of the human genome to a graph-like model
+    to better represent regions with a high degree of structural variability. The
+    new model offers opportunities to improve the technical validity of variant calling
+    in whole-genome sequencing (WGS).\r\nMethods\r\n\r\nWe developed an algorithm
+    that analyzes the patterns of variant calls in the 178 structurally variable regions
+    of the GRCh38 genome assembly, and infers whether a given sample is most likely
+    to contain sequences from the primary assembly, an alternate locus, or their heterozygous
+    combination at each of these 178 regions. We investigate 121 in-house WGS datasets
+    that have been aligned to the GRCh37 and GRCh38 assemblies.\r\n\r\nResults\r\n\r\nWe
+    show that stretches of sequences that are largely but not entirely identical between
+    the primary assembly and an alternate locus can result in multiple variant calls
+    against regions of the primary assembly. In WGS analysis, this results in characteristic
+    and recognizable patterns of variant calls at positions that we term alignable
+    scaffold-discrepant positions (ASDPs). In 121 in-house genomes, on average 51.8±3.8
+    of the 178 regions were found to correspond best to an alternate locus rather
+    than the primary assembly sequence, and filtering these genomes with our algorithm
+    led to the identification of 7863 variant calls per genome that colocalized with
+    ASDPs. Additionally, we found that 437 of 791 genome-wide association study hits
+    located within one of the regions corresponded to ASDPs.\r\n\r\nConclusions\r\n\r\nOur
+    algorithm uses the information contained in the 178 structurally variable regions
+    of the GRCh38 genome assembly to avoid spurious variant calls in cases where samples
+    contain an alternate locus rather than the corresponding segment of the primary
+    assembly. These results suggest the great potential of fully incorporating the
+    resources of graph-like genome assemblies into variant calling, but also underscore
+    the importance of developing computational resources that will allow a full reconstruction
+    of the genotype in personal genomes. Our algorithm is freely available at https://github.com/charite/asdpex."
+- status_changed: '2009-03-11 11:27:10'
+  title: A Polyhedral Approach to Sequence Alignment Problems
+  rev_number: 3
+  type: article
+  userid: 1
+  creators:
+  - name:
+      family: Kececioglu
+      honourific:
+      given: J. D.
+      lineage:
+  - name:
+      honourific:
+      given: H.-P.
+      family: Lenhof
+      lineage:
+  - name:
+      lineage:
+      family: Mehlhorn
+      given: K.
+      honourific:
+  - name:
+      family: Reinert
+      honourific:
+      given: K.
+      lineage:
+  - name:
+      honourific:
+      given: M.
+      family: Vingron
+      lineage:
+  datestamp: '2017-03-03 14:40:14'
+  publication: Discrete Applied Mathematics
+  lastmod: '2017-03-03 14:40:14'
+  ispublished: pub
+  uri: http://publications.imp.fu-berlin.de/id/eprint/370
+  date: 2000
+  pagerange: 143-186
+  volume: 104
+  subjects:
+  - G400
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  dir: disk0/00/00/03/70
+  item_issues_count: 0
+  full_text_status: none
+  metadata_visibility: show
+  eprintid: 370
+  refereed: 'TRUE'
+- eprint_status: archive
+  dir: disk0/00/00/11/68
+  date: 2012
+  pagerange: 391-403
+  place_of_pub: Berlin
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  volume: 7534
+  eprintid: 1168
+  refereed: 'TRUE'
+  item_issues_count: 0
+  metadata_visibility: show
+  full_text_status: none
+  date_type: published
+  creators:
+  - name:
+      lineage:
+      family: Kehr
+      honourific:
+      given: B.
+    id: birte.kehr@fu-berlin.de
+  - name:
+      given: K.
+      honourific:
+      family: Reinert
+      lineage:
+    id: knut.reinert@fu-berlin.de
+  - name:
+      lineage:
+      honourific:
+      given: A. E.
+      family: Darling
+    id:
+  related_url:
+  - url: http://www.springerlink.com/content/978-3-642-33121-3/
+  datestamp: '2012-10-16 11:59:27'
+  title: 'Hidden Breakpoints in Genome Alignments '
+  editors:
+  - name:
+      family: Raphael
+      honourific:
+      given: B.
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: J.
+      family: Tang
+  abstract: "During the course of evolution, an organism’s genome can undergo changes
+    that affect the large-scale structure of the genome. These changes include gene
+    gain, loss, duplication, chromosome fusion, fission, and rearrangement. When gene
+    gain and loss occurs in addition to other types of rearrangement, breakpoints
+    of rearrangement can exist that are only detectable by comparison of three or
+    more genomes. An arbitrarily large number of these “hidden” breakpoints can exist
+    among genomes that exhibit no rearrangements in pairwise comparisons. \r\n\r\nWe
+    present an extension of the multichromosomal breakpoint median problem to genomes
+    that have undergone gene gain and loss. We then demonstrate that the median distance
+    among three genomes can be used to calculate a lower bound on the number of hidden
+    breakpoints present. We provide an implementation of this calculation including
+    the median distance, along with some practical improvements on the time complexity
+    of the underlying algorithm. \r\n\r\nWe apply our approach to measure the abundance
+    of hidden breakpoints in simulated data sets under a wide range of evolutionary
+    scenarios. We demonstrate that in simulations the hidden breakpoint counts depend
+    strongly on relative rates of inversion and gene gain/loss. Finally we apply current
+    multiple genome aligners to the simulated genomes, and show that all aligners
+    introduce a high degree of error in hidden breakpoint counts, and that this error
+    grows with evolutionary distance in the simulation. Our results suggest that hidden
+    breakpoint error may be pervasive in genome alignments. "
+  status_changed: '2012-10-16 12:04:02'
+  userid: 132
+  publisher: Springer-Verlag
+  rev_number: 11
+  type: book_section
+  official_url: http://www.springerlink.com/content/u776nx9n7h013887/
+  book_title: 'Lecture Notes in Computer Science: Algorithms in Bioinformatics'
+  ispublished: pub
+  lastmod: '2012-10-16 12:04:02'
+  isbn: 978-3-642-33121-3
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1168
+- item_issues_count: 0
+  date_type: published
+  full_text_status: none
+  metadata_visibility: show
+  id_number: doi:10.1186/1471-2105-15-99
+  refereed: 'TRUE'
+  eprintid: 1437
+  date: '2014-04-09'
+  volume: 15
+  subjects:
+  - G400
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  issn: 1471-2105
+  dir: disk0/00/00/14/37
+  lastmod: '2014-08-19 12:35:56'
+  ispublished: pub
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1437
+  official_url: http://www.biomedcentral.com/1471-2105/15/99/abstract
+  abstract: "Background\r\n\r\nRecent advances in rapid, low-cost sequencing have
+    opened up the opportunity to study complete genome sequences. The computational
+    approach of multiple genome alignment allows investigation of evolutionarily related
+    genomes in an integrated fashion, providing a basis for downstream analyses such
+    as rearrangement studies and phylogenetic inference.\r\n\r\nGraphs have proven
+    to be a powerful tool for coping with the complexity of genome-scale sequence
+    alignments. The potential of graphs to intuitively represent all aspects of genome
+    alignments led to the development of graph-based approaches for genome alignment.
+    These approaches construct a graph from a set of local alignments, and derive
+    a genome alignment through identification and removal of graph substructures that
+    indicate errors in the alignment.\r\n\r\nResults\r\n\r\nWe compare the structures
+    of commonly used graphs in terms of their abilities to represent alignment information.
+    We describe how the graphs can be transformed into each other, and identify and
+    classify graph substructures common to one or more graphs. Based on previous approaches,
+    we compile a list of modifications that remove these substructures.\r\n\r\nConclusion\r\n\r\nWe
+    show that crucial pieces of alignment information, associated with inversions
+    and duplications, are not visible in the structure of all graphs. If we neglect
+    vertex or edge labels, the graphs differ in their information content. Still,
+    many ideas are shared among all graph-based approaches. Based on these findings,
+    we outline a conceptual framework for graph-based genome alignment that can assist
+    in the development of future genome alignment tools. "
+  status_changed: '2014-08-19 12:35:56'
+  title: 'Genome alignment with graph data structures: a comparison'
+  type: article
+  publisher: BioMed Central
+  rev_number: 12
+  userid: 132
+  creators:
+  - id:
+    name:
+      lineage:
+      honourific:
+      given: B.
+      family: Kehr
+  - id:
+    name:
+      family: Trappe
+      honourific:
+      given: K.
+      lineage:
+  - id:
+    name:
+      honourific:
+      given: M.
+      family: Holtgrewe
+      lineage:
+  - name:
+      lineage:
+      family: Reinert
+      given: K.
+      honourific:
+    id: knut.reinert@fu-berlin.de
+  datestamp: '2014-08-19 12:35:56'
+  publication: BMC Bioinformatics
+- userid: 30
+  publisher: BioMed Central
+  rev_number: 11
+  type: article
+  title: 'STELLAR: fast and exact local alignments'
+  abstract: "Background\r\nLarge-scale comparison of genomic sequences requires reliable
+    tools for the search of local alignments. Practical local aligners are in general
+    fast, but heuristic, and hence sometimes miss significant matches.\r\n\r\nResults\r\nWe
+    present here the local pairwise aligner STELLAR that has full sensitivity for
+    ε-alignments, i.e. guarantees to report all local alignments of a given minimal
+    length and maximal error rate. The aligner is composed of two steps, filtering
+    and verification. We apply the SWIFT algorithm for lossless filtering, and have
+    developed a new verification strategy that we prove to be exact. Our results on
+    simulated and real genomic data confirm and quantify the conjecture that heuristic
+    tools like BLAST or BLAT miss a large percentage of significant local alignments.\r\n\r\nConclusions\r\nSTELLAR
+    is very practical and fast on very long sequences which makes it a suitable new
+    tool for finding local alignments between genomic sequences under the edit distance
+    model. Binaries are freely available for Linux, Windows, and Mac OS X at http://www.seqan.de/projects/stellar.
+    The source code is freely distributed with the SeqAn C++ library version 1.3 and
+    later at http://www.seqan.de."
+  status_changed: '2011-10-08 13:20:36'
+  datestamp: '2011-10-08 13:20:36'
+  publication: BMC Bioinformatics
+  creators:
+  - name:
+      family: Kehr
+      given: B.
+      honourific:
+      lineage:
+  - name:
+      family: Weese
+      given: D.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      family: Reinert
+      given: K.
+      honourific:
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1092
+  lastmod: '2011-10-08 13:20:36'
+  ispublished: pub
+  official_url: http://www.biomedcentral.com/1471-2105/12/S9/S15
+  divisions:
+  - group_algbioinf
+  subjects:
+  - C400
+  - G400
+  volume: 12
+  pagerange: S15
+  date: '2011-10-03'
+  dir: disk0/00/00/10/92
+  issn: 1471-2105
+  eprint_status: archive
+  metadata_visibility: show
+  date_type: published
+  full_text_status: none
+  item_issues_count: 0
+  eprintid: 1092
+  refereed: 'TRUE'
+  number: S9
+- official_url: http://doi.org/10.1101/301085
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2284
+  book_title: Optimum Search Schemes for Approximate String Matching Using Bidirectional
+    FM-Index
+  lastmod: '2018-11-12 14:25:35'
+  ispublished: pub
+  related_url:
+  - url: https://www.biorxiv.org/content/early/2018/04/14/301085
+  datestamp: '2018-11-12 14:25:35'
+  publication: bioRxiv, The Preprint Server for Biology
+  creators:
+  - name:
+      given: Kiavash
+      honourific:
+      family: Kianfar
+      lineage:
+  - name:
+      lineage:
+      family: Pockrandt
+      honourific:
+      given: Christopher
+  - name:
+      lineage:
+      family: Torkamandi
+      given: Bahman
+      honourific:
+  - name:
+      given: Haochen
+      honourific:
+      family: Luo
+      lineage:
+  - name:
+      given: Knut
+      honourific:
+      family: Reinert
+      lineage:
+  userid: 132
+  rev_number: 5
+  type: article
+  title: Optimum Search Schemes for Approximate String Matching Using Bidirectional
+    FM-Index
+  status_changed: '2018-11-12 14:25:35'
+  abstract: Finding approximate occurrences of a pattern in a text using a full-text
+    index is a central problem in bioinformatics and has been extensively researched.
+    Bidirectional indices have opened new possibilities in this regard allowing the
+    search to start from anywhere within the pattern and extend in both directions.
+    In particular, use of search schemes (partitioning the pattern and searching the
+    pieces in certain orders with given bounds on errors) can yield significant speed-ups.
+    However, finding optimal search schemes is a difficult combinatorial optimization
+    problem. Here for the first time, we propose a mixed integer program (MIP) capable
+    to solve this optimization problem for Hamming distance with given number of pieces.
+    Our experiments show that the optimal search schemes found by our MIP significantly
+    improve the performance of search in bidirectional FM-index upon previous ad-hoc
+    solutions. For example, approximate matching of 101-bp Illumina reads (with two
+    errors) becomes 35 times faster than standard backtracking. Moreover, despite
+    being performed purely in the index, the running time of search using our optimal
+    schemes (for up to two errors) is comparable to the best state-of-the-art aligners,
+    which benefit from combining search in index with in-text verification using dynamic
+    programming. As a result, we anticipate a full-fledged aligner that employs an
+    intelligent combination of search in the bidirectional FM-index using our optimal
+    search schemes and in-text verification using dynamic programming outperforms
+    today's best aligners. The development of such an aligner, called FAMOUS (Fast
+    Approximate string Matching using OptimUm search Schemes), is ongoing as our future
+    work.
+  eprintid: 2284
+  refereed: 'FALSE'
+  id_number: doi:10.1101/301085
+  metadata_visibility: show
+  date_type: published
+  full_text_status: none
+  dir: disk0/00/00/22/84
+  eprint_status: archive
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  date: '2018-04-14'
+- publisher: Dagstuhl LIPIcs
+  rev_number: 8
+  editors:
+  - name:
+      lineage:
+      given: Russell
+      honourific:
+      family: Schwartz
+  - name:
+      honourific:
+      given: Knut
+      family: Reinert
+      lineage:
+  status_changed: '2017-11-23 12:21:14'
+  official_url: http://drops.dagstuhl.de/opus/volltexte/2017/7635/
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2133
+  lastmod: '2017-11-23 12:21:14'
+  ispublished: pub
+  pages: 14
+  dir: disk0/00/00/21/33
+  eprint_status: archive
+  divisions:
+  - group_algbioinf
+  pagerange: 185(13:1)-198(13:14)
+  number: 88
+  date_type: published
+  metadata_visibility: show
+  id_number: 'DOI: 10.4230/LIPIcs.WABI.2017.13'
+  datestamp: '2017-11-23 12:21:14'
+  related_url:
+  - url: http://www.dagstuhl.de/dagpub/978-3-95977-050-7
+  creators:
+  - name:
+      family: Kim
+      honourific:
+      given: Jongkyu
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: Knut
+      family: Reinert
+  type: book_section
+  userid: 132
+  abstract: "Motivation: \r\nComprehensive identification of structural variations
+    (SVs) is a crucial task for studying genetic diversity and diseases. However,
+    it remains challenging. There is only a marginal consensus between different methods,
+    and our understanding of SVs is substantially limited.In general, integration
+    of multiple pieces of evidence including split-read, read-pair, soft-clip, and
+    read-depth yields the best result regarding accuracy. However, doing this step
+    by step is usually cumbersome and computationally expensive. \r\nResult: \r\nWe
+    present Vaquita, an accurate and fast tool for the identification of structural
+    variations, which leverages all four types of evidence in a single program. After
+    merging SVs from split-reads and discordant read-pairs, Vaquita realigns the soft-clipped
+    reads to the selected regions using a fast bit-vector algorithm. Furthermore,
+    it also considers the discrepancy of depth distribution around breakpoints using
+    Kullback-Leibler divergence. Finally, Vaquita provides an additional metric for
+    candidate selection based on voting, and also provides robust prioritization based
+    on rank aggregation. We show that Vaquita is robust in terms of sequencing coverage,
+    insertion size of the library, and read length, and is comparable or even better
+    for the identification of deletions, inversions, duplications, and translocations
+    than state-of-the-art tools, using both simulated and real datasets. In addition,
+    Vaquita is more than eight times faster than any other tools in comparison. \r\nAvailability:
+    \r\nVaquita is implemented in C++ using the SeqAn library. The source code is
+    distributed under the BSD license and can be downloaded at http://github.com/seqan/vaquita"
+  title: 'Vaquita: Fast and Accurate Identification of Structural Variation Using
+    Combined Evidence'
+  isbn: 978-3-95977-050-7
+  book_title: 17th International Workshop on Algorithms in Bioinformatics (WABI 2017)
+  subjects:
+  - G400
+  place_of_pub: Saarbrücken/Wadern
+  date: 2017-08
+  refereed: 'TRUE'
+  eprintid: 2133
+  full_text_status: none
+  series: LIPICS
+- item_issues_count: 0
+  metadata_visibility: show
+  full_text_status: none
+  refereed: 'TRUE'
+  eprintid: 371
+  pagerange: 840-856
+  date: 2007
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  volume: 155
+  eprint_status: archive
+  dir: disk0/00/00/03/71
+  ispublished: pub
+  lastmod: '2017-03-03 14:40:14'
+  uri: http://publications.imp.fu-berlin.de/id/eprint/371
+  title: Integer Linear Programming Approaches for Non-unique Probe Selection
+  status_changed: '2009-03-11 11:27:10'
+  userid: 1
+  type: article
+  rev_number: 3
+  creators:
+  - name:
+      lineage:
+      family: Klau
+      honourific:
+      given: G. W.
+  - name:
+      lineage:
+      family: Rahmann
+      honourific:
+      given: S.
+  - name:
+      family: Schliep
+      honourific:
+      given: A.
+      lineage:
+  - name:
+      lineage:
+      given: M.
+      honourific:
+      family: Vingron
+  - name:
+      lineage:
+      family: Reinert
+      honourific:
+      given: K.
+  publication: Discrete Applied Mathematics
+  datestamp: '2017-03-03 14:40:14'
+- ispublished: pub
+  lastmod: '2017-03-03 14:40:14'
+  uri: http://publications.imp.fu-berlin.de/id/eprint/372
+  event_title: "Proceedings of the Twelfth International Conference on Intelligent\tSystems
+    for Molecular Biology (ISMB-04)"
+  creators:
+  - name:
+      lineage:
+      honourific:
+      given: G. W.
+      family: Klau
+  - name:
+      family: Rahmann
+      given: S.
+      honourific:
+      lineage:
+  - name:
+      honourific:
+      given: A.
+      family: Schliep
+      lineage:
+  - name:
+      lineage:
+      given: K.
+      honourific:
+      family: Reinert
+  datestamp: '2017-03-03 14:40:14'
+  status_changed: '2009-03-11 11:27:11'
+  title: Optimal Robust Non-Unique Probe Selection Using Integer Linear Programming
+  rev_number: 3
+  type: conference_item
+  userid: 1
+  refereed: 'TRUE'
+  eprintid: 372
+  item_issues_count: 0
+  full_text_status: none
+  metadata_visibility: show
+  eprint_status: archive
+  dir: disk0/00/00/03/72
+  date: 2004
+  pagerange: 186-193
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+- lastmod: '2017-03-03 14:40:14'
+  ispublished: pub
+  uri: http://publications.imp.fu-berlin.de/id/eprint/373
+  creators:
+  - name:
+      lineage:
+      family: Klein
+      honourific:
+      given: C. L.
+  - name:
+      lineage:
+      honourific:
+      given: O.
+      family: Kohlbacher
+  - name:
+      given: K.
+      honourific:
+      family: Reinert
+      lineage:
+  datestamp: '2017-03-03 14:40:14'
+  publication: FEBS Journal
+  status_changed: '2009-03-11 11:27:11'
+  title: "Reference methods and materials in standardisation and quality assurance\t(abstract)"
+  rev_number: 3
+  type: article
+  userid: 1
+  number: Supplement 1
+  eprintid: 373
+  refereed: 'TRUE'
+  item_issues_count: 0
+  full_text_status: none
+  metadata_visibility: show
+  eprint_status: archive
+  dir: disk0/00/00/03/73
+  date: 2005
+  pagerange: 490-504
+  volume: 272
+  subjects:
+  - G400
+  divisions:
+  - group_algbioinf
+- divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  date: 2006
+  dir: disk0/00/00/03/75
+  eprint_status: archive
+  metadata_visibility: show
+  full_text_status: none
+  item_issues_count: 0
+  refereed: 'TRUE'
+  eprintid: 375
+  userid: 1
+  type: conference_item
+  rev_number: 3
+  title: TOPP - The OpenMS Proteomics Pipeline
+  status_changed: '2009-03-11 11:27:12'
+  abstract: "Motivation: Experimental techniques in proteomics have seen rapid\tdevelopment
+    over the last few years. Volume and complexity of the\r\n\tdata have both been
+    growing at a similar rate. Accordingly, data\r\n\tmanagement and analysis are
+    one of the major challenges in proteomics.\r\n\tFlexible algorithms are required
+    to handle changing experimental\r\n\tsetups and to assist in developing and validating
+    new methods. In\r\n\torder to facilitate these studies, it would be desirable
+    to have\r\n\ta flexible `toolbox' of versatile and user-friendly applications\r\n\tallowing
+    for rapid construction of computational workflows in proteomics.\r\n\tResults:
+    We describe a set of tools for proteomics data analysis\r\n\t-- TOPP, The OpenMS
+    Proteomics Pipeline. TOPP provides a set of computational\r\n\ttools which can
+    be easily combined into analysis pipelines even by\r\n\tnon-experts and can be
+    used in proteomics workflows. These applications\r\n\trange from useful utilities
+    (file format conversion, peak picking)\r\n\tover wrapper applications for known
+    applications (e.g. Mascot) to\r\n\tcompletely new algorithmic techniques for data
+    reduction and data\r\n\tanalysis. We anticipate that TOPP will greatly facilitate
+    rapid prototyping\r\n\tof proteomics data evaluation pipelines. As such, we describe
+    the\r\n\tbasic concepts and the current abilities of TOPP and illustrate these\r\n\tconcepts
+    in the context of two example applications: the identification\r\n\tof peptides
+    from a raw data set through database search and the complex\r\n\tanalysis of a
+    standard addition experiment for the absolute quantitation\r\n\tof biomarkers.
+    The latter example demonstrates TOPP's ability to\r\n\tconstruct flexible analysis
+    pipelines in support of complex experimental\r\n\tsetups. Availability: The TOPP
+    components are available as open-source\r\n\tsoftware under the lesser GNU public
+    license (LGPL). Source code\r\n\tis available from the project web site at www.OpenMS.de"
+  datestamp: '2009-04-14 14:25:23'
+  creators:
+  - name:
+      family: Kohlbacher
+      given: O.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      family: Reinert
+      honourific:
+      given: K.
+  - name:
+      family: Gröpl
+      honourific:
+      given: C.
+      lineage:
+  - name:
+      family: Lange
+      given: E.
+      honourific:
+      lineage:
+  - name:
+      family: Pfeiffer
+      given: N.
+      honourific:
+      lineage:
+  - name:
+      family: Schulz-Trieglaff
+      honourific:
+      given: O.
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: M.
+      family: Sturm
+  uri: http://publications.imp.fu-berlin.de/id/eprint/375
+  event_title: "Proceedings of the 5th European Conference on Computational Biology\t(ECCB
+    2006)"
+  lastmod: '2009-04-14 14:25:23'
+  ispublished: pub
+- ispublished: pub
+  lastmod: '2017-03-03 14:40:14'
+  uri: http://publications.imp.fu-berlin.de/id/eprint/374
+  status_changed: '2009-03-11 11:27:12'
+  title: "Differenzielle Proteomanalyse -- Experimentelle Methoden, Algorithmische\tHerausforderungen"
+  type: article
+  rev_number: 3
+  userid: 1
+  creators:
+  - name:
+      honourific:
+      given: O.
+      family: Kohlbacher
+      lineage:
+  - name:
+      honourific:
+      given: K.
+      family: Reinert
+      lineage:
+  publication: it -- Information technology
+  datestamp: '2017-03-03 14:40:14'
+  item_issues_count: 0
+  full_text_status: none
+  metadata_visibility: show
+  refereed: 'TRUE'
+  eprintid: 374
+  pagerange: 31-38
+  date: 2004
+  volume: 46
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  eprint_status: archive
+  dir: disk0/00/00/03/74
+- eprint_status: archive
+  dir: disk0/00/00/15/51
+  issn: 1367-4803
+  date: 2015
+  pagerange: 2963-2971
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  volume: 31
+  refereed: 'TRUE'
+  eprintid: 1551
+  number: 18
+  item_issues_count: 0
+  id_number: doi:10.1093/bioinformatics/btv309
+  metadata_visibility: show
+  date_type: published
+  full_text_status: none
+  creators:
+  - name:
+      lineage:
+      given: L.
+      honourific:
+      family: Kuchenbecker
+  - name:
+      lineage:
+      family: Nienen
+      honourific:
+      given: M.
+  - name:
+      lineage:
+      honourific:
+      given: J.
+      family: Hecht
+  - name:
+      lineage:
+      honourific:
+      given: A. U.
+      family: Neumann
+  - name:
+      honourific:
+      given: N.
+      family: Babel
+      lineage:
+  - name:
+      lineage:
+      family: Reinert
+      given: K.
+      honourific:
+  - name:
+      honourific:
+      given: P. N.
+      family: Robinson
+      lineage:
+  datestamp: '2015-06-02 12:53:46'
+  publication: Bioinformatics
+  title: IMSEQ - a fast and error aware approach to immunogenetic sequence analysis
+  status_changed: '2016-02-25 11:24:07'
+  abstract: "Motivation: Recombined T and B cell receptor repertoires are increasingly
+    being studied using next generation sequencing (NGS) in order to interrogate the
+    repertoire composition as well as changes in the distribution of receptor clones
+    under different physiological and disease states. This type of analysis requires
+    efficient and unambiguous clonotype assignment to a large number of NGS read sequences,
+    including the identification of the incorporated V and J gene segments and the
+    CDR3 sequence. Current tools have deficits with respect to performance, accuracy
+    and documentation of their underlying algorithms and usage.\r\n\r\nResults: We
+    present IMSEQ, a method to derive clonotype repertoires from next generation sequencing
+    data with sophisticated routines for handling errors stemming from PCR and sequencing
+    artefacts. The application can handle different kinds of input data originating
+    from single- or paired-end sequencing in different configurations and is generic
+    regarding the species and gene of interest. We have carefully evaluated our method
+    with simulated and real world data and show that IMSEQ is superior to other tools
+    with respect to its clonotyping as well as standalone error correction and runtime
+    performance.\r\n\r\nAvailability: IMSEQ was implemented in C++ using the SeqAn
+    library for efficient sequence analysis. It is freely available under the GPLv2
+    open source license and can be downloaded at www.imtools.org. "
+  userid: 132
+  type: article
+  publisher: Oxford University Press (online advanced access)
+  rev_number: 11
+  official_url: http://dx.doi.org/10.1093/bioinformatics/btv309
+  ispublished: pub
+  lastmod: '2016-02-25 11:24:07'
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1551
+- datestamp: '2009-03-11 17:18:04'
+  creators:
+  - name:
+      lineage:
+      given: E.
+      honourific:
+      family: Lange
+  type: other
+  rev_number: 3
+  userid: 1
+  status_changed: '2009-03-11 11:26:54'
+  abstract: "High throughput analysis of proteins using mass spectrometry requires\tan
+    efficient signal preprocessing which reduces the amount of data\r\n\twith minimal
+    loss of information. Therefore the peaks that belong\r\n\tto a peptide have to
+    be detected, and important features like their\r\n\tpeak centroid position, the
+    height and the area have to be determined.\r\n\tHere we present a peak picking
+    algorithm which detects peaks in a\r\n\tnoisy mass spectrum using its continuous
+    wavelet transform. By adapting\r\n\tthe wavelet to the theoretical peak shape,
+    each peaks centroid position\r\n\tis precisely identified; thus, overlapping peaks
+    (e.g. caused by\r\n\telectronspray ionization) are well separated. Representing
+    each peak\r\n\tnot only by its centroid position and area but also by the parameters\r\n\tof
+    the best fitting asymmetric lorentzian or hyperbolic secant squared\r\n\tfunctions,
+    yields valuable information about the original peak shape\r\n\tfor further analysis.
+    Given a mass spectrum with 100,000 raw data\r\n\tpoints representing 200 peaks,
+    our algorithm stored 5 parameters\r\n\tper peak, and was able to reduce the memory
+    requirement down to 1\r\n\tpercent."
+  title: Peak picking in mass spectra
+  uri: http://publications.imp.fu-berlin.de/id/eprint/344
+  ispublished: pub
+  lastmod: '2009-03-11 17:18:04'
+  dir: disk0/00/00/03/44
+  eprint_status: archive
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  date: 2004
+  eprintid: 344
+  refereed: 'TRUE'
+  full_text_status: none
+  metadata_visibility: show
+  item_issues_count: 0
+- creators:
+  - name:
+      honourific:
+      given: E.
+      family: Lange
+      lineage:
+  - name:
+      family: Gröpl
+      honourific:
+      given: C.
+      lineage:
+  - name:
+      given: K.
+      honourific:
+      family: Reinert
+      lineage:
+  - name:
+      lineage:
+      family: Hildebrandt
+      honourific:
+      given: A.
+  datestamp: '2009-04-14 14:22:41'
+  title: High Accuracy Peak-Picking of Proteomics Data using Wavelet Techniques
+  status_changed: '2009-03-11 11:27:13'
+  userid: 1
+  rev_number: 3
+  type: conference_item
+  lastmod: '2009-04-14 14:22:41'
+  ispublished: pub
+  event_title: Proceedings of the 11th Pacific Symposium on Biocomputing (PSB-06)
+  uri: http://publications.imp.fu-berlin.de/id/eprint/376
+  eprint_status: archive
+  dir: disk0/00/00/03/76
+  date: 2006
+  pagerange: 243-254
+  subjects:
+  - G400
+  divisions:
+  - group_algbioinf
+  eprintid: 376
+  refereed: 'TRUE'
+  item_issues_count: 0
+  metadata_visibility: show
+  full_text_status: none
+- dir: disk0/00/00/03/77
+  eprint_status: archive
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  date: 2005
+  refereed: 'TRUE'
+  eprintid: 377
+  full_text_status: none
+  metadata_visibility: show
+  item_issues_count: 0
+  datestamp: '2009-04-14 14:33:24'
+  creators:
+  - name:
+      family: Lange
+      given: E.
+      honourific:
+      lineage:
+  - name:
+      family: Gröpl
+      given: C.
+      honourific:
+      lineage:
+  - name:
+      family: Reinert
+      honourific:
+      given: K.
+      lineage:
+  - name:
+      lineage:
+      given: A.
+      honourific:
+      family: Hildebrandt
+  rev_number: 3
+  publisher: Dagstuhl Online Publication Server (DROPS)
+  type: conference_item
+  userid: 1
+  status_changed: '2009-03-11 11:27:14'
+  title: High-accuracy peak picking of proteomics data
+  official_url: http://www.dagstuhl.de/05471/
+  event_title: Computational Proteomics
+  uri: http://publications.imp.fu-berlin.de/id/eprint/377
+  lastmod: '2009-04-14 14:33:24'
+  ispublished: pub
+  note: "Extended abstract for talk given at Dagstuhl Seminar 05471 on Computational\tProteomics,
+    20.-25. November 2005"
+- event_title: "Proceedings of the 15th Annual International Conference on Intelligent\tSystems
+    for Molecular Biology (ISMB) &amp; 6th European Conference on \tComputational
+    Biology (ECCB)"
+  userid: 132
+  type: article
+  title: "A Geometric Approach for the Alignment of Liquid Chromatography-Mass\tSpectrometry
+    Data"
+  abstract: "Motivation: Liquid chromatography coupled to mass spectrometry (LC-MS)
+    and combined with tandem mass spectrometry (LC-MS/MS) have become a prominent
+    tool for the analysis of complex proteomic samples. An important step in a typical
+    workflow is the combination of results from multiple LC-MS experiments to improve
+    confidence in the obtained measurements or to compare results from different samples.
+    To do so, a suitable mapping or alignment between the data sets needs to be estimated.
+    The alignment has to correct for variations in mass and elution time which are
+    present in all mass spectrometry experiments. \r\n\r\nResults: We propose a novel
+    algorithm to align LC-MS samples and to match corresponding ion species across
+    samples. Our algorithm matches landmark signals between two data sets using a
+    geometric technique based on pose clustering. Variations in mass and retention
+    time are corrected by an affine dewarping function estimated from matched landmarks.
+    We use the pairwise dewarping in an algorithm for aligning multiple samples. We
+    show that our pose clustering approach is fast and reliable as compared to previous
+    approaches. It is robust in the presence of noise and able to accurately align
+    samples with only few common ion species. In addition, we can easily handle different
+    kinds of LC-MS data and adopt our algorithm to new mass spectrometry technologies.
+    \r\n\r\nAvailability: This algorithm is implemented as part of the OpenMS software
+    library for shotgun proteomics and available under the Lesser GNU Public License
+    (LGPL) at www.openms.de"
+  datestamp: '2012-04-10 14:34:51'
+  creators:
+  - id:
+    name:
+      lineage:
+      honourific:
+      given: E.
+      family: Lange
+  - name:
+      honourific:
+      given: C.
+      family: Gröpl
+      lineage:
+    id:
+  - name:
+      honourific:
+      given: O.
+      family: Schulz-Trieglaff
+      lineage:
+    id:
+  - name:
+      lineage:
+      family: Leinenbach
+      given: A.
+      honourific:
+    id:
+  - name:
+      lineage:
+      given: Ch.
+      honourific:
+      family: Huber
+    id:
+  - id: knut.reinert@fu-berlin.de
+    name:
+      lineage:
+      given: K.
+      honourific:
+      family: Reinert
+  succeeds: 378
+  full_text_status: none
+  refereed: 'TRUE'
+  eprintid: 1133
+  subjects:
+  - G400
+  date: 2007
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1133
+  lastmod: '2012-04-10 14:34:51'
+  ispublished: pub
+  official_url: http://bioinformatics.oxfordjournals.org/content/23/13/i273.long
+  publisher: Oxford University Press
+  rev_number: 7
+  status_changed: '2012-04-10 14:34:51'
+  publication: Oxford Journals
+  id_number: 'doi: 10.1093/bioinformatics/btm209'
+  metadata_visibility: show
+  date_type: published
+  item_issues_count: 0
+  number: 13
+  divisions:
+  - group_algbioinf
+  volume: 23
+  pagerange: i273-i281
+  dir: disk0/00/00/11/33
+  issn: 1460-2059 (online), 1367-4803 (print)
+  eprint_status: archive
+- creators:
+  - name:
+      family: Lange
+      given: E.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      family: Tautenhahn
+      honourific:
+      given: R.
+  - name:
+      family: Neumann
+      honourific:
+      given: S.
+      lineage:
+  - name:
+      lineage:
+      family: Gröpl
+      given: C.
+      honourific:
+  datestamp: '2009-04-14 14:12:16'
+  publication: BMC Bioinformatics
+  status_changed: '2009-03-11 11:27:15'
+  title: "Critical assessment of alignment procedures for LC-MS proteomics\tand metabolomic
+    measurements"
+  rev_number: 3
+  type: article
+  userid: 1
+  official_url: http://www.biomedcentral.com/1471-2105/9/375
+  ispublished: pub
+  lastmod: '2009-04-14 14:12:16'
+  uri: http://publications.imp.fu-berlin.de/id/eprint/379
+  eprint_status: archive
+  dir: disk0/00/00/03/79
+  date: 2008
+  volume: 9
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  number: 375
+  refereed: 'TRUE'
+  eprintid: 379
+  item_issues_count: 0
+  full_text_status: none
+  metadata_visibility: show
+- divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  volume: 15
+  pagerange: 203-210
+  date: 1999
+  dir: disk0/00/00/03/81
+  eprint_status: archive
+  metadata_visibility: show
+  full_text_status: none
+  item_issues_count: 0
+  eprintid: 381
+  refereed: 'TRUE'
+  number: 3
+  userid: 1
+  type: article
+  rev_number: 3
+  title: "An exact solution for the segment-to-segment multiple sequence alignment\tproblem"
+  status_changed: '2009-03-11 11:27:16'
+  datestamp: '2017-03-03 14:40:14'
+  publication: BIOINFORMATICS
+  creators:
+  - name:
+      lineage:
+      given: H.-P.
+      honourific:
+      family: Lenhof
+  - name:
+      family: Morgenstern
+      given: B.
+      honourific:
+      lineage:
+  - name:
+      given: K.
+      honourific:
+      family: Reinert
+      lineage:
+  uri: http://publications.imp.fu-berlin.de/id/eprint/381
+  ispublished: pub
+  lastmod: '2017-03-03 14:40:14'
+- datestamp: '2017-03-03 14:40:14'
+  publication: Journal of Computational Biology
+  creators:
+  - name:
+      lineage:
+      honourific:
+      given: H.-P.
+      family: Lenhof
+  - name:
+      given: K.
+      honourific:
+      family: Reinert
+      lineage:
+  - name:
+      lineage:
+      given: M.
+      honourific:
+      family: Vingron
+  type: article
+  rev_number: 3
+  userid: 1
+  status_changed: '2009-03-11 11:27:16'
+  title: A Polyhedral Approach to RNA Sequence Structure Alignment
+  uri: http://publications.imp.fu-berlin.de/id/eprint/382
+  lastmod: '2017-03-03 14:40:14'
+  ispublished: pub
+  dir: disk0/00/00/03/82
+  eprint_status: archive
+  volume: 5
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  date: 1998
+  pagerange: 517-530
+  number: 3
+  refereed: 'TRUE'
+  eprintid: 382
+  full_text_status: none
+  metadata_visibility: show
+  item_issues_count: 0
+- datestamp: '2010-11-02 13:46:49'
+  creators:
+  - name:
+      lineage:
+      given: H.-P.
+      honourific:
+      family: Lenhof
+  - name:
+      family: Reinert
+      given: K.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      given: M.
+      honourific:
+      family: Vingron
+  userid: 1
+  rev_number: 5
+  type: conference_item
+  title: A polyhedral approach to RNA sequence structure alignment
+  status_changed: '2010-11-02 13:46:56'
+  event_title: "Proceedings of the Second Annual International Conference on Computational\tMolecular
+    Biology (RECOMB-98)"
+  uri: http://publications.imp.fu-berlin.de/id/eprint/380
+  lastmod: '2010-11-02 13:46:56'
+  ispublished: pub
+  dir: disk0/00/00/03/80
+  eprint_status: archive
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  pagerange: 153-162
+  date: 1998
+  refereed: 'TRUE'
+  eprintid: 380
+  metadata_visibility: show
+  full_text_status: none
+  item_issues_count: 0
+- eprint_status: archive
+  dir: disk0/00/00/03/83
+  date: 2000
+  pagerange: 655-671
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  refereed: 'TRUE'
+  eprintid: 383
+  item_issues_count: 0
+  metadata_visibility: show
+  full_text_status: none
+  creators:
+  - name:
+      lineage:
+      honourific:
+      given: M.
+      family: Lermen
+  - name:
+      given: K.
+      honourific:
+      family: Reinert
+      lineage:
+  datestamp: '2017-03-03 14:40:14'
+  publication: Journal of Computational Biology
+  title: "The Practical Use of the A* Algorithm for Exact Multiple Sequence\tAlignment"
+  status_changed: '2009-03-11 11:27:17'
+  userid: 1
+  type: article
+  rev_number: 3
+  ispublished: pub
+  lastmod: '2017-03-03 14:40:14'
+  uri: http://publications.imp.fu-berlin.de/id/eprint/383
+- official_url: http://dx.doi.org/10.1093/bib/bbw089
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1981
+  lastmod: '2018-11-08 12:31:04'
+  ispublished: pub
+  datestamp: '2016-11-17 12:32:39'
+  publication: Briefings in Bioinformatics
+  creators:
+  - name:
+      lineage:
+      family: Marschall
+      given: T.
+      honourific:
+    id:
+  - name:
+      lineage:
+      given: K.
+      honourific:
+      family: Reinert
+    id: knut.reinert@fu-berlin.de
+  - name:
+      lineage:
+      family: others
+      given: "(59 authors in total)"
+      honourific:
+    id:
+  publisher: Oxford University Press
+  type: article
+  rev_number: 17
+  userid: 132
+  abstract: Many disciplines, from human genetics and oncology to plant breeding,
+    microbiology and virology, commonly face the challenge of analyzing rapidly increasing
+    numbers of genomes. In case of Homo sapiens, the number of sequenced genomes will
+    approach hundreds of thousands in the next few years. Simply scaling up established
+    bioinformatics pipelines will not be sufficient for leveraging the full potential
+    of such rich genomic data sets. Instead, novel, qualitatively different computational
+    methods and paradigms are needed. We will witness the rapid extension of computational
+    pan-genomics, a new sub-area of research in computational biology. In this article,
+    we generalize existing definitions and understand a pan-genome as any collection
+    of genomic sequences to be analyzed jointly or to be used as a reference. We examine
+    already available approaches to construct and use pan-genomes, discuss the potential
+    benefits of future technologies and methodologies and review open challenges from
+    the vantage point of the above-mentioned biological disciplines. As a prominent
+    example for a computational paradigm shift, we particularly highlight the transition
+    from the representation of reference genomes as strings to representations as
+    graphs. We outline how this and other challenges from different application domains
+    translate into common computational problems, point out relevant bioinformatics
+    techniques and identify open problems in computer science. With this review, we
+    aim to increase awareness that a joint approach to computational pan-genomics
+    can help address many of the problems currently faced in various domains.
+  status_changed: '2018-11-08 12:31:04'
+  title: 'Computational pan-genomics: status, promises and challenges'
+  number: 1
+  refereed: 'TRUE'
+  eprintid: 1981
+  date_type: published
+  full_text_status: none
+  id_number: doi:10.1093/bib/bbw089
+  metadata_visibility: show
+  item_issues_count: 0
+  issn: 1467-5463 (Print), 1477-4054 (Online)
+  dir: disk0/00/00/19/81
+  eprint_status: archive
+  volume: 19
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  date: '2018-01-01'
+  pagerange: 118-135
+- refereed: 'TRUE'
+  eprintid: 384
+  full_text_status: none
+  metadata_visibility: show
+  item_issues_count: 0
+  series: LNBI
+  dir: disk0/00/00/03/84
+  eprint_status: archive
+  volume: 4360
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  date: 2007
+  pagerange: 19-32
+  uri: http://publications.imp.fu-berlin.de/id/eprint/384
+  event_title: Proc. of GCCB 2006
+  lastmod: '2017-03-03 14:40:14'
+  ispublished: pub
+  datestamp: '2017-03-03 14:40:14'
+  creators:
+  - name:
+      lineage:
+      honourific:
+      given: P.
+      family: May
+  - name:
+      lineage:
+      honourific:
+      given: G. W.
+      family: Klau
+  - name:
+      lineage:
+      honourific:
+      given: M.
+      family: Bauer
+  - name:
+      family: Steinke
+      honourific:
+      given: T.
+      lineage:
+  rev_number: 3
+  type: conference_item
+  userid: 1
+  status_changed: '2009-03-11 11:27:17'
+  title: "Accelerated microRNA Precursor Detection Using the Smith-Waterman\tAlgorithm
+    on FPGAs"
+- title: "Absolute Myoglobin Quantitation in Serum by Combining Two-Dimensional\tLiquid
+    Chromatography-Electrospray Ionization Mass Spectrometry and\r\n\tNovel Data Analysis
+    Algorithms"
+  status_changed: '2009-03-11 11:27:18'
+  userid: 1
+  rev_number: 3
+  type: article
+  creators:
+  - name:
+      honourific:
+      given: B. M.
+      family: Mayr
+      lineage:
+  - name:
+      lineage:
+      given: O.
+      honourific:
+      family: Kohlbacher
+  - name:
+      family: Reinert
+      honourific:
+      given: K.
+      lineage:
+  - name:
+      lineage:
+      given: C.
+      honourific:
+      family: Gröpl
+  - name:
+      lineage:
+      family: Lange
+      honourific:
+      given: E.
+  - name:
+      lineage:
+      given: C. L.
+      honourific:
+      family: Klein
+  - name:
+      lineage:
+      given: Ch.
+      honourific:
+      family: Huber
+  publication: Journal of Proteome Research
+  datestamp: '2009-04-14 14:21:42'
+  lastmod: '2009-04-14 14:21:42'
+  ispublished: pub
+  uri: http://publications.imp.fu-berlin.de/id/eprint/385
+  date: 2006
+  pagerange: 414-421
+  subjects:
+  - G400
+  divisions:
+  - group_algbioinf
+  volume: 5
+  eprint_status: archive
+  dir: disk0/00/00/03/85
+  item_issues_count: 0
+  metadata_visibility: show
+  full_text_status: none
+  refereed: 'TRUE'
+  eprintid: 385
+- subjects:
+  - G400
+  divisions:
+  - group_algbioinf
+  date: 2007-06
+  dir: disk0/00/00/03/86
+  eprint_status: archive
+  full_text_status: none
+  metadata_visibility: show
+  item_issues_count: 0
+  refereed: 'TRUE'
+  eprintid: 386
+  type: other
+  rev_number: 3
+  userid: 1
+  status_changed: '2009-03-11 11:27:18'
+  title: "Bioinformatik: Aktuelle Proteinausstattung erlaubt Aussagen\tüber den Gesundheitszustand.
+    Software hilft Ärzten künftig\n\tbei der Diagnose."
+  datestamp: '2017-03-03 14:40:14'
+  creators:
+  - name:
+      lineage:
+      family: Meier
+      given: Ch.
+      honourific:
+  uri: http://publications.imp.fu-berlin.de/id/eprint/386
+  lastmod: '2017-03-03 14:40:14'
+  ispublished: pub
+  note: "Der Artikel eines freien Medienjournalisten beschreibt den Einsatz\tvon OpenMS
+    in der Proteomik"
+- date_type: published
+  full_text_status: none
+  metadata_visibility: show
+  id_number: 'DOI: 10.4230/DagRep.6.8.91'
+  eprintid: 2134
+  place_of_pub: Dagstuhl, Germany
+  date: 2017
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  eprint_status: archive
+  dir: disk0/00/00/21/34
+  ispublished: pub
+  lastmod: '2017-11-23 13:19:47'
+  pages: 40
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2134
+  official_url: http://drops.dagstuhl.de/opus/volltexte/2017/6839
+  abstract: Next Generation Sequencing (NGS) data have begun to appear in many applications
+    that are clinically relevant, such as resequencing of cancer patients, disease-gene
+    discovery and diagnostics for rare diseases, microbiome analyses, and gene expression
+    profiling. The analysis of sequencing data is demanding because of the enormous
+    data volume and the need for fast turnaround time, accuracy, reproducibility,
+    and data security. This Dagstuhl Seminar aimed at a free and deep exchange of
+    ideas and needs between the communities of algorithmicists and theoreticians and
+    practitioners from the biomedical field. It identified several relevant fields
+    such as data structures and algorithms for large data sets, hardware acceleration,
+    new problems in the upcoming age of genomes, etc. which were discussed in breakout
+    groups.
+  status_changed: '2017-11-23 13:19:47'
+  title: 'Dagstuhl Reports, Vol. 6, No. 8, pp. 91-130: Next Generation Sequencing
+    (Dagstuhl Seminar 16351)'
+  rev_number: 6
+  publisher: Schloss Dagstuhl--Leibniz-Zentrum fuer Informatik
+  type: monograph
+  userid: 132
+  creators:
+  - name:
+      family: Meyers
+      given: Gene
+      honourific:
+      lineage:
+  - name:
+      family: Pop
+      honourific:
+      given: Mihai
+      lineage:
+  - name:
+      lineage:
+      family: Reinert
+      given: Knut
+      honourific:
+  - name:
+      given: Tandy
+      honourific:
+      family: Warnow
+      lineage:
+  datestamp: '2017-11-23 13:19:47'
+  monograph_type: documentation
+- rev_number: 4
+  type: article
+  userid: 1
+  status_changed: '2009-03-11 11:27:19'
+  abstract: The high degree of similarity between the mouse and human genomes is demonstrated
+    through analysis of the sequence of mouse chromosome 16 (Mmu 16), which was obtained
+    as part of a whole-genome shotgun assembly of the mouse genome. The mouse genome
+    is about 10% smaller than the human genome, owing to a lower repetitive DNA content.
+    Comparison of the structure and protein-coding potential of Mmu 16 with that of
+    the homologous segments of the human genome identifies regions of conserved synteny
+    with human chromosomes (Hsa) 3, 8, 12, 16, 21, and 22. Gene content and order
+    are highly conserved between Mmu 16 and the syntenic blocks of the human genome.
+    Of the 731 predicted genes on Mmu 16, 509 align with orthologs on the corre- sponding
+    portions of the human genome, 44 are likely paralogous to these genes, and 164
+    genes have homologs elsewhere in the human genome; there are 14 genes for which
+    we could find no human counterpart.
+  title: "A Comparison of Whole-Genome Shotgun-Derived Mouse Chromosome 16\tand the
+    Human Genome"
+  datestamp: '2009-11-24 15:48:00'
+  publication: Science
+  creators:
+  - name:
+      lineage:
+      honourific:
+      given: Richard
+      family: Mural
+  - name:
+      family: Adams
+      given: M. D.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      given: K.
+      honourific:
+      family: Reinert
+  uri: http://publications.imp.fu-berlin.de/id/eprint/387
+  ispublished: pub
+  lastmod: '2009-11-24 15:49:20'
+  volume: 296
+  subjects:
+  - G400
+  divisions:
+  - group_algbioinf
+  date: 2002
+  pagerange: 1661-1671
+  dir: disk0/00/00/03/87
+  eprint_status: archive
+  full_text_status: none
+  metadata_visibility: show
+  item_issues_count: 0
+  eprintid: 387
+  refereed: 'TRUE'
+- volume: 287
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  date: 2000
+  pagerange: 2196-2203
+  dir: disk0/00/00/03/88
+  eprint_status: archive
+  full_text_status: none
+  metadata_visibility: show
+  item_issues_count: 0
+  number: 5461
+  eprintid: 388
+  refereed: 'TRUE'
+  type: article
+  rev_number: 3
+  userid: 1
+  status_changed: '2009-03-11 11:27:20'
+  title: A Whole-Genome Assembly of Drosophila
+  datestamp: '2009-04-03 12:23:26'
+  publication: Science
+  creators:
+  - name:
+      lineage:
+      given: E. W.
+      honourific:
+      family: Myers
+  - name:
+      lineage:
+      honourific:
+      given: G. G.
+      family: Sutton
+  - name:
+      given: A. L.
+      honourific:
+      family: Delcher
+      lineage:
+  - name:
+      lineage:
+      given: D. P.
+      honourific:
+      family: Dew
+  - name:
+      lineage:
+      honourific:
+      given: M. J.
+      family: Flanigan
+  - name:
+      family: Kravitz
+      given: S. A.
+      honourific:
+      lineage:
+  - name:
+      family: Mobarry
+      honourific:
+      given: C. M.
+      lineage:
+  - name:
+      family: Reinert
+      given: K.
+      honourific:
+      lineage:
+  - name:
+      honourific:
+      given: K. A.
+      family: Remington
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: E. L.
+      family: Anson
+  - name:
+      lineage:
+      family: Bolanos
+      honourific:
+      given: R.
+  - name:
+      family: Chou
+      given: H.-H.
+      honourific:
+      lineage:
+  - name:
+      honourific:
+      given: C. M.
+      family: Jordan
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: A. L.
+      family: Halpern
+  - name:
+      lineage:
+      honourific:
+      given: S.
+      family: Lonardi
+  - name:
+      honourific:
+      given: E. M.
+      family: Beasly
+      lineage:
+  - name:
+      family: Brandon
+      given: R. C.
+      honourific:
+      lineage:
+  - name:
+      honourific:
+      given: L.
+      family: Chen
+      lineage:
+  - name:
+      lineage:
+      family: Dunn
+      honourific:
+      given: P. J.
+  - name:
+      lineage:
+      given: Z.
+      honourific:
+      family: Lai
+  - name:
+      lineage:
+      honourific:
+      given: Y.
+      family: Liang
+  - name:
+      lineage:
+      family: Nusskern
+      honourific:
+      given: D. R.
+  - name:
+      lineage:
+      family: Zhan
+      honourific:
+      given: M.
+  - name:
+      lineage:
+      family: Zhang
+      honourific:
+      given: Q.
+  - name:
+      lineage:
+      honourific:
+      given: X. H.
+      family: Zheng
+  - name:
+      lineage:
+      family: Rubin
+      honourific:
+      given: G. M.
+  - name:
+      lineage:
+      family: Adams
+      given: M. D.
+      honourific:
+  - name:
+      given: J. C.
+      honourific:
+      family: Venter
+      lineage:
+  uri: http://publications.imp.fu-berlin.de/id/eprint/388
+  lastmod: '2009-04-03 12:23:26'
+  ispublished: pub
+  keywords: ASSEMBLY
+- eprintid: 1473
+  refereed: 'TRUE'
+  number: 3
+  metadata_visibility: show
+  id_number: doi:10.1074/mcp.R112.025163
+  date_type: published
+  full_text_status: none
+  item_issues_count: 0
+  dir: disk0/00/00/14/73
+  issn: 1535-9476
+  eprint_status: archive
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  volume: 12
+  pagerange: 549-556
+  date: '2013-03-01'
+  official_url: http://dx.doi.org/10.1074/mcp.R112.025163
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1473
+  ispublished: pub
+  lastmod: '2014-12-09 12:32:07'
+  publication: Molecular & Cellular Proteomics
+  datestamp: '2014-12-09 12:32:07'
+  creators:
+  - name:
+      lineage:
+      family: Nahnsen
+      honourific:
+      given: S.
+  - name:
+      lineage:
+      given: C.
+      honourific:
+      family: Bielow
+  - name:
+      given: K.
+      honourific:
+      family: Reinert
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: O.
+      family: Kohlbacher
+  userid: 132
+  rev_number: 7
+  type: article
+  title: Tools for Label-free Peptide Quantification
+  abstract: The increasing scale and complexity of quantitative proteomics studies
+    complicate subsequent analysis of the acquired data. Untargeted label-free quantification,
+    based either on feature intensities or on spectral counting, is a method that
+    scales particularly well with respect to the number of samples. It is thus an
+    excellent alternative to labeling techniques. In order to profit from this scalability,
+    however, data analysis has to cope with large amounts of data, process them automatically,
+    and do a thorough statistical analysis in order to achieve reliable results. We
+    review the state of the art with respect to computational tools for label-free
+    quantification in untargeted proteomics. The two fundamental approaches are feature-based
+    quantification, relying on the summed-up mass spectrometric intensity of peptides,
+    and spectral counting, which relies on the number of MS/MS spectra acquired for
+    a certain protein. We review the current algorithmic approaches underlying some
+    widely used software packages and briefly discuss the statistical strategies for
+    analyzing the data.
+  status_changed: '2014-12-09 12:32:07'
+- eprint_status: archive
+  issn: 0003-2700
+  dir: disk0/00/00/13/97
+  date: '2013-02-08'
+  pagerange: 3309-3317
+  volume: 85
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  number: 6
+  refereed: 'TRUE'
+  eprintid: 1397
+  item_issues_count: 0
+  full_text_status: none
+  date_type: published
+  id_number: doi 10.1021/ac303722j
+  metadata_visibility: show
+  creators:
+  - id:
+    name:
+      given: V.
+      honourific:
+      family: Neu
+      lineage:
+  - name:
+      lineage:
+      given: C.
+      honourific:
+      family: Bielow
+    id:
+  - name:
+      honourific:
+      given: I.
+      family: Gostomski
+      lineage:
+    id:
+  - name:
+      lineage:
+      family: Wintringer
+      given: R.
+      honourific:
+    id:
+  - id:
+    name:
+      lineage:
+      family: Braun
+      given: R.
+      honourific:
+  - name:
+      family: Reinert
+      honourific:
+      given: K.
+      lineage:
+    id: knut.reinert@fu-berlin.de
+  - name:
+      lineage:
+      family: Schneider
+      honourific:
+      given: P.
+    id:
+  - id:
+    name:
+      given: H.
+      honourific:
+      family: Stuppner
+      lineage:
+  - name:
+      lineage:
+      given: C.
+      honourific:
+      family: Huber
+    id:
+  publication: Analytical Chemistry
+  datestamp: '2014-03-18 14:56:17'
+  status_changed: '2014-03-18 14:56:17'
+  abstract: Rapid and efficient quality control according to the public authority
+    regulations is mandatory to guarantee safety of the pharmaceuticals and to save
+    resources in the pharmaceutical industry. In the case of so-called "grandfather
+    products" like the synthetic thyroid hormone thyroxine, strict regulations enforce
+    a detailed chemical analysis in order to characterize potentially toxic or pharmacologically
+    relevant impurities. We report a straightforward workflow for the comprehensive
+    impurity profiling of synthetic thyroid hormones and impurities employing ultrahigh-performance
+    liquid chromatography (UHPLC) hyphenated to high-resolution mass spectrometry
+    (HRMS). Five different batches of synthetic thyroxin were analyzed resulting in
+    the detection of 71 impurities within 3 min total analysis time. Structural elucidation
+    of the compounds was accomplished via a combination of accurate mass measurements,
+    computer based calculations of molecular formulas, multistage high-resolution
+    mass spectrometry (HRMS(n)), and nuclear magnetic resonance spectroscopy, which
+    enabled the identification of 71 impurities, of which 47 have been unknown so
+    far. Thirty of the latter were structurally elucidated, including products of
+    deiodination, aliphatic chain oxidation, as well as dimeric compounds as new class
+    of thyroid hormone derivatives. Limits of detection for the thyroid compounds
+    were in the 6 ng/mL range for negative electrospray ionization mass spectrometric
+    detection in full scan mode. Within day and day-to-day repeatabilities of retention
+    times and peak areas were below 0.5% and 3.5% R.SD. The performance characteristics
+    of the method in terms of robustness and information content clearly show that
+    UHPLC-HRMS is adequate for the rapid and reliable detection, identification, and
+    semiquantitative determination of trace levels of impurities in synthetic pharmaceuticals.
+  title: Rapid and Comprehensive Impurity Profiling of Synthetic Thyroxine by Ultrahigh-Performance
+    Liquid Chromatography–High-Resolution Mass Spectrometry
+  type: article
+  publisher: American Chemical Society
+  rev_number: 9
+  userid: 132
+  official_url: http://pubs.acs.org/doi/abs/10.1021/ac303722j
+  ispublished: pub
+  lastmod: '2014-03-18 14:56:17'
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1397
+- date: 2014-12
+  pagerange: 196-203
+  divisions:
+  - group_algbioinf
+  subjects:
+  - C710
+  volume: 1371
+  eprint_status: archive
+  dir: disk0/00/00/14/63
+  item_issues_count: 0
+  metadata_visibility: show
+  full_text_status: none
+  date_type: published
+  eprintid: 1463
+  refereed: 'TRUE'
+  title: Ultrahigh-performance liquid chromatography-ultraviolet absorbance detection-high-resolution-mass
+    spectrometry combined with automated data processing for studying the kinetics
+    of oxidative thermal degradation of thyroxine in the solid state
+  abstract: "Received 29 June 2014\r\nReceived in revised form\r\n29 September 2014\r\nAccepted
+    24 October 2014 Available online 30 October 2014\r\nKeywords:\r\nThyroxine\r\nUltrahigh-performance
+    liquid chromatography\r\nElectrospray ionization Orbitrap mass spectrometry\r\nKinetics\r\nDrug
+    degradation\r\nBioinformatics\r\n1. Introduction\r\nLevothyroxine (T4) is a well-known
+    and widely used drug for the treatment of hypothyroidism. The therapy is usually
+    based on substitution of the natural hormone by a long-term treatment with synthetic
+    levothyroxine [1]. It is a narrow therapeutic index drug, for which individual
+    dosage levels of patients need to be established over several weeks. Consequently,
+    products differing in content of levothyroxine due to compound instability or
+    problems in formu- lation can lead to wrong medication and potentially cause severe
+    health problems [2,3].\r\n∗ Corresponding author. Tel.:+43 0 662 8044 5704; fax:
+    +43 0 662 8044 5751. E-mail addresses: volker.a.neu@basf.com (V. Neu), chris.bielow@fu-berlin.de
+    (C. Bielow), reinert@inf.fu-berlin.de (K. Reinert), c.huber@sbg.ac.at (C.G. Huber).\r\nhttp://dx.doi.org/10.1016/j.chroma.2014.10.071\r\n0021-9673/©
+    2014 Elsevier B.V. All rights reserved.\r\nabstract\r\nLevothyroxine as active
+    pharmaceutical ingredient of formulations used for the treatment of hypothy- roidism
+    is distributed worldwide and taken by millions of people. An important issue in
+    terms of compound stability is its capability to react with ambient oxygen, especially
+    in case of long term com- pound storage at elevated temperature. In this study
+    we demonstrate that ultrahigh-performance liquid chromatography coupled to UV
+    spectrometry and high-resolution mass spectrometry (UHPLC-UV-HRMS) represent very
+    useful approaches to investigate the influence of ambient oxygen on the degradation
+    kinet- ics of levothyroxine in the solid state at enhanced degradation conditions.
+    Moreover, the impurity pattern of oxidative degradation of levothyroxine is elucidated
+    and classified with respect to degradation kinetics at different oxygen levels.
+    Kinetic analysis of thyroxine bulk material at 100 ◦ C reveals bi-phasic degra-
+    dation kinetics with a distinct change in degradation phases dependent on the
+    availability of oxygen. The results clearly show that contact of the bulk material
+    to ambient oxygen is a key factor for fast compound degradation. Furthermore,
+    the combination of time-resolved HRMS data and automated data processing is shown
+    to allow insights into the kinetics and mechanism of impurity formation on individual
+    com- pound basis. By comparing degradation profiles, four main classes of profiles
+    linked to reaction pathways of thyroxine degradation were identifiable. Finally,
+    we show the capability of automated data process- ing for the matching of different
+    stressing conditions, in order to extract information about mechanistic similarities.
+    As a result, degradation kinetics is influenced by factors like availability of
+    oxygen, stressing time, or stressing temperature, while the degradation mechanisms
+    appear to be conserved."
+  status_changed: '2016-11-15 14:03:10'
+  userid: 29
+  type: article
+  rev_number: 12
+  creators:
+  - name:
+      family: Neu
+      given: V.
+      honourific:
+      lineage:
+  - name:
+      family: Bielow
+      given: C.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: K.
+      family: Reinert
+  - name:
+      family: Huber
+      honourific:
+      given: C. G.
+      lineage:
+  datestamp: '2014-11-19 15:15:57'
+  publication: Journal of chromatography A
+  lastmod: '2016-11-15 14:03:10'
+  ispublished: pub
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1463
+  official_url: http://linkinghub.elsevier.com/retrieve/pii/S0021967314016823
+- metadata_visibility: show
+  id_number: 'doi: 10.1021/ac303404e'
+  date_type: published
+  full_text_status: none
+  item_issues_count: 0
+  refereed: 'TRUE'
+  eprintid: 1398
+  number: 4
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  volume: 85
+  pagerange: 2385-2390
+  date: '2013-01-12'
+  dir: disk0/00/00/13/98
+  issn: 0003-2700
+  eprint_status: archive
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1398
+  ispublished: pub
+  lastmod: '2014-03-18 15:10:11'
+  official_url: http://pubs.acs.org/doi/abs/10.1021/ac303404e
+  userid: 132
+  publisher: American Chemical Society
+  rev_number: 7
+  type: article
+  title: 'Investigation of Reaction Mechanisms of Drug Degradation in the Solid State:
+    A Kinetic Study Implementing Ultrahigh-Performance Liquid Chromatography and High-Resolution
+    Mass Spectrometry for Thermally Stressed Thyroxine'
+  status_changed: '2014-03-18 15:10:11'
+  abstract: A reaction scheme was derived for the thermal degradation of thyroxine
+    in the solid state, using data obtained from ultrahigh-performance liquid chromatography
+    and high-resolution mass spectrometry (UHPLC-HRMS). To study the reaction mechanism
+    and kinetics of the thermal degradation of the pharmaceutical in the solid state,
+    a workflow was developed by generating compound-specific, time-dependent degradation
+    or formation curves of at least 13 different degradation products. Such curves
+    allowed one to distinguish between first- and second-generation degradation products,
+    as well as impurities resulting from chemical synthesis. The structures of the
+    degradation products were derived from accurate molecular masses and multistage
+    mass spectrometry. Deiodination and oxidative side chain degradation were found
+    to be the major degradation reactions, resulting in the formation of deiodinated
+    thyroxines, as well as acetic acid, benzoic acid, formaldehyde, acetamide, hydroxyacetic
+    acid, oxoacetic acid, hydroxyacetamide, or oxoacetamide derivatives of thyroxine
+    or deiodinated thyroxine. Upon additional structural verification of mass spectrometric
+    data using nuclear magnetic resonance spectroscopy, this comprehensive body of
+    data sheds light on an elaborate, radical-driven reaction scheme, explaining the
+    presence or formation of impurities in thermally stressed thyroxine.
+  publication: Analytical Chemistry
+  datestamp: '2014-03-18 15:10:11'
+  creators:
+  - id:
+    name:
+      lineage:
+      family: Neu
+      honourific:
+      given: V.
+  - name:
+      lineage:
+      given: C.
+      honourific:
+      family: Bielow
+    id:
+  - id:
+    name:
+      lineage:
+      honourific:
+      given: P.
+      family: Schneider
+  - name:
+      honourific:
+      given: K.
+      family: Reinert
+      lineage:
+    id: knut.reinert@fu-berlin.de
+  - name:
+      lineage:
+      family: Stuppner
+      given: H.
+      honourific:
+    id:
+  - id:
+    name:
+      family: Huber
+      honourific:
+      given: C.
+      lineage:
+- full_text_status: none
+  date_type: published
+  metadata_visibility: show
+  id_number: doi:10.1016/j.jbiotec.2017.05.016
+  eprintid: 2116
+  refereed: 'TRUE'
   volume: 261
-  pages: 157-168
-  doi: 10.1016/j.jbiotec.2017.07.017
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  date: '2017-11-10'
+  pagerange: 142-148
+  issn: 1681656
+  dir: disk0/00/00/21/16
+  eprint_status: archive
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2116
+  ispublished: pub
+  lastmod: '2017-10-12 12:05:59'
+  official_url: http://doi.org/10.1016/j.jbiotec.2017.05.016
+  publisher: ELSEVIER
+  type: article
+  rev_number: 5
+  userid: 132
+  abstract: "Background\r\n\r\nIn recent years, several mass spectrometry-based omics
+    technologies emerged to investigate qualitative and quantitative changes within
+    thousands of biologically active components such as proteins, lipids and metabolites.
+    The research enabled through these methods potentially contributes to the diagnosis
+    and pathophysiology of human diseases as well as to the clarification of structures
+    and interactions between biomolecules. Simultaneously, technological advances
+    in the field of mass spectrometry leading to an ever increasing amount of data,
+    demand high standards in efficiency, accuracy and reproducibility of potential
+    analysis software.\r\n\r\nResults\r\n\r\nThis article presents the current state
+    and ongoing developments in OpenMS, a versatile open-source framework aimed at
+    enabling reproducible analyses of high-throughput mass spectrometry data. It provides
+    implementations of frequently occurring processing operations on MS data through
+    a clean application programming interface in C++ and Python. A collection of 185
+    tools and ready-made workflows for typical MS-based experiments enable convenient
+    analyses for non-developers and facilitate reproducible research without losing
+    flexibility.\r\n\r\nConclusions\r\n\r\nOpenMS will continue to increase its ease
+    of use for developers as well as users with improved continuous integration/deployment
+    strategies, regular trainings with updated training materials and multiple sources
+    of support. The active developer community ensures the incorporation of new features
+    to support state of the art research."
+  status_changed: '2017-10-12 12:05:59'
+  title: OpenMS – A platform for reproducible analysis of mass spectrometry data
+  datestamp: '2017-10-12 12:05:59'
+  publication: Journal of Biotechnology
+  creators:
+  - name:
+      lineage:
+      honourific:
+      given: Julianus
+      family: Pfeuffer
+  - name:
+      family: Sachsenberg
+      given: Timo
+      honourific:
+      lineage:
+  - name:
+      family: Alka
+      honourific:
+      given: Oliver
+      lineage:
+  - name:
+      lineage:
+      given: Mathias
+      honourific:
+      family: Walzer
+  - name:
+      given: Alexander
+      honourific:
+      family: Fillbrunn
+      lineage:
+  - name:
+      lineage:
+      family: Nilse
+      given: Lars
+      honourific:
+  - name:
+      given: Oliver
+      honourific:
+      family: Schilling
+      lineage:
+  - name:
+      given: Knut
+      honourific:
+      family: Reinert
+      lineage:
+  - name:
+      lineage:
+      family: Kohlbacher
+      given: Oliver
+      honourific:
+- number: 3
+  refereed: 'TRUE'
+  eprintid: 2429
+  date_type: published
+  full_text_status: none
+  id_number: doi:10.1021/acs.jproteome.9b00566
+  metadata_visibility: show
+  eprint_status: archive
+  issn: 1535-3893
+  dir: disk0/00/00/24/29
+  date: '2020-01-24'
+  pagerange: 1060-1072
+  volume: 19
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  official_url: http://doi.org/10.1021/acs.jproteome.9b00566
+  keywords: bottom-up proteomics, protein inference, Bayesian networks, convolution
+    trees, loopy belief propagation, iPRG2016
+  lastmod: '2020-04-02 10:05:57'
+  ispublished: pub
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2429
+  creators:
+  - name:
+      lineage:
+      given: Julianus
+      honourific:
+      family: Pfeuffer
+  - name:
+      lineage:
+      family: Sachsenberg
+      given: Timo
+      honourific:
+  - name:
+      lineage:
+      given: Tjeerd M. H.
+      honourific:
+      family: Dijkstra
+  - name:
+      family: Serang
+      given: Oliver
+      honourific:
+      lineage:
+  - name:
+      given: Knut
+      honourific:
+      family: Reinert
+      lineage:
+  - name:
+      family: Kohlbacher
+      given: Oliver
+      honourific:
+      lineage:
+  datestamp: '2020-04-02 10:05:57'
+  publication: Journal of Proteome Research
+  status_changed: '2020-04-02 10:05:57'
+  abstract: Accurate protein inference in the presence of shared peptides is still
+    one of the key problems in bottom-up proteomics. Most protein inference tools
+    employing simple heuristic inference strategies are efficient but exhibit reduced
+    accuracy. More advanced probabilistic methods often exhibit better inference quality
+    but tend to be too slow for large data sets. Here, we present a novel protein
+    inference method, EPIFANY, combining a loopy belief propagation algorithm with
+    convolution trees for efficient processing of Bayesian networks. We demonstrate
+    that EPIFANY combines the reliable protein inference of Bayesian methods with
+    significantly shorter runtimes. On the 2016 iPRG protein inference benchmark data,
+    EPIFANY is the only tested method that finds all true-positive proteins at a 5%
+    protein false discovery rate (FDR) without strict prefiltering on the peptide-spectrum
+    match (PSM) level, yielding an increase in identification performance (+10% in
+    the number of true positives and +14% in partial AUC) compared to previous approaches.
+    Even very large data sets with hundreds of thousands of spectra (which are intractable
+    with other Bayesian and some non-Bayesian tools) can be processed with EPIFANY
+    within minutes. The increased inference quality including shared peptides results
+    in better protein inference results and thus increased robustness of the biological
+    hypotheses generated. EPIFANY is available as open-source software for all major
+    platforms at https://OpenMS.de/epifany.
+  title: 'EPIFANY: A Method for Efficient High-Confidence Protein Inference'
+  publisher: ACS Publications
+  rev_number: 5
+  type: article
+  userid: 132
+- divisions:
+  - group_algbioinf
+  volume: 10229
+  pagerange: 190-206
+  dir: disk0/00/00/21/18
+  issn: 0302-9743
+  eprint_status: archive
+  metadata_visibility: show
+  id_number: doi:10.1007/978-3-319-56970-3_12
+  date_type: published
+  rev_number: 6
+  publisher: Springer, Cham
+  status_changed: '2017-10-12 12:37:21'
+  editors:
+  - name:
+      lineage:
+      family: Sahinalp
+      honourific:
+      given: S.
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2118
+  pages: 16
+  ispublished: pub
+  lastmod: '2017-10-12 12:37:21'
+  official_url: http://doi.org/10.1007/978-3-319-56970-3_12
+  subjects:
+  - G400
+  date: '2017-04-12'
+  full_text_status: none
+  series: Lecture Notes in Computer Science (LNCS)
+  refereed: 'TRUE'
+  eprintid: 2118
+  userid: 132
+  type: book_section
+  title: 'EPR-Dictionaries: A Practical and Fast Data Structure for Constant Time
+    Searches in Unidirectional and Bidirectional FM Indices'
+  abstract: "The unidirectional FM index was introduced by Ferragina and Manzini in
+    2000 and allows to search a pattern in the index in one direction. The bidirectional
+    FM index (2FM) was introduced by Lam et al. in 2009. It allows to search for a
+    pattern by extending an infix of the pattern arbitrarily to the left or right.
+    If σ is the size of the alphabet then the method of Lam et al. can conduct one
+    step in time O(σ) while needing space O(σ⋅n) using constant time rank queries
+    on bit vectors. Schnattinger and colleagues improved this time to O(logσ) while
+    using O(logσ⋅n) bits of space for both, the FM and 2FM index. This is achieved
+    by the use of binary wavelet trees.\r\n\r\nIn this paper we introduce a new, practical
+    method for conducting an exact search in a uni- and bidirectional FM index in
+    O(1) time per step while using O(logσ⋅n)+o(logσ⋅σ⋅n) \r\nbits of space. This is
+    done by replacing the binary wavelet tree by a new data structure, the Enhanced
+    Prefixsum Rank dictionary (EPR-dictionary).\r\n\r\nWe implemented this method
+    in the SeqAn C++ library and experimentally validated our theoretical results.
+    In addition we compared our implementation with other freely available implementations
+    of bidirectional indices and show that we are between ≈2.2−4.2 times faster. This
+    will have a large impact for many bioinformatics applications that rely on practical
+    implementations of (2)FM indices e.g. for read mapping. To our knowledge this
+    is the first implementation of a constant time method for a search step in 2FM
+    indices."
+  datestamp: '2017-10-12 12:37:21'
+  creators:
+  - name:
+      given: Christopher
+      honourific:
+      family: Pockrandt
+      lineage:
+  - name:
+      given: Marcel
+      honourific:
+      family: Ehrhardt
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: Knut
+      family: Reinert
+  isbn: 978-3-319-56970-3 (elektronisch)
+  book_title: Research in Computational Molecular Biology. RECOMB 2017
+- datestamp: '2014-08-25 18:46:21'
+  publication: Bioinformatics
+  creators:
+  - name:
+      honourific:
+      given: R.
+      family: Rahn
+      lineage:
+  - name:
+      given: D.
+      honourific:
+      family: Weese
+      lineage:
+  - name:
+      given: K.
+      honourific:
+      family: Reinert
+      lineage:
+  type: article
+  rev_number: 8
+  userid: 132
+  abstract: "Motivation: Next-generation sequencing (NGS) has revolutionized biomedical
+    research in the past decade and led to a continuous stream of developments in
+    bioinformatics, addressing the need for fast and space-efficient solutions for
+    analyzing NGS data. Often researchers need to analyze a set of genomic sequences
+    that stem from closely related species or are indeed individuals of the same species.
+    Hence, the analyzed sequences are similar. For analyses where local changes in
+    the examined sequence induce only local changes in the results, it is obviously
+    desirable to examine identical or similar regions not repeatedly.\r\n\r\nResults:
+    In this work, we provide a datatype that exploits data parallelism inherent in
+    a set of similar sequences by analyzing shared regions only once. In real-world
+    experiments, we show that algorithms that otherwise would scan each reference
+    sequentially can be speeded up by a factor of 115.\r\n\r\nAvailability: The data
+    structure and associated tools are publicly available at http://www.seqan.de/projects/jst
+    and are part of SeqAn, the C++ template library for sequence analysis.\r\n\r\nContact:
+    rene.rahn@fu-berlin.de"
+  status_changed: '2014-08-25 18:46:21'
+  title: Journaled string tree--a scalable data structure for analyzing thousands
+    of similar genomes on your laptop
+  official_url: http://dx.doi.org/10.1093/bioinformatics/btu438
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1448
+  ispublished: pub
+  lastmod: '2014-08-25 18:46:21'
+  issn: Online ISSN 1460-2059 - Print ISSN 1367-4803
+  dir: disk0/00/00/14/48
+  eprint_status: archive
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  date: '2014-07-15'
+  eprintid: 1448
+  refereed: 'TRUE'
+  date_type: published
+  full_text_status: none
+  metadata_visibility: show
+  id_number: doi:10.1093/bioinformatics/btu438
+  item_issues_count: 0
+- official_url: http://doi.org/10.1093/bioinformatics/bty380
+  lastmod: '2018-11-13 13:43:57'
+  ispublished: pub
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2253
+  creators:
+  - name:
+      family: Rahn
+      given: René
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      family: Budach
+      honourific:
+      given: Stefan
+  - name:
+      family: Costanza
+      honourific:
+      given: Pascal
+      lineage:
+  - name:
+      lineage:
+      given: Marcel
+      honourific:
+      family: Ehrhardt
+  - name:
+      lineage:
+      honourific:
+      given: Jonny
+      family: Hancox
+  - name:
+      lineage:
+      family: Reinert
+      given: Knut
+      honourific:
+  datestamp: '2018-05-31 11:28:35'
+  publication: Bioinformatics
+  title: Generic accelerated sequence alignment in SeqAn using vectorization and multi-threading
+  abstract: "Motivation\r\n\r\nPairwise sequence alignment is undoubtedly a central
+    tool in many bioinformatics analyses. In this paper, we present a generically
+    accelerated module for pairwise sequence lignments applicable for a broad range
+    of applications. In our module, we unified the standard dynamic programming kernel
+    used for pairwise sequence alignments and extended it with a generalized inter-sequence
+    vectorization layout, such that many alignments can be computed simultaneously
+    by exploiting SIMD (Single Instruction Multiple Data) instructions of modern processors.
+    We then extended the module by adding two layers of thread-level parallelization,
+    where we a) distribute many independent alignments on multiple threads and b)
+    inherently parallelize a single alignment computation using a work stealing approach
+    producing a dynamic wavefront progressing along the minor diagonal.\r\n\r\nResults\r\n\r\nWe
+    evaluated our alignment vectorization and parallelization on different processors,
+    including the newest Intel® Xeon® (Skylake) and Intel® Xeon Phi™ (KNL) processors,
+    and use cases. The instruction set AVX512-BW (Byte and Word), available on Skylake
+    processors, can genuinely improve the performance of vectorized alignments. We
+    could run single alignments 1600 times faster on the Xeon Phi™ and 1400 times
+    faster on the Xeon® than executing them with our previous sequential alignment
+    module.\r\n\r\nAvailability\r\n\r\nThe module is programmed in C++ using the SeqAn
+    (Reinert et al., 2017) library and distributed with version 2.4. under the BSD
+    license. We support SSE4, AVX2, AVX512 instructions and included UME::SIMD, a
+    SIMD-instruction wrapper library, to extend our module for further instruction
+    sets. We thoroughly test all alignment components with all major C++ compilers
+    on various platforms."
+  status_changed: '2018-11-13 13:43:57'
+  userid: 132
+  type: article
+  publisher: Oxford Academic (OUP)
+  rev_number: 8
+  refereed: 'TRUE'
+  eprintid: 2253
+  number: 20
+  id_number: doi:10.1093/bioinformatics/bty380
+  metadata_visibility: show
+  date_type: published
+  full_text_status: none
+  eprint_status: archive
+  dir: disk0/00/00/22/53
+  issn: 1367-4803
+  pagerange: 3437-3445
+  date: '2018-10-15'
+  subjects:
+  - G400
+  divisions:
+  - group_algbioinf
+  volume: 34
+- userid: 1
+  type: article
+  rev_number: 3
+  title: Robust consensus computation
+  status_changed: '2009-03-11 11:27:21'
+  publication: BMC Bioinformatics
+  datestamp: '2010-09-01 13:10:01'
+  creators:
+  - name:
+      lineage:
+      family: Rausch
+      honourific:
+      given: T.
+  - name:
+      lineage:
+      family: Emde
+      given: A.-K.
+      honourific:
+  - name:
+      family: Reinert
+      given: K.
+      honourific:
+      lineage:
+  uri: http://publications.imp.fu-berlin.de/id/eprint/390
+  lastmod: '2010-09-01 13:10:01'
+  ispublished: pub
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  volume: 9
+  pagerange: P4
+  date: 2008
+  dir: disk0/00/00/03/90
+  eprint_status: archive
+  metadata_visibility: show
+  full_text_status: none
+  item_issues_count: 0
+  refereed: 'TRUE'
+  eprintid: 390
+  number: Suppl 10
+- ispublished: pub
+  lastmod: '2010-11-18 14:19:41'
+  pages: 347
+  book_title: Problem Solving Handbook in Computational Biology and Bioinformatics
+  uri: http://publications.imp.fu-berlin.de/id/eprint/393
+  isbn: 978-0-387-09759-6
+  official_url: http://www.springer.com/computer/bioinformatics/book/978-0-387-09759-6
+  status_changed: '2010-02-04 14:02:02'
+  editors:
+  - name:
+      given: L. S.
+      honourific:
+      family: Heath
+      lineage:
+  - name:
+      lineage:
+      family: Ramakrishnan
+      honourific:
+      given: N.
+  abstract: Abstract Multiple sequence alignment as a means of comparing DNA, RNA
+    or amino acid sequences is an essential precondition for various analyses, including
+    structure prediction, modeling binding sites, phylogeny or function prediction.
+    This range of applications implies a demand for versatile, flexible and specialized
+    meth- ods to compute accurate alignments. This chapter summarizes the key algorithmic
+    insights gained in the past years to facilitate both, an easy understanding of
+    the current multiple sequence alignment literature and to enable the readers to
+    use and apply current tools in their own everyday research.
+  title: Practical multiple Sequence alignment
+  publisher: Springer Science+Business Media
+  rev_number: 8
+  type: book_section
+  userid: 1
+  creators:
+  - name:
+      lineage:
+      given: T.
+      honourific:
+      family: Rausch
+  - name:
+      lineage:
+      honourific:
+      given: K.
+      family: Reinert
+  datestamp: '2009-11-24 15:20:29'
+  related_url:
+  - url: http://www.springerlink.com/content/978-0-387-09759-6#section=798327&page=1&locus=0
+  item_issues_count: 0
+  date_type: published
+  full_text_status: none
+  id_number: DOI 10.1007/978-0-387-09760-2
+  metadata_visibility: show
+  eprintid: 393
+  refereed: 'TRUE'
+  pagerange: 21-43
+  date: 2011
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  eprint_status: archive
+  dir: disk0/00/00/03/93
+- eprint_status: archive
+  dir: disk0/00/00/03/89
+  date: 2006-09
+  subjects:
+  - G400
+  divisions:
+  - group_algbioinf
+  institution: "Hasso-Plattner-Institut für Softwaresystemtechnik GmbH, Universität\tPotsdam"
+  refereed: 'TRUE'
+  eprintid: 389
+  item_issues_count: 0
+  full_text_status: none
+  metadata_visibility: show
+  creators:
+  - name:
+      lineage:
+      family: Rausch
+      honourific:
+      given: T.
+  datestamp: '2017-03-03 14:40:14'
+  thesis_type: masters
+  status_changed: '2009-03-11 11:27:20'
+  title: Discovering causes of multifactorial diseases
+  rev_number: 3
+  type: thesis
+  userid: 1
+  ispublished: unpub
+  lastmod: '2017-03-03 14:40:14'
+  uri: http://publications.imp.fu-berlin.de/id/eprint/389
+- date: 2008-07
+  pagerange: 826-836
+  volume: 38
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  eprint_status: archive
+  dir: disk0/00/00/03/94
+  item_issues_count: 0
+  full_text_status: none
+  metadata_visibility: show
+  eprintid: 394
+  refereed: 'TRUE'
+  abstract: "This paper describes a novel algorithm to analyze genetic linkage\tdata
+    using pattern recognition techniques and genetic algorithms\n\t(GA). The method
+    allows a search for regions of the chromosome that\n\tmay contain genetic variations
+    that jointly predispose individuals\n\tfor a particular disease. The method uses
+    correlation analysis, filtering\n\ttheory and genetic algorithms to achieve this
+    goal. Because current\n\tgenome scans use from hundreds to hundreds of thousands
+    of markers,\n\ttwo versions of the method have been implemented. The first is
+    an\n\texhaustive analysis version that can be used to visualize, explore,\n\tand
+    analyze small genetic data sets for two marker correlations;\n\tthe second is
+    a GA version, which uses a parallel implementation\n\tallowing searches of higher-order
+    correlations in large data sets.\n\tResults on simulated data sets indicate that
+    the method can be informative\n\tin the identification of major disease loci and
+    geneâ\x80\x93gene interactions\n\tin genome-wide linkage data and that further
+    exploration of these\n\ttechniques is justified. The results presented for both
+    variants\n\tof the method show that it can help genetic epidemiologists to identify\n\tpromising
+    combinations of genetic factors that might predispose to\n\tcomplex disorders.
+    In particular, the correlation analysis of IBD\n\texpression patterns might hint
+    to possible geneâ\x80\x93gene interactions\n\tand the filtering might be a fruitful
+    approach to distinguish true\n\tcorrelation signals from noise."
+  status_changed: '2009-03-11 11:27:23'
+  title: "A parallel genetic algorithm to discover patterns in genetic markers\tthat
+    indicate predisposition to multifactorial disease"
+  type: article
+  rev_number: 3
+  userid: 1
+  creators:
+  - name:
+      lineage:
+      family: Rausch
+      given: T.
+      honourific:
+  - name:
+      honourific:
+      given: A.
+      family: Thomas
+      lineage:
+  - name:
+      honourific:
+      given: N. J.
+      family: Camp
+      lineage:
+  - name:
+      family: Facelli
+      honourific:
+      given: L. A.
+      lineage:
+  datestamp: '2017-03-03 14:40:15'
+  publication: Comput. Biol. Med.
+  ispublished: pub
+  lastmod: '2017-03-03 14:40:15'
+  uri: http://publications.imp.fu-berlin.de/id/eprint/394
+  official_url: http://www.ncbi.nlm.nih.gov/pubmed/18547558
+- title: Segment-based multiple sequence alignment
+  status_changed: '2009-03-11 11:27:21'
+  abstract: "Motivation: Many multiple sequence alignment tools have been developed\tin
+    the past, progressing either in speed or alignment accuracy. Given\r\n\tthe importance
+    and wide-spread use of alignment tools, progress in\r\n\tboth categories is a
+    contribution to the community and has driven\r\n\tresearch in the field so far.
+    Results: We introduce a graph-based\r\n\textension to the consistency-based, progressive
+    alignment strategy.\r\n\tWe apply the consistency notion to segments instead of
+    single characters.\r\n\tThe main problem we solve in this context is to define
+    segments of\r\n\tthe sequences in such a way that a graph-based alignment is possible.\r\n\tWe
+    implemented the algorithm using the SeqAn library and report results\r\n\ton amino
+    acid and DNA sequences. The benefit of our approach is threefold:\r\n\t(1) sequences
+    with conserved blocks can be rapidly aligned, (2) the\r\n\timplementation is conceptually
+    easy, generic and fast and (3) the\r\n\tconsistency idea can be extended to align
+    multiple genomic sequences.\r\n\tAvailability: The segment-based multiple sequence
+    alignment tool\r\n\tcan be downloaded from http://www.seqan.de/projects/msa.html.
+    A novel\r\n\tversion of T-Coffee interfaced with the tool is available from http://www.tcoffee.org.\r\n\tThe
+    usage of the tool is described in both documentations. Contact:\r\n\trausch@inf.fu-berlin.de"
+  userid: 1
+  rev_number: 7
+  type: article
+  creators:
+  - name:
+      family: Rausch
+      honourific:
+      given: T.
+      lineage:
+  - name:
+      family: Emde
+      honourific:
+      given: A.-K.
+      lineage:
+  - name:
+      family: Weese
+      honourific:
+      given: D.
+      lineage:
+  - name:
+      family: Notredame
+      honourific:
+      given: C.
+      lineage:
+  - name:
+      family: Reinert
+      given: K.
+      honourific:
+      lineage:
+  documents:
+  - format: application/pdf
+    uri: http://publications.imp.fu-berlin.de/id/document/181
+    main: Bioinformatics_2008_RauschSegment-based_multiple_sequence_alignment.pdf
+    docid: 181
+    mime_type: application/pdf
+    pos: 1
+    eprintid: 391
+    security: public
+    rev_number: 3
+    relation:
+    - type: http://eprints.org/relation/haspreviewThumbnailVersion
+      uri: "/id/document/1005"
+    - type: http://eprints.org/relation/hasVolatileVersion
+      uri: "/id/document/1005"
+    - type: http://eprints.org/relation/hasVersion
+      uri: "/id/document/1005"
+    language: en
+    files:
+    - datasetid: document
+      mtime: '2017-03-03 14:40:15'
+      fileid: 5101
+      filename: Bioinformatics_2008_RauschSegment-based_multiple_sequence_alignment.pdf
+      objectid: 181
+      mime_type: application/pdf
+      uri: http://publications.imp.fu-berlin.de/id/file/5101
+      filesize: 212460
+  publication: Bioinformatics
+  datestamp: '2009-04-03 20:10:51'
+  lastmod: '2017-03-03 14:40:15'
+  ispublished: pub
+  uri: http://publications.imp.fu-berlin.de/id/eprint/391
+  official_url: http://bioinformatics.oxfordjournals.org/cgi/content/abstract/24/16/i187
+  date: 2008
+  pagerange: i187-192
+  subjects:
+  - G400
+  divisions:
+  - group_algbioinf
+  volume: 24
+  eprint_status: archive
+  dir: disk0/00/00/03/91
+  item_issues_count: 0
+  metadata_visibility: show
+  full_text_status: public
+  refereed: 'TRUE'
+  eprintid: 391
+  number: 16
+- rev_number: 25
+  publisher: Oxford University Press
+  type: article
+  userid: 1
+  abstract: 'Motivation: Novel high-throughput sequencing technologies pose new algorithmic
+    challenges in handling massive amounts of short- read, high-coverage data. A robust
+    and versatile consensus tool is of particular interest for such data since a sound
+    multi-read alignment is a prerequisite for variation analyses, accurate genome
+    assemblies and insert sequencing. Results: A multi-read alignment algorithm for
+    de novo or reference- guided genome assembly is presented. The program identifies
+    segments shared by multiple reads and then aligns these segments using a consistency-enhanced
+    alignment graph. On real de novo sequencing data obtained from the newly established
+    NCBI Short Read Archive, the program performs similarly in quality to other comparable
+    programs. On more challenging simulated datasets for insert sequencing and variation
+    analyses, our program outperforms the other tools. Availability: The consensus
+    program can be downloaded from http://www.seqan.de/projects/consensus.html. It
+    can be used stand- alone or in conjunction with the Celera Assembler. Both application
+    scenarios as well as the usage of the tool are described in the documentation.
+    Contact: rausch@inf.fu-berlin.de'
+  status_changed: '2010-02-04 14:00:19'
+  title: "A consistency-based consensus algorithm for de novo and reference-guided\tsequence
+    assembly of short reads"
+  publication: Bioinformatics
+  datestamp: '2009-04-14 13:41:05'
+  documents:
+  - relation:
+    - uri: "/id/document/1006"
+      type: http://eprints.org/relation/haspreviewThumbnailVersion
+    - type: http://eprints.org/relation/hasVolatileVersion
+      uri: "/id/document/1006"
+    - uri: "/id/document/1006"
+      type: http://eprints.org/relation/hasVersion
+    language: en
+    files:
+    - objectid: 235
+      filename: Bioinformatics_2009_RauschA_Consistency-based_Consensus_Algorithm_for.pdf
+      fileid: 5137
+      mtime: '2017-03-03 14:40:15'
+      datasetid: document
+      filesize: 285683
+      mime_type: application/pdf
+      uri: http://publications.imp.fu-berlin.de/id/file/5137
+    rev_number: 4
+    pos: 1
+    eprintid: 392
+    security: public
+    format: application/pdf
+    docid: 235
+    uri: http://publications.imp.fu-berlin.de/id/document/235
+    main: Bioinformatics_2009_RauschA_Consistency-based_Consensus_Algorithm_for.pdf
+    mime_type: application/pdf
+    content: published
+  creators:
+  - name:
+      lineage:
+      given: T.
+      honourific:
+      family: Rausch
+  - name:
+      family: Koren
+      honourific:
+      given: S.
+      lineage:
+  - name:
+      honourific:
+      given: G.
+      family: Denisov
+      lineage:
+  - name:
+      family: Weese
+      honourific:
+      given: D.
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: A.-K.
+      family: Emde
+  - name:
+      given: A.
+      honourific:
+      family: Döring
+      lineage:
+  - name:
+      family: Reinert
+      honourific:
+      given: K.
+      lineage:
+  uri: http://publications.imp.fu-berlin.de/id/eprint/392
+  lastmod: '2017-03-03 14:40:15'
+  ispublished: pub
+  volume: 25
+  subjects:
+  - G400
+  divisions:
+  - group_algbioinf
+  date: 2009
+  pagerange: 1118-1124
+  dir: disk0/00/00/03/92
+  eprint_status: archive
+  date_type: published
+  full_text_status: public
+  metadata_visibility: show
+  id_number: doi:10.1093/bioinformatics/btp131
+  item_issues_count: 0
+  number: 9
+  eprintid: 392
+  refereed: 'TRUE'
+- rev_number: 4
+  type: conference_item
+  userid: 1
+  status_changed: '2009-03-11 11:27:24'
+  title: "A general paradigm for fast and adaptive clustering of biological\tsequences"
+  datestamp: '2009-04-14 13:45:54'
+  creators:
+  - name:
+      honourific:
+      given: K.
+      family: Reinert
+      lineage:
+  - name:
+      lineage:
+      given: M.
+      honourific:
+      family: Bauer
+  - name:
+      family: Döring
+      given: A.
+      honourific:
+      lineage:
+  - name:
+      given: A. L.
+      honourific:
+      family: Halpern
+      lineage:
+  event_title: German Conference on Bioinformatics (GCB 2007)
+  uri: http://publications.imp.fu-berlin.de/id/eprint/395
+  ispublished: pub
+  lastmod: '2009-04-14 13:47:53'
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  pagerange: 15-29
+  date: 2007
+  dir: disk0/00/00/03/95
+  eprint_status: archive
+  full_text_status: none
+  metadata_visibility: show
+  item_issues_count: 0
+  eprintid: 395
+  refereed: 'TRUE'
+- full_text_status: none
+  metadata_visibility: show
+  item_issues_count: 0
+  series: Dagstuhl Seminar Proceedings
+  number: 5471
+  refereed: 'TRUE'
+  eprintid: 397
+  subjects:
+  - G400
+  divisions:
+  - group_algbioinf
+  date: 2006
+  dir: disk0/00/00/03/97
+  eprint_status: archive
+  uri: http://publications.imp.fu-berlin.de/id/eprint/397
+  event_title: Computational Proteomics
+  ispublished: pub
+  lastmod: '2009-04-14 14:22:33'
+  note: "<span class='mathrm'>&lt;</span>http://drops.dagstuhl.de/opus/volltexte/2006/546<span
+    class='mathrm'>&gt;</span> [date of citation:\t2006-01-01]"
+  rev_number: 3
+  publisher: "Internationales Begegnungs- und Forschungszentrum fÃ¼r Informatik\t(IBFI),
+    Schloss Dagstuhl, Germany"
+  type: conference_item
+  userid: 1
+  status_changed: '2009-03-11 11:27:25'
+  editors:
+  - name:
+      given: C. G.
+      honourific:
+      family: Huber
+      lineage:
+  - name:
+      given: O.
+      honourific:
+      family: Kohlbacher
+      lineage:
+  - name:
+      given: K.
+      honourific:
+      family: Reinert
+      lineage:
+  title: OpenMS - A Framework for Quantitative HPLC/MS-Based Proteomics
+  datestamp: '2009-04-14 14:22:33'
+  creators:
+  - name:
+      honourific:
+      given: K.
+      family: Reinert
+      lineage:
+  - name:
+      lineage:
+      family: Kohlbacher
+      honourific:
+      given: O.
+  - name:
+      family: Gröpl
+      honourific:
+      given: C.
+      lineage:
+  - name:
+      lineage:
+      family: Lange
+      given: E.
+      honourific:
+  - name:
+      given: O.
+      honourific:
+      family: Schulz-Trieglaff
+      lineage:
+  - name:
+      lineage:
+      given: M.
+      honourific:
+      family: Sturm
+  - name:
+      family: Pfeifer
+      given: N.
+      honourific:
+      lineage:
+- eprint_status: archive
+  dir: disk0/00/00/03/98
+  date: 2005
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  eprintid: 398
+  refereed: 'TRUE'
+  item_issues_count: 0
+  metadata_visibility: show
+  full_text_status: none
+  creators:
+  - name:
+      honourific:
+      given: K.
+      family: Reinert
+      lineage:
+  - name:
+      family: Kohlbacher
+      honourific:
+      given: O.
+      lineage:
+  - name:
+      given: C.
+      honourific:
+      family: Gröpl
+      lineage:
+  - name:
+      family: Lange
+      given: E.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      family: Schulz-Trieglaff
+      honourific:
+      given: O.
+  - name:
+      lineage:
+      given: M.
+      honourific:
+      family: Sturm
+  - name:
+      lineage:
+      family: Pfeifer
+      honourific:
+      given: N.
+  datestamp: '2009-04-14 14:33:46'
+  title: OpenMS - A Framework for Quantitative HPLC/MS-Based Proteomics
+  status_changed: '2009-03-11 11:27:26'
+  userid: 1
+  publisher: Dagstuhl Online Publication Server (DROPS)
+  type: conference_item
+  rev_number: 3
+  official_url: http://www.dagstuhl.de/05471/
+  note: "Extended abstract for talk given at Dagstuhl Seminar 05471 on Computational\tProteomics,
+    20.-25. November 2005"
+  ispublished: pub
+  lastmod: '2009-04-14 14:33:46'
+  event_title: Computational Proteomics
+  uri: http://publications.imp.fu-berlin.de/id/eprint/398
+- metadata_visibility: show
+  id_number: doi:10.1146/annurev-genom-090413-025358
+  full_text_status: none
+  date_type: published
+  item_issues_count: 0
+  refereed: 'TRUE'
+  eprintid: 1544
+  number: 1
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  volume: 16
+  pagerange: 133-151
+  date: '2015-05-04'
+  dir: disk0/00/00/15/44
+  issn: 1527-8204
+  eprint_status: archive
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1544
+  ispublished: pub
+  lastmod: '2016-02-25 13:11:02'
+  official_url: http://dx.doi.org/10.1146/annurev-genom-090413-025358
+  userid: 132
+  type: article
+  rev_number: 13
+  title: Alignment of Next-Generation Sequencing Reads
+  status_changed: '2016-02-25 13:11:02'
+  abstract: "High-throughput DNA sequencing has considerably changed the possibilities
+    for conducting biomedical research by measuring billions of short DNA or RNA fragments.
+    A central computational problem, and for many applications a first step, consists
+    of determining where the fragments came from\r\nin the original genome. In this
+    article, we review the main techniques for generating the fragments, the main
+    applications, and the main algorithmic ideas for computing a solution to the read
+    alignment problem. In addition, we describe pitfalls and difficulties connected
+    to determining the correct positions of reads."
+  datestamp: '2015-05-07 12:25:03'
+  publication: Annual Review of Genomics and Human Genetics
+  creators:
+  - name:
+      lineage:
+      family: Reinert
+      given: K.
+      honourific:
+  - name:
+      given: B.
+      honourific:
+      family: Langmead
+      lineage:
+  - name:
+      lineage:
+      family: Weese
+      honourific:
+      given: D.
+  - name:
+      lineage:
+      family: Evers
+      honourific:
+      given: D.J.
+- uri: http://publications.imp.fu-berlin.de/id/eprint/400
+  ispublished: pub
+  lastmod: '2017-03-03 14:40:15'
+  userid: 1
+  type: article
+  rev_number: 3
+  title: An Iterative Methods for Faster Sum-of-Pairs Multiple Sequence Alignment
+  status_changed: '2009-03-11 11:27:27'
+  publication: BIOINFORMATICS
+  datestamp: '2017-03-03 14:40:15'
+  creators:
+  - name:
+      lineage:
+      given: K.
+      honourific:
+      family: Reinert
+  - name:
+      family: Stoye
+      honourific:
+      given: J.
+      lineage:
+  - name:
+      family: Will
+      given: T.
+      honourific:
+      lineage:
+  metadata_visibility: show
+  full_text_status: none
+  item_issues_count: 0
+  refereed: 'TRUE'
+  eprintid: 400
+  number: 9
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  volume: 16
+  date: 2000
+  pagerange: 808-814
+  dir: disk0/00/00/04/00
+  eprint_status: archive
+- dir: disk0/00/00/03/96
+  eprint_status: archive
+  volume: 1
+  subjects:
+  - G400
+  divisions:
+  - group_algbioinf
+  place_of_pub: Weinheim
+  date: 2007-12
+  pagerange: 25-55
+  eprintid: 396
+  refereed: 'TRUE'
+  full_text_status: none
+  metadata_visibility: show
+  item_issues_count: 0
+  series: Bioinformatics - From Genomes to Therapies
+  datestamp: '2017-03-03 14:40:15'
+  creators:
+  - name:
+      lineage:
+      family: Reinert
+      honourific:
+      given: K.
+  - name:
+      lineage:
+      given: D. H.
+      honourific:
+      family: Huson
+  rev_number: 3
+  publisher: Wiley-VCH
+  type: book_section
+  userid: 1
+  status_changed: '2009-03-11 11:27:24'
+  title: Sequence Assembly
+  uri: http://publications.imp.fu-berlin.de/id/eprint/396
+  ispublished: pub
+  lastmod: '2017-03-03 14:40:15'
+- event_title: "Proceedings of the First Annual International Conference on Computational\tMolecular
+    Biology (RECOMB-97)"
+  uri: http://publications.imp.fu-berlin.de/id/eprint/399
+  lastmod: '2017-03-03 14:40:15'
+  ispublished: pub
+  datestamp: '2017-03-03 14:40:15'
+  creators:
+  - name:
+      lineage:
+      family: Reinert
+      given: K.
+      honourific:
+  - name:
+      family: Lenhof
+      given: H.-P.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: P.
+      family: Mutzel
+  - name:
+      lineage:
+      family: Kececioglu
+      given: J. D.
+      honourific:
+  rev_number: 3
+  type: conference_item
+  userid: 1
+  status_changed: '2009-03-11 11:27:26'
+  title: 'A branch-and-Cut algorithm for multiple sequence alignment '
+  refereed: 'TRUE'
+  eprintid: 399
+  full_text_status: none
+  metadata_visibility: show
+  item_issues_count: 0
+  dir: disk0/00/00/03/99
+  eprint_status: archive
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  date: 1997
+  pagerange: 241-249
+- eprint_status: archive
+  issn: 1681656
+  dir: disk0/00/00/21/03
+  date: '2017-11-10'
+  pagerange: 157-168
+  volume: 261
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  refereed: 'TRUE'
+  eprintid: 2103
+  full_text_status: none
+  date_type: published
+  id_number: doi:10.1016/j.jbiotec.2017.07.017
+  metadata_visibility: show
+  creators:
+  - name:
+      lineage:
+      given: Knut
+      honourific:
+      family: Reinert
+  - name:
+      family: Dadi
+      honourific:
+      given: Temesgen Hailemariam
+      lineage:
+  - name:
+      lineage:
+      family: Ehrhardt
+      honourific:
+      given: Marcel
+  - name:
+      lineage:
+      given: Hannes
+      honourific:
+      family: Hauswedell
+  - name:
+      family: Mehringer
+      honourific:
+      given: Svenja
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: René
+      family: Rahn
+  - name:
+      lineage:
+      given: Jongkyu
+      honourific:
+      family: Kim
+  - name:
+      given: Christopher
+      honourific:
+      family: Pockrandt
+      lineage:
+  - name:
+      lineage:
+      given: Jörg
+      honourific:
+      family: Winkler
+  - name:
+      honourific:
+      given: Enrico
+      family: Siragusa
+      lineage:
+  - name:
+      family: Urgese
+      given: Gianvito
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: David
+      family: Weese
+  datestamp: '2017-09-12 14:16:48'
+  publication: Journal of Biotechnology
+  status_changed: '2017-09-12 14:16:48'
+  abstract: "Background\r\n\r\nThe use of novel algorithmic techniques is pivotal
+    to many important problems in life science. For example the sequencing of the
+    human genome (Venter et al., 2001) would not have been possible without advanced
+    assembly algorithms and the development of practical BWT based read mappers have
+    been instrumental for NGS analysis. However, owing to the high speed of technological
+    progress and the urgent need for bioinformatics tools, there was a widening gap
+    between state-of-the-art algorithmic techniques and the actual algorithmic components
+    of tools that are in widespread use. We previously addressed this by introducing
+    the SeqAn library of efficient data types and algorithms in 2008 (Döring et al.,
+    2008).\r\n\r\nResults\r\n\r\nThe SeqAn library has matured considerably since
+    its first publication 9 years ago. In this article we review its status as an
+    established resource for programmers in the field of sequence analysis and its
+    contributions to many analysis tools.\r\n\r\nConclusions\r\n\r\nWe anticipate
+    that SeqAn will continue to be a valuable resource, especially since it started
+    to actively support various hardware acceleration techniques in a systematic manner.\r\n\r\nKeywords\r\n\r\nNGS
+    analysis; Software libraries; C++; Data structures"
+  title: 'The SeqAn C++ template library for efficient sequence analysis: A resource
+    for programmers'
+  rev_number: 6
+  publisher: ELSEVIER
+  type: article
+  userid: 132
+  official_url: http://doi.org/10.1016/j.jbiotec.2017.07.017
+  keywords: NGS analysis; Software libraries; C++; Data structures
+  lastmod: '2017-10-12 11:37:39'
+  ispublished: pub
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2103
+- divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  volume: 33
+  pagerange: 2941-2942
+  date: '2017-09-15'
+  dir: disk0/00/00/21/17
+  issn: 1367-4803
+  eprint_status: archive
+  metadata_visibility: show
+  id_number: doi:10.1093/bioinformatics/btx330
+  full_text_status: none
+  date_type: published
+  eprintid: 2117
+  refereed: 'TRUE'
+  number: 18
+  userid: 132
+  type: article
+  rev_number: 5
+  title: Flexbar 3.0 – SIMD and multicore parallelization
+  abstract: "Motivation: \r\nHigh-throughput sequencing machines can process many
+    samples in a single run. For Illumina systems, sequencing reads are barcoded with
+    an additional DNA tag that is contained in the respective sequencing adapters.
+    The recognition of barcode and adapter sequences is hence commonly needed for
+    the analysis of next-generation sequencing data. Flexbar performs demultiplexing
+    based on barcodes and adapter trimming for such data. The massive amounts of data
+    generated on modern sequencing machines demand that this preprocessing is done
+    as efficiently as possible.\r\n\r\nResults: \r\nWe present Flexbar 3.0, the successor
+    of the popular program Flexbar. It employs now twofold parallelism: multi-threading
+    and additionally SIMD vectorization. Both types of parallelism are used to speed-up
+    the computation of pair-wise sequence alignments, which are used for the detection
+    of barcodes and adapters. Furthermore, new features were included to cover a wide
+    range of applications. We evaluated the performance of Flexbar based on a simulated
+    sequencing dataset. Our program outcompetes other tools in terms of speed and
+    is among the best tools in the presented quality benchmark.\r\n\r\nAvailability
+    and implementation:\r\nhttps://github.com/seqan/flexbar\r\n\r\nContact:\r\njohannes.roehr@fu-berlin.de
+    or knut.reinert@fu-berlin.de"
+  status_changed: '2017-10-12 12:16:48'
+  datestamp: '2017-10-12 12:16:48'
+  publication: Bioinformatics
+  creators:
+  - name:
+      given: Johannes T.
+      honourific:
+      family: Roehr
+      lineage:
+  - name:
+      given: Christoph
+      honourific:
+      family: Dieterich
+      lineage:
+  - name:
+      lineage:
+      family: Reinert
+      given: Knut
+      honourific:
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2117
+  lastmod: '2017-10-12 12:16:48'
+  ispublished: pub
+  official_url: http://doi.org/10.1093/bioinformatics/btx330
+- full_text_status: none
+  date_type: published
+  metadata_visibility: show
+  id_number: doi:10.1038/nmeth.3959
+  number: 9
+  eprintid: 2129
+  refereed: 'TRUE'
+  pagerange: 741-748
+  date: '2016-08-30'
+  volume: 13
+  subjects:
+  - G400
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  issn: 1548-7091
+  dir: disk0/00/00/21/29
+  ispublished: pub
+  lastmod: '2017-11-22 13:17:53'
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2129
+  official_url: http://doi.org/10.1038/nmeth.3959
+  status_changed: '2017-11-22 13:17:53'
+  abstract: High-resolution mass spectrometry (MS) has become an important tool in
+    the life sciences, contributing to the diagnosis and understanding of human diseases,
+    elucidating biomolecular structural information and characterizing cellular signaling
+    networks. However, the rapid growth in the volume and complexity of MS data makes
+    transparent, accurate and reproducible analysis difficult. We present OpenMS 2.0
+    (http://www.openms.de), a robust, open-source, cross-platform software specifically
+    designed for the flexible and reproducible analysis of high-throughput MS data.
+    The extensible OpenMS software implements common mass spectrometric data processing
+    tasks through a well-defined application programming interface in C++ and Python
+    and through standardized open data formats. OpenMS additionally provides a set
+    of 185 tools and ready-made workflows for common mass spectrometric data processing
+    tasks, which enable users to perform complex quantitative mass spectrometric analyses
+    with ease.
+  title: 'OpenMS: a flexible open-source software platform for mass spectrometry data
+    analysis'
+  rev_number: 5
+  publisher: Springer Nature/Macmillan Publishers Limited
+  type: article
+  userid: 132
+  creators:
+  - name:
+      family: Röst
+      given: Hannes L
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      family: Sachsenberg
+      given: Timo
+      honourific:
+  - name:
+      lineage:
+      honourific:
+      given: Stephan
+      family: Aiche
+  - name:
+      given: Chris
+      honourific:
+      family: Bielow
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: Hendrik
+      family: Weisser
+  - name:
+      lineage:
+      honourific:
+      given: Fabian
+      family: Aicheler
+  - name:
+      lineage:
+      family: Andreotti
+      given: Sandro
+      honourific:
+  - name:
+      honourific:
+      given: Hans-Christian
+      family: Ehrlich
+      lineage:
+  - name:
+      given: Petra
+      honourific:
+      family: Gutenbrunner
+      lineage:
+  - name:
+      honourific:
+      given: Erhan
+      family: Kenar
+      lineage:
+  - name:
+      honourific:
+      given: Xiao
+      family: Liang
+      lineage:
+  - name:
+      given: Sven
+      honourific:
+      family: Nahnsen
+      lineage:
+  - name:
+      family: Nilse
+      given: Lars
+      honourific:
+      lineage:
+  - name:
+      family: Pfeuffer
+      given: Julianus
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      family: Rosenberger
+      given: George
+      honourific:
+  - name:
+      lineage:
+      family: Rurik
+      honourific:
+      given: Marc
+  - name:
+      family: Schmitt
+      honourific:
+      given: Uwe
+      lineage:
+  - name:
+      lineage:
+      family: Veit
+      honourific:
+      given: Johannes
+  - name:
+      honourific:
+      given: Mathias
+      family: Walzer
+      lineage:
+  - name:
+      family: Wojnar
+      honourific:
+      given: David
+      lineage:
+  - name:
+      given: Witold E
+      honourific:
+      family: Wolski
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: Oliver
+      family: Schilling
+  - name:
+      family: Choudhary
+      given: Jyoti S
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      family: Malmström
+      honourific:
+      given: Lars
+  - name:
+      lineage:
+      family: Aebersold
+      given: Ruedi
+      honourific:
+  - name:
+      honourific:
+      given: Knut
+      family: Reinert
+      lineage:
+  - name:
+      lineage:
+      given: Oliver
+      honourific:
+      family: Kohlbacher
+  datestamp: '2017-11-22 13:17:53'
+  publication: Nature Methods
+- creators:
+  - name:
+      honourific:
+      given: L.
+      family: Schultz
+      lineage:
+    id:
+  - id:
+    name:
+      lineage:
+      family: Zurich
+      honourific:
+      given: M.-G.
+  - id:
+    name:
+      family: Culot
+      given: M.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      given: A.
+      honourific:
+      family: da Costa
+    id:
+  - id:
+    name:
+      family: Landry
+      honourific:
+      given: C.
+      lineage:
+  - id:
+    name:
+      lineage:
+      family: Bellwon
+      given: P.
+      honourific:
+  - id:
+    name:
+      lineage:
+      family: Kristl
+      given: T.
+      honourific:
+  - name:
+      honourific:
+      given: K.
+      family: Hörmann
+      lineage:
+    id:
+  - id:
+    name:
+      lineage:
+      family: Ruzek
+      honourific:
+      given: S.
+  - name:
+      given: S.
+      honourific:
+      family: Aiche
+      lineage:
+    id:
+  - name:
+      lineage:
+      family: Reinert
+      given: K.
+      honourific:
+    id: knut.reinert@fu-berlin.de
+  - name:
+      given: C.
+      honourific:
+      family: Bielow
+      lineage:
+    id:
+  - name:
+      lineage:
+      given: F.
+      honourific:
+      family: Gosselet
+    id:
+  - name:
+      honourific:
+      given: R.
+      family: Cecchelli
+      lineage:
+    id:
+  - id:
+    name:
+      honourific:
+      given: C. G.
+      family: Huber
+      lineage:
+  - name:
+      lineage:
+      family: Schroeder
+      honourific:
+      given: O. H.-U.
+    id:
+  - id:
+    name:
+      honourific:
+      given: A.
+      family: Gramowski-Voss
+      lineage:
+  - id:
+    name:
+      lineage:
+      family: Weiss
+      honourific:
+      given: D. G.
+  - name:
+      lineage:
+      family: Bal-Price
+      honourific:
+      given: A.
+    id:
+  datestamp: '2015-10-01 08:35:15'
+  abstract: "The present study was performed in an attempt to develop an in vitro
+    integrated testing strategy (ITS) to evaluate drug-induced neurotoxicity. A number
+    of endpoints were analyzed using two complementary brain cell culture models and
+    an in vitro blood–brain barrier (BBB) model after single and repeated exposure
+    treatments with selected drugs that covered the major biological, pharmacological
+    and neuro-toxicological responses. Furthermore, four drugs (diazepam, cyclosporine
+    A, chlorpromazine and amiodarone) were tested more in depth as representatives
+    of different classes of neurotoxicants, inducing toxicity through different pathways
+    of toxicity.\r\n\r\nThe developed in vitro BBB model allowed detection of toxic
+    effects at the level of BBB and evaluation of drug transport through the barrier
+    for predicting free brain concentrations of the studied drugs. The measurement
+    of neuronal electrical activity was found to be a sensitive tool to predict the
+    neuroactivity and neurotoxicity of drugs after acute exposure. The histotypic
+    3D re-aggregating brain cell cultures, containing all brain cell types, were found
+    to be well suited for OMICs analyses after both acute and long term treatment.\r\n\r\nThe
+    obtained data suggest that an in vitro ITS based on the information obtained from
+    BBB studies and combined with metabolomics, proteomics and neuronal electrical
+    activity measurements performed in stable in vitro neuronal cell culture systems,
+    has high potential to improve current in vitro drug-induced neurotoxicity evaluation.\r\n\r\nAbbreviations:\r\nBBB,
+    blood brain barrier; DMSO, dimethylsulfoxide; EC, endothelial cells; DIV, day
+    in vitro; IPA, Ingenuity Pathway Analysis; ITS, integrated testing strategy; LY,
+    Lucifer Yellow; MEA, micro-electrode array; RH, Ringer HEPES medium; SPSS, Statistical
+    Package for the Social Sciences\r\n"
+  title: Evaluation of drug-induced neurotoxicity based on metabolomics, proteomics
+    and electrical activity measurements in complementary CNS in vitro models
+  type: article
+  userid: 132
+  keywords: In vitro blood brain barrier; MEA; Neuronal network culture; OMICs; Drug
+    development; 3D brain culture
+  note: 'Online publication: May 2015'
+  date: '2015-12-25'
+  subjects:
+  - G400
+  refereed: 'TRUE'
+  eprintid: 1736
+  full_text_status: none
+  publication: Toxicology in Vitro
+  status_changed: '2016-11-15 13:58:51'
+  rev_number: 15
+  publisher: Elsevier B.V.
+  official_url: http://dx.doi.org/10.1016/j.tiv.2015.05.016
+  lastmod: '2016-11-15 13:58:51'
+  ispublished: pub
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1736
+  eprint_status: archive
+  issn: 8872333
+  dir: disk0/00/00/17/36
+  pagerange: 138-165
+  volume: 30
+  divisions:
+  - group_algbioinf
+  number: 1
+  item_issues_count: 0
+  date_type: published
+  metadata_visibility: show
+  id_number: doi:10.1016/j.tiv.2015.05.016
+- event_title: "Proceedings of the 8th International Workshop in Algorithms in Bioinformatics\t(WABI'08)"
+  uri: http://publications.imp.fu-berlin.de/id/eprint/401
+  lastmod: '2009-04-15 07:16:23'
+  ispublished: pub
+  datestamp: '2009-04-15 07:15:58'
+  creators:
+  - name:
+      lineage:
+      given: M. H.
+      honourific:
+      family: Schulz
+  - name:
+      lineage:
+      family: Weese
+      given: D.
+      honourific:
+  - name:
+      lineage:
+      family: Rausch
+      given: T.
+      honourific:
+  - name:
+      family: Döring
+      honourific:
+      given: A.
+      lineage:
+  - name:
+      family: Reinert
+      given: K.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      family: Vingron
+      given: M.
+      honourific:
+  userid: 1
+  rev_number: 5
+  publisher: Springer Verlag
+  type: conference_item
+  title: Fast and Adaptive Variable Order Markov Chain Construction
+  status_changed: '2009-03-11 11:27:27'
+  abstract: " Variable order Markov chains (VOMCs) are a flexible class of models\tthat
+    extend the well-known Markov chains. They have been applied\r\n\tto a variety
+    of problems in computational biology, e.g. protein family\r\n\tclassification.
+    A linear time and space construction algorithm has\r\n\tbeen published in 2000
+    by Apostolico and Bejerano. However, neither\r\n\ta report of the actual running
+    time nor an implementation of it have\r\n\tever been published since. Using their
+    theoretical results, we implement\r\n\tgeneral and problem oriented algorithms
+    considering recent advances\r\n\tin string matching. We introduce a new software
+    which is orders of\r\n\tmagnitudes faster than current tools for building VOMCs,
+    and is suitable\r\n\tfor large scale analysis. Along the way we show that the
+    lazy suffix\r\n\ttree algorithm by Giegerich and others can compete with state-of-the-art\r\n\tsuffix
+    array methods in terms of time and space under the type of\r\n\tconstraints we
+    have analyzed in this work. "
+  eprintid: 401
+  refereed: 'TRUE'
+  metadata_visibility: show
+  full_text_status: none
+  item_issues_count: 0
+  dir: disk0/00/00/04/01
+  eprint_status: archive
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  pagerange: 306-317
+  date: 2008
+- official_url: http://bioinformatics.oxfordjournals.org/content/30/17/i356.abstract
+  ispublished: pub
+  lastmod: '2017-03-03 14:41:37'
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1451
+  creators:
+  - name:
+      given: M. H.
+      honourific:
+      family: Schulz
+      lineage:
+  - name:
+      honourific:
+      given: D.
+      family: Weese
+      lineage:
+  - name:
+      given: M.
+      honourific:
+      family: Holtgrewe
+      lineage:
+  - name:
+      honourific:
+      given: V.
+      family: Dimitrova
+      lineage:
+  - name:
+      lineage:
+      given: S.
+      honourific:
+      family: Niu
+  - name:
+      given: K.
+      honourific:
+      family: Reinert
+      lineage:
+  - name:
+      lineage:
+      family: Richard
+      given: H.
+      honourific:
+  documents:
+  - pos: 1
+    eprintid: 1451
+    security: public
+    format: application/pdf
+    main: Bioinformatics-2014-Schulz-i356-63.pdf
+    uri: http://publications.imp.fu-berlin.de/id/document/619
+    docid: 619
+    formatdesc: Main Article
+    content: supplemental
+    mime_type: application/pdf
+    relation:
+    - uri: "/id/document/1277"
+      type: http://eprints.org/relation/hasVolatileVersion
+    - type: http://eprints.org/relation/haspreviewThumbnailVersion
+      uri: "/id/document/1277"
+    - uri: "/id/document/1277"
+      type: http://eprints.org/relation/hasVersion
+    language: en
+    files:
+    - mime_type: application/pdf
+      uri: http://publications.imp.fu-berlin.de/id/file/18114
+      filesize: 472369
+      fileid: 18114
+      filename: Bioinformatics-2014-Schulz-i356-63.pdf
+      objectid: 619
+      datasetid: document
+      mtime: '2017-03-03 14:41:37'
+    rev_number: 8
+  - relation:
+    - type: http://eprints.org/relation/hasVersion
+      uri: "/id/document/1278"
+    - uri: "/id/document/1278"
+      type: http://eprints.org/relation/hasVolatileVersion
+    - type: http://eprints.org/relation/haspreviewThumbnailVersion
+      uri: "/id/document/1278"
+    files:
+    - fileid: 18117
+      objectid: 620
+      filename: fiona_supplement.pdf
+      datasetid: document
+      mtime: '2017-03-03 14:41:37'
+      uri: http://publications.imp.fu-berlin.de/id/file/18117
+      mime_type: application/pdf
+      filesize: 249703
+    language: en
+    rev_number: 6
+    pos: 2
+    eprintid: 1451
+    security: public
+    format: application/pdf
+    main: fiona_supplement.pdf
+    uri: http://publications.imp.fu-berlin.de/id/document/620
+    docid: 620
+    mime_type: application/pdf
+    formatdesc: Supplemental Material
+  publication: Bioinformatics
+  datestamp: '2014-08-26 14:02:44'
+  title: 'Fiona: a parallel and automatic strategy for read error correction'
+  abstract: 'Motivation: Automatic error correction of high-throughput sequencing
+    data can have a dramatic impact on the amount of usable base pairs and their quality.
+    It has been shown that the performance of tasks such as de novo genome assembly
+    and SNP calling can be dramatically improved after read error correction. While
+    a large number of methods specialized for correcting substitution errors as found
+    in Illumina data exist, few methods for the correction of indel errors, common
+    to technologies like 454 or Ion Torrent, have been proposed.Results: We present
+    Fiona, a new stand-alone read errorâ��correction method. Fiona provides a new
+    statistical approach for sequencing error detection and optimal error correction
+    and estimates its parameters automatically. Fiona is able to correct substitution,
+    insertion and deletion errors and can be applied to any sequencing technology.
+    It uses an efficient implementation of the partial suffix array to detect read
+    overlaps with different seed lengths in parallel. We tested Fiona on several real
+    datasets from a variety of organisms with different read lengths and compared
+    its performance with state-of-the-art methods. Fiona shows a constantly higher
+    correction accuracy over a broad range of datasets from 454 and Ion Torrent sequencers,
+    without compromise in speed.Conclusion: Fiona is an accurate parameter-free read
+    errorâ��correction method that can be run on inexpensive hardware and can make
+    use of multicore parallelization whenever available. Fiona was implemented using
+    the SeqAn library for sequence analysis and is publicly available for download
+    at http://www.seqan.de/projects/fiona.Contact: mschulz@mmci.uni-saarland.de or
+    hugues.richard@upmc.frSupplementary information: Supplementary data are available
+    at Bioinformatics online.'
+  status_changed: '2014-08-26 14:06:03'
+  userid: 30
+  rev_number: 18
+  type: article
+  eprintid: 1451
+  refereed: 'TRUE'
+  number: 17
+  item_issues_count: 0
+  metadata_visibility: show
+  full_text_status: public
+  date_type: published
+  eprint_status: archive
+  dir: disk0/00/00/14/51
+  date: 2014
+  pagerange: i356-i363
+  subjects:
+  - C
+  - G
+  divisions:
+  - group_algbioinf
+  volume: 30
+- status_changed: '2009-04-14 14:56:57'
+  abstract: "Liquid chromatography coupled to mass spectrometry (LC-MS) has become\ta
+    major tool for the study of biological processes. High-throughput\r\n\tLC-MS experimentsare
+    frequently conducted in modern laboratories,\r\n\tgenerating an enormous amountof
+    data per day. A manual inspection\r\n\tis therefore no longer a feasible task.
+    Consequently, there is a\r\n\tneed for computational tools that can rapidly provide
+    informationabout\r\n\tmass, elution time, and abundance of the compounds in a
+    LC-MS sample.\r\n\tWepresent an algorithm for the detection and quantification
+    of peptides\r\n\tin LC-MS data. Our approach is flexible and independent of the
+    MS\r\n\ttechnology in use. It is basedon a combination of the sweep line\r\n\tparadigm
+    with a novel wavelet function tailoredto detect isotopic\r\n\tpatterns of peptides.
+    We propose a simple voting schema to usethe\r\n\tredundant information in consecutive
+    scans for an accurate determination\r\n\tofmonoisotopic masses and charge states.
+    By explicitly modeling the\r\n\tinstrument inaccuracy, we are also able to cope
+    with data sets of\r\n\tdifferent quality and resolution.We evaluate our technique
+    on data\r\n\tfrom different instruments and show that we canrapidly estimate mass,\r\n\tcentroid
+    of retention time and abundance of peptides in a sound algorithmic\r\n\tframework.
+    Finally, we compare the performance of our method to several\r\n\tother techniques
+    on three data sets of varying complexity."
+  title: Computational Quantification of Peptides from LC-MS data
+  type: article
+  rev_number: 5
+  userid: 1
+  creators:
+  - name:
+      lineage:
+      given: O.
+      honourific:
+      family: Schulz-Trieglaff
+  - name:
+      honourific:
+      given: R.
+      family: Hussong
+      lineage:
+  - name:
+      family: Gröpl
+      given: C.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      given: A.
+      honourific:
+      family: Hildebrandt
+  - name:
+      lineage:
+      family: Hildebrandt
+      honourific:
+      given: A.
+  - name:
+      lineage:
+      given: Ch.
+      honourific:
+      family: Huber
+  - name:
+      given: K.
+      honourific:
+      family: Reinert
+      lineage:
+  publication: Journal of Computational Biology
+  datestamp: '2009-04-14 14:09:23'
+  lastmod: '2009-04-14 14:56:57'
+  ispublished: pub
+  uri: http://publications.imp.fu-berlin.de/id/eprint/406
+  official_url: http://dx.doi.org/10.1089/cmb.2007.0117
+  keywords: "computational mass spectrometry, liquid chromatography - massspectrometry,\tquantification,
+    wavelets"
+  date: 2008
+  pagerange: 685-704
+  volume: 15
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  eprint_status: archive
+  dir: disk0/00/00/04/06
+  item_issues_count: 0
+  full_text_status: none
+  metadata_visibility: show
+  number: 7
+  eprintid: 406
+  refereed: 'TRUE'
+- eprint_status: archive
+  dir: disk0/00/00/04/07
+  date: 2007
+  pagerange: 473-487
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  refereed: 'TRUE'
+  eprintid: 407
+  item_issues_count: 0
+  metadata_visibility: show
+  full_text_status: none
+  creators:
+  - name:
+      family: Schulz-Trieglaff
+      honourific:
+      given: O.
+      lineage:
+  - name:
+      given: R.
+      honourific:
+      family: Hussong
+      lineage:
+  - name:
+      lineage:
+      family: Gröpl
+      given: C.
+      honourific:
+  - name:
+      family: Hildebrandt
+      honourific:
+      given: A.
+      lineage:
+  - name:
+      family: Reinert
+      given: K.
+      honourific:
+      lineage:
+  datestamp: '2009-04-14 14:18:25'
+  title: "A Fast and Accurate Algorithm for the Quantification of Peptides\tfrom Mass
+    Spectrometry data"
+  status_changed: '2009-03-11 11:27:31'
+  userid: 1
+  rev_number: 3
+  type: conference_item
+  lastmod: '2009-04-14 14:18:25'
+  ispublished: pub
+  uri: http://publications.imp.fu-berlin.de/id/eprint/407
+  event_title: "Proceedings of the Eleventh Annual International Conference on Research\tin
+    Computational Molecular Biology (RECOMB 2007)"
+- uri: http://publications.imp.fu-berlin.de/id/eprint/408
+  ispublished: pub
+  lastmod: '2009-04-14 14:14:37'
+  official_url: http://dx.doi.org/10.1186/1471-2105-9-423
+  keywords: algorithm, benchmark, lc-ms-ms, massspec, metabolomics, proteomics
+  rev_number: 3
+  type: article
+  userid: 1
+  status_changed: '2009-03-11 11:27:31'
+  abstract: "BACKGROUND: Mass Spectrometry coupled to Liquid Chromatography (LC-MS)\tis
+    commonly used to analyze the protein content of biological samples\r\n\tin large
+    scale studies. The data resulting from an LC-MS experiment\r\n\tis huge, highly
+    complex and noisy. Accordingly, it has sparked new\r\n\tdevelopments in Bioinformatics,
+    especially in the fields of algorithm\r\n\tdevelopment, statistics and software
+    engineering. In a quantitative\r\n\tlabel-free mass spectrometry experiment, crucial
+    steps are the detection\r\n\tof peptide features in the mass spectra and the alignment
+    of samples\r\n\tby correcting for shifts in retention time. At the moment, it
+    is\r\n\tdifficult to compare the plethora of algorithms for these tasks.\r\n\tSo
+    far, curated benchmark data exists only for peptide identification\r\n\talgorithms
+    but no data that represents a ground truth for the evaluation\r\n\tof feature
+    detection, alignment and filtering algorithms. RESULTS:\r\n\tWe present LC-MSsim,
+    a simulation software for LC-ESI-MS experiments.\r\n\tIt simulates ESI spectra
+    on the MS level. It reads a list of proteins\r\n\tfrom a FASTA file and digests
+    the protein mixture using a user-defined\r\n\tenzyme. The software creates an
+    LC-MS data set using a predictor\r\n\tfor the retention time of the peptides and
+    a model for peak shapes\r\n\tand elution profiles of the mass spectral peaks.
+    Our software also\r\n\toffers the possibility to add contaminants, to change the
+    background\r\n\tnoise level and includes a model for the detectability of peptides\r\n\tin
+    mass spectra. After the simulation, LC-MSsim writes the simulated\r\n\tdata to
+    public XML formats (mzXML or mzData). The software also stores\r\n\tthe positions
+    (monoisotopic m/z and retention time) and ion counts\r\n\tof the simulated ions
+    in separate files. CONCLUSIONS: LC-MSsim generates\r\n\tsimulated LC-MS data sets
+    and incorporates models for peak shapes\r\n\tand contaminations. Algorithm developers
+    can match the results of\r\n\tfeature detection and alignment algorithms against
+    the simulated\r\n\tion lists and meaningful error rates can be computed. We anticipate\r\n\tthat
+    LC-MSsim will be useful to the wider community to perform benchmark\r\n\tstudies
+    and comparisons between computational tools."
+  title: "LC-MSsim - a simulation software for liquid chromatography mass\tspectrometry
+    data"
+  publication: BMC Bioinformatics
+  datestamp: '2009-04-14 14:14:37'
+  creators:
+  - name:
+      lineage:
+      family: Schulz-Trieglaff
+      honourific:
+      given: O.
+  - name:
+      honourific:
+      given: N.
+      family: Pfeifer
+      lineage:
+  - name:
+      lineage:
+      family: Gröpl
+      honourific:
+      given: C.
+  - name:
+      given: O.
+      honourific:
+      family: Kohlbacher
+      lineage:
+  - name:
+      family: Reinert
+      honourific:
+      given: K.
+      lineage:
+  full_text_status: none
+  metadata_visibility: show
+  item_issues_count: 0
+  number: 423
+  eprintid: 408
+  refereed: 'TRUE'
+  volume: 9
+  subjects:
+  - G400
+  divisions:
+  - group_algbioinf
+  date: 2008
+  dir: disk0/00/00/04/08
+  eprint_status: archive
+- dir: disk0/00/00/04/02
+  eprint_status: archive
+  subjects:
+  - G400
+  divisions:
+  - group_algbioinf
+  date: 2005
+  refereed: 'TRUE'
+  eprintid: 402
+  full_text_status: none
+  metadata_visibility: show
+  item_issues_count: 0
+  datestamp: '2017-03-03 14:40:15'
+  creators:
+  - name:
+      lineage:
+      family: Schulz-Trieglaff
+      honourific:
+      given: O.
+  type: other
+  rev_number: 3
+  userid: 1
+  status_changed: '2009-03-11 11:27:28'
+  title: Modelling the Randomness in Biological Systems
+  keywords: petri nets, Gillespie algorithm
+  uri: http://publications.imp.fu-berlin.de/id/eprint/402
+  ispublished: pub
+  lastmod: '2017-03-03 14:40:15'
+- item_issues_count: 0
+  full_text_status: none
+  metadata_visibility: show
+  eprintid: 403
+  refereed: 'TRUE'
+  date: 2005
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  eprint_status: archive
+  dir: disk0/00/00/04/03
+  lastmod: '2017-03-03 14:40:15'
+  ispublished: pub
+  note: "Extended abstract for talk given at Dagstuhl Seminar 05471 on Computational\tProteomics,
+    20.-25. November 2005"
+  event_title: Computational Proteomics
+  uri: http://publications.imp.fu-berlin.de/id/eprint/403
+  official_url: http://www.dagstuhl.de/05471/
+  status_changed: '2009-03-11 11:27:28'
+  title: Software Platforms for Computational Proteomics
+  rev_number: 3
+  publisher: Dagstuhl Online Publication Server (DROPS)
+  type: conference_item
+  userid: 1
+  creators:
+  - name:
+      lineage:
+      given: O.
+      honourific:
+      family: Schulz-Trieglaff
+  datestamp: '2017-03-03 14:40:15'
+- lastmod: '2020-04-16 11:47:46'
+  ispublished: pub
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2434
+  official_url: http://doi.org/10.1371/journal.pcbi.1007208
+  title: 'Where did you come from, where did you go: Refining metagenomic analysis
+    tools for horizontal gene transfer characterisation'
+  abstract: "Horizontal gene transfer (HGT) has changed the way we regard evolution.
+    Instead of waiting for the next generation to establish new traits, especially
+    bacteria are able to take a shortcut via HGT that enables them to pass on genes
+    from one individual to another, even across species boundaries. The tool Daisy
+    offers the first HGT detection approach based on read mapping that provides complementary
+    evidence compared to existing methods. However, Daisy relies on the acceptor and
+    donor organism involved in the HGT being known. We introduce DaisyGPS, a mapping-based
+    pipeline that is able to identify acceptor and donor reference candidates of an
+    HGT event based on sequencing reads. Acceptor and donor identification is akin
+    to species identification in metagenomic samples based on sequencing reads, a
+    problem addressed by metagenomic profiling tools. However, acceptor and donor
+    references have certain properties such that these methods cannot be directly
+    applied. DaisyGPS uses MicrobeGPS, a metagenomic profiling tool tailored towards
+    estimating the genomic distance between organisms in the sample and the reference
+    database. We enhance the underlying scoring system of MicrobeGPS to account for
+    the sequence patterns in terms of mapping coverage of an acceptor and donor involved
+    in an HGT event, and report a ranked list of reference candidates. These candidates
+    can then be further evaluated by tools like Daisy to establish HGT regions. We
+    successfully validated our approach on both simulated and real data, and show
+    its benefits in an investigation of an outbreak involving Methicillin-resistant
+    Staphylococcus aureus data.\r\n\r\nAuthor summary\r\n\r\nEvolution is traditionally
+    viewed as a process where changes are only vertically inherited from parent to
+    offspring across generations. Many principles such as phylogenetic trees and even
+    the “tree of life” are based on that doctrine. The concept of horizontal gene
+    transfer changed the way we regard evolution completely. Horizontal gene transfer
+    is the movement of genetic information between distantly related organisms of
+    the same generation. Genome sequencing not only provided further evidence complementing
+    experimental evidence but also shed light onto the frequency and prominence of
+    this concept. Especially the rapid spread of antimicrobial resistance genes is
+    a prominent example for the impact that horizontal gene transfer can have for
+    public health. Next generation sequencing brought means for quick and relatively
+    cheap analysis of even complex metagenomic samples where horizontal gene transfer
+    is bound to happen frequently. Methods to directly detect and characterise horizontal
+    gene transfer from such sequencing data, however, are still lacking. We here provide
+    a method to identify organisms potentially involved in horizontal gene transfer
+    events to be used in downstream analysis that enables a characterisation of a
+    horizontal gene transfer event in terms of impact and prevalence."
+  status_changed: '2020-04-16 11:47:46'
+  userid: 132
+  type: article
+  publisher: Public Library of Science
+  rev_number: 11
+  creators:
+  - name:
+      honourific:
+      given: Enrico
+      family: Seiler
+      lineage:
+  - name:
+      given: Kathrin
+      honourific:
+      family: Trappe
+      lineage:
+  - name:
+      lineage:
+      family: Renard
+      honourific:
+      given: Bernhard Y.
+  datestamp: '2020-04-16 11:47:46'
+  publication: PLOS Computational Biology
+  id_number: doi:10.1371/journal.pcbi.1007208
+  metadata_visibility: show
+  full_text_status: none
+  date_type: published
+  eprintid: 2434
+  refereed: 'TRUE'
+  number: 7
+  date: '2019-07-23'
+  pagerange: e1007208
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  volume: 15
+  eprint_status: archive
+  dir: disk0/00/00/24/34
+  issn: 1553-7358
+- official_url: http://nar.oxfordjournals.org/content/41/7/e78
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1161
+  lastmod: '2013-08-10 09:39:39'
+  ispublished: pub
+  datestamp: '2012-09-12 08:48:19'
+  publication: Oxford Journals
+  creators:
+  - name:
+      lineage:
+      family: Siragusa
+      given: E.
+      honourific:
+  - name:
+      lineage:
+      honourific:
+      given: D.
+      family: Weese
+  - name:
+      lineage:
+      given: K.
+      honourific:
+      family: Reinert
+  userid: 30
+  publisher: Oxford University Press
+  type: article
+  rev_number: 19
+  title: Fast and accurate read mapping with approximate seeds and multiple backtracking
+  abstract: We present Masai, a read mapper representing the state-of-the-art in terms
+    of speed and accuracy. Our tool is an order of magnitude faster than RazerS 3
+    and mrFAST, 2–4 times faster and more accurate than Bowtie 2 and BWA. The novelties
+    of our read mapper are filtration with approximate seeds and a method for multiple
+    backtracking. Approximate seeds, compared with exact seeds, increase filtration
+    specificity while preserving sensitivity. Multiple backtracking amortizes the
+    cost of searching a large set of seeds by taking advantage of the repetitiveness
+    of next-generation sequencing data. Combined together, these two methods significantly
+    speed up approximate search on genomic data sets. Masai is implemented in C++
+    using the SeqAn library. The source code is distributed under the BSD license
+    and binaries for Linux, Mac OS X and Windows can be freely downloaded from http://www.seqan.de/projects/masai.
+  status_changed: '2013-08-10 09:39:39'
+  eprintid: 1161
+  refereed: 'TRUE'
+  number: 7
+  metadata_visibility: show
+  id_number: 10.1093/nar/gkt005
+  full_text_status: none
+  date_type: published
+  item_issues_count: 0
+  dir: disk0/00/00/11/61
+  issn: Print ISSN 0305-1048; Online ISSN 1362-4962
+  eprint_status: archive
+  divisions:
+  - group_algbioinf
+  subjects:
+  - C
+  - G
+  volume: 41
+  date: '2013-01-28'
+  pagerange: e78
+- event_title: Proceedings of the Joint EDBT/ICDT 2013 Workshops
+  keywords: approximate seeds, backtracking, banded Myers bit-vector, banded dynamic
+    programming, filtration, radix tree, suffix tree
+  event_location: Genoa, Italy
+  abstract: We present in this paper scalable algorithms for optimal string similarity
+    search and join. Our methods are variations of those applied in Masai [15], our
+    recently published tool for mapping high-throughput DNA sequencing data with unpreceded
+    speed and accuracy. The key features of our approach are filtration with approximate
+    seeds and methods for multiple backtracking. Approximate seeds, compared to exact
+    seeds, increase filtration specificity while preserving sensitivity. Multiple
+    backtracking amortizes the cost of searching a large set of seeds. Combined together,
+    these two methods significantly speed up string similarity search and join operations.
+    Our tool is implemented in C++ and OpenMP using the SeqAn library. The source
+    code is distributed under the BSD license and can be freely downloaded from http://www.seqan.de/projects/edbt2013.
+  title: Scalable string similarity search/join with approximate seeds and multiple
+    backtracking
+  type: conference_item
+  userid: 132
+  creators:
+  - name:
+      lineage:
+      given: E.
+      honourific:
+      family: Siragusa
+  - name:
+      lineage:
+      family: Weese
+      given: D.
+      honourific:
+  - name:
+      lineage:
+      honourific:
+      given: K.
+      family: Reinert
+  datestamp: '2013-03-28 12:24:08'
+  related_url:
+  - url: http://dl.acm.org/citation.cfm?id=2457386&bnc=1
+  series: EDBT '13
+  full_text_status: none
+  eprintid: 1225
+  refereed: 'TRUE'
+  place_of_pub: New York, NY, USA
+  date: 2013
+  subjects:
+  - G400
+  ispublished: pub
+  lastmod: '2013-08-10 11:41:05'
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1225
+  official_url: http://doi.acm.org/10.1145/2457317.2457386
+  status_changed: '2013-08-10 11:41:05'
+  rev_number: 18
+  publisher: ACM
+  event_type: workshop
+  item_issues_count: 0
+  date_type: published
+  metadata_visibility: show
+  pres_type: paper
+  pagerange: 370-374
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  dir: disk0/00/00/12/25
+- userid: 30
+  type: article
+  publisher: Nature Publishing Group
+  rev_number: 20
+  title: Assessment of transcript reconstruction methods for RNA-seq
+  contact_email: david.weese@fu-berlin.de
+  abstract: We evaluated 25 protocol variants of 14 independent computational methods
+    for exon identification, transcript reconstruction and expression-level quantification
+    from RNA-seq data. Our results show that most algorithms are able to identify
+    discrete transcript components with high success rates but that assembly of complete
+    isoform structures poses a major challenge even when all constituent elements
+    are identified. Expression-level estimates also varied widely across methods,
+    even when based on similar transcript models. Consequently, the complexity of
+    higher eukaryotic genomes imposes severe limitations on transcript recall and
+    splice product discrimination that are likely to remain limiting factors for the
+    analysis of current-generation RNA-seq data.
+  status_changed: '2014-02-21 05:42:01'
+  documents:
+  - security: public
+    pos: 1
+    eprintid: 1380
+    uri: http://publications.imp.fu-berlin.de/id/document/595
+    main: nmeth.2714.pdf
+    docid: 595
+    mime_type: application/pdf
+    content: published
+    format: application/pdf
+    relation:
+    - type: http://eprints.org/relation/haspreviewThumbnailVersion
+      uri: "/id/document/1267"
+    - type: http://eprints.org/relation/hasVolatileVersion
+      uri: "/id/document/1267"
+    - uri: "/id/document/1267"
+      type: http://eprints.org/relation/hasVersion
+    language: en
+    files:
+    - fileid: 17299
+      objectid: 595
+      filename: nmeth.2714.pdf
+      datasetid: document
+      mtime: '2017-03-03 14:41:32'
+      mime_type: application/pdf
+      uri: http://publications.imp.fu-berlin.de/id/file/17299
+      filesize: 649888
+    rev_number: 4
+  publication: Nature Methods
+  datestamp: '2014-02-20 22:54:03'
+  creators:
+  - name:
+      lineage:
+      family: Steijger
+      given: T.
+      honourific:
+  - name:
+      given: J. F.
+      honourific:
+      family: Abril
+      lineage:
+  - name:
+      honourific:
+      given: P. G.
+      family: Engström
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: F.
+      family: Kokocinski
+  - name:
+      lineage:
+      family: The RGASP Consortium
+      honourific:
+      given:
+  - name:
+      lineage:
+      given: H.
+      honourific:
+      family: Richard
+  - name:
+      given: M. H.
+      honourific:
+      family: Schulz
+      lineage:
+  - name:
+      honourific:
+      given: D.
+      family: Weese
+      lineage:
+  - name:
+      family: Hubbard
+      honourific:
+      given: T.
+      lineage:
+  - name:
+      lineage:
+      family: Guigó
+      given: R.
+      honourific:
+  - name:
+      lineage:
+      given: J.
+      honourific:
+      family: Harrow
+  - name:
+      lineage:
+      given: P.
+      honourific:
+      family: Bertone
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1380
+  ispublished: pub
+  lastmod: '2017-03-03 14:41:32'
+  official_url: http://dx.doi.org/10.1038/nmeth.2714
+  divisions:
+  - group_algbioinf
+  subjects:
+  - C
+  - G400
+  volume: 10
+  date: '2013-11-03'
+  pagerange: 1177-1184
+  dir: disk0/00/00/13/80
+  eprint_status: archive
+  metadata_visibility: show
+  id_number: 10.1038/nmeth.2714
+  date_type: published
+  full_text_status: public
+  item_issues_count: 0
+  eprintid: 1380
+  refereed: 'TRUE'
+  number: 12
+- uri: http://publications.imp.fu-berlin.de/id/eprint/409
+  ispublished: pub
+  lastmod: '2009-04-14 14:16:52'
+  keywords: lc-ms-ms, massspec, proteomics
+  official_url: http://dx.doi.org/10.1186/1471-2105-9-163
+  userid: 1
+  type: article
+  rev_number: 3
+  title: OpenMS - An open-source software framework for mass spectrometry
+  abstract: "BACKGROUND: Mass spectrometry is an essential analytical technique\tfor
+    high-throughput analysis in proteomics and metabolomics. The\r\n\tdevelopment
+    of new separation techniques, precise mass analyzers\r\n\tand experimental protocols
+    is a very active field of research. This\r\n\tleads to more complex experimental
+    setups yielding ever increasing\r\n\tamounts of data. Consequently, analysis of
+    the data is currently\r\n\toften the bottleneck for experimental studies. Although
+    software\r\n\ttools for many data analysis tasks are available today, they are\r\n\toften
+    hard to combine with each other or not flexible enough to allow\r\n\tfor rapid
+    prototyping of a new analysis workflow. RESULTS: We present\r\n\tOpenMS, a software
+    framework for rapid application development in\r\n\tmass spectrometry. OpenMS
+    has been designed to be portable, easy-to-use\r\n\tand robust while offering a
+    rich functionality ranging from basic\r\n\tdata structures to sophisticated algorithms
+    for data analysis. This\r\n\thas already been demonstrated in several studies.
+    CONCLUSIONS: OpenMS\r\n\tis available under the Lesser GNU Public License (LGPL)
+    from the\r\n\tproject website at http://www.openms.de."
+  status_changed: '2009-03-11 11:27:32'
+  datestamp: '2009-04-14 14:16:52'
+  publication: BMC Bioinformatics
+  creators:
+  - name:
+      family: Sturm
+      honourific:
+      given: M.
+      lineage:
+  - name:
+      lineage:
+      given: B.
+      honourific:
+      family: Andreas
+  - name:
+      lineage:
+      family: Gröpl
+      honourific:
+      given: C.
+  - name:
+      family: Hussong
+      honourific:
+      given: R.
+      lineage:
+  - name:
+      lineage:
+      family: Lange
+      given: E.
+      honourific:
+  - name:
+      lineage:
+      honourific:
+      given: N.
+      family: Pfeifer
+  - name:
+      lineage:
+      family: Schulz-Trieglaff
+      given: O.
+      honourific:
+  - name:
+      lineage:
+      family: Zerck
+      honourific:
+      given: A.
+  - name:
+      family: Reinert
+      given: K.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      given: O.
+      honourific:
+      family: Kohlbacher
+  metadata_visibility: show
+  full_text_status: none
+  item_issues_count: 0
+  eprintid: 409
+  refereed: 'TRUE'
+  number: 163
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  volume: 9
+  date: 2008
+  dir: disk0/00/00/04/09
+  eprint_status: archive
+- lastmod: '2014-12-10 15:11:44'
+  ispublished: pub
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1455
+  official_url: http://bioinformatics.oxfordjournals.org/content/early/2014/07/29/bioinformatics.btu431.full
+  abstract: "MOTIVATION:\r\nThe landscape of structural variation (SV) including complex
+    duplication and translocation patterns is far from resolved. SV detection tools
+    usually exhibit low agreement, are often geared toward certain types or size ranges
+    of variation and struggle to correctly classify the type and exact size of SVs.\r\n\r\nRESULTS:\r\nWe
+    present Gustaf (Generic mUlti-SpliT Alignment Finder), a sound generic multi-split
+    SV detection tool that detects and classifies deletions, inversions, dispersed
+    duplications and translocations of <span class='mathrm'>ge</span>30 bp. Our approach
+    is based on a generic multi-split alignment strategy that can identify SV breakpoints
+    with base pair resolution. We show that Gustaf correctly identifies SVs, especially
+    in the range from 30 to 100 bp, which we call the next-generation sequencing (NGS)
+    twilight zone of SVs, as well as larger SVs &gt;500 bp. Gustaf performs better
+    than similar tools in our benchmark and is furthermore able to correctly identify
+    size and location of dispersed duplications and translocations, which otherwise
+    might be wrongly classified, for example, as large deletions. Availability and
+    implementation: Project information, paper benchmark and source code are available
+    via http://www.seqan.de/projects/gustaf/.\r\n\r\nCONTACT:kathrin.trappe@fu-berlin.de."
+  status_changed: '2014-12-10 15:11:43'
+  title: 'Gustaf: Detecting and correctly classifying SVs in the NGS twilight zone'
+  type: article
+  publisher: Oxford University Press
+  rev_number: 12
+  userid: 29
+  creators:
+  - id:
+    name:
+      family: Trappe
+      honourific:
+      given: K.
+      lineage:
+  - id:
+    name:
+      lineage:
+      family: Emde
+      honourific:
+      given: A.-K.
+  - name:
+      lineage:
+      family: Ehrlich
+      given: H.-C.
+      honourific:
+    id:
+  - id: knut.reinert@fu-berlin.de
+    name:
+      family: Reinert
+      given: K.
+      honourific:
+      lineage:
+  publication: Bioinformatics
+  datestamp: '2014-09-30 11:00:30'
+  item_issues_count: 0
+  full_text_status: none
+  date_type: published
+  metadata_visibility: show
+  number: 24
+  refereed: 'TRUE'
+  eprintid: 1455
+  pagerange: 3484-3490
+  date: '2014-07-14'
+  volume: 30
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G620
+  - G400
+  eprint_status: archive
+  issn: 1367-4803
+  dir: disk0/00/00/14/55
+- full_text_status: none
+  metadata_visibility: show
+  item_issues_count: 0
+  eprintid: 410
+  refereed: 'TRUE'
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  pagerange: 7-18
+  date: 2001
+  dir: disk0/00/00/04/10
+  eprint_status: archive
+  event_title: "IEEE 2001 Symposium on Parallel and Large-Data Visualization and\tGraphics"
+  uri: http://publications.imp.fu-berlin.de/id/eprint/410
+  lastmod: '2017-03-03 14:40:15'
+  ispublished: pub
+  note: Keynote address
+  type: conference_item
+  rev_number: 3
+  userid: 1
+  status_changed: '2009-03-11 11:27:32'
+  title: Visualization Challenges for a New Cyberpharmaceutical Computing
+  datestamp: '2017-03-03 14:40:15'
+  creators:
+  - name:
+      given: R. J.
+      honourific:
+      family: Turner
+      lineage:
+  - name:
+      honourific:
+      given: K.
+      family: Chaturvedi
+      lineage:
+  - name:
+      family: Edwards
+      given: N. J.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      given: A. L.
+      honourific:
+      family: Halpern
+  - name:
+      family: Huson
+      given: D. H.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: O.
+      family: Kohlbacher
+  - name:
+      family: Miller
+      given: J. R.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      family: Reinert
+      given: K.
+      honourific:
+  - name:
+      family: Remington
+      honourific:
+      given: K. A.
+      lineage:
+  - name:
+      family: Schwartz
+      given: R.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      given: B.
+      honourific:
+      family: Walenz
+  - name:
+      lineage:
+      family: Yooseph
+      given: S.
+      honourific:
+  - name:
+      given: S.
+      honourific:
+      family: Istrail
+      lineage:
+- eprintid: 1976
+  refereed: 'TRUE'
+  number: 4
+  item_issues_count: 0
+  metadata_visibility: show
+  id_number: doi:10.1007/s00216-016-0013-z
+  full_text_status: none
+  date_type: published
+  eprint_status: archive
+  dir: disk0/00/00/19/76
+  issn: 1618-2642
+  date: 2017-02
+  pagerange: 989-997
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  volume: 409
+  official_url: http://dx.doi.org/10.1007/s00216-016-0013-z
+  ispublished: pub
+  lastmod: '2017-09-12 13:35:25'
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1976
+  creators:
+  - name:
+      family: Vatansever
+      honourific:
+      given: B.
+      lineage:
+  - name:
+      family: Muñoz
+      honourific:
+      given: A.
+      lineage:
+  - name:
+      lineage:
+      family: Klein
+      honourific:
+      given: C. L.
+  - name:
+      lineage:
+      honourific:
+      given: K.
+      family: Reinert
+  datestamp: '2016-11-03 11:34:05'
+  publication: Analytical and Bioanalytical Chemistry
+  title: Development and optimisation of a generic micro LC-ESI-MS method for the
+    qualitative and quantitative determination of 30-mer toxic gliadin peptides in
+    wheat flour for food analysis
+  abstract: We sometimes see manufactured bakery products on the market which are
+    labelled as being gluten free. Why is the content of such gluten proteins of importance
+    for the fabrication of bakery industry and for the products? The gluten proteins
+    represent up to 80 % of wheat proteins, and they are conventionally subdivided
+    into gliadins and glutenins. Gliadins belong to the proline and glutamine-rich
+    prolamin family. Its role in human gluten intolerance, as a consequence of its
+    harmful effects, is well documented in the scientific literature. The only known
+    therapy so far is a gluten-free diet, and hence, it is important to develop robust
+    and reliable analytical methods to quantitatively assess the presence of the identified
+    peptides causing the so-called coeliac disease. This work describes the development
+    of a new, fast and robust micro ion pair-LC-MS analytical method for the qualitative
+    and quantitative determination of 30-mer toxic gliadin peptides in wheat flour.
+    The use of RapiGest™ SF as a denaturation reagent prior to the enzymatic digestion
+    showed to shorten the measuring time. During the optimisation of the enzymatic
+    digestion step, the best 30-mer toxic peptide was identified from the maximum
+    recovery after 3 h of digestion time. The lower limit of quantification was determined
+    to be 0.25 ng/μL. The method has shown to be linear for the selected concentration
+    range of 0.25–3.0 ng/μL. The uncertainty related to reproducibility of measurement
+    procedure, excluding the extraction step, has shown to be 5.0 % (N = 12). Finally,
+    this method was successfully applied to the quantification of 30-mer toxic peptides
+    from commercial wheat flour with an overall uncertainty under reproducibility
+    conditions of 6.4 % including the extraction of the gliadin fraction. The results
+    were always expressed as the average of the values from all standard concentrations.
+    Subsequently, the final concentration of the 30-mer toxic peptide in the flour
+    was calculated and expressed in milligrams per gram unit. The determined, calculated
+    concentration of the 30-mer toxic peptide in the flour was found to be 1.29 ± 0.37
+    μg/g in flour (N = 25, sy = 545,075, f = 25 − 2 (t = 2.069), P = 95 %, two-sided).
+  status_changed: '2017-09-12 13:35:25'
+  userid: 132
+  type: article
+  publisher: Springer Berlin Heidelberg
+  rev_number: 13
+- eprint_status: archive
+  dir: disk0/00/00/04/11
+  pagerange: 1304-1351
+  date: 2001
+  volume: 291
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  number: 5507
+  eprintid: 411
+  refereed: 'TRUE'
+  item_issues_count: 0
+  full_text_status: public
+  date_type: published
+  metadata_visibility: show
+  creators:
+  - name:
+      lineage:
+      given: J. C.
+      honourific:
+      family: Venter
+  - name:
+      lineage:
+      family: Adams
+      given: M. D.
+      honourific:
+  - name:
+      honourific:
+      given: E. W.
+      family: Myers
+      lineage:
+  - name:
+      honourific:
+      given: K.
+      family: Reinert
+      lineage:
+  - name:
+      lineage:
+      family: et al
+      honourific:
+      given: "."
+  publication: Science
+  datestamp: '2009-11-24 15:43:17'
+  documents:
+  - rev_number: 3
+    language: en
+    files:
+    - datasetid: document
+      mtime: '2017-03-03 14:40:15'
+      fileid: 5222
+      objectid: 241
+      filename: Science_2001_VenterThe_sequence_of_the_human.pdf
+      uri: http://publications.imp.fu-berlin.de/id/file/5222
+      mime_type: application/pdf
+      filesize: 3474439
+    relation:
+    - type: http://eprints.org/relation/hasVersion
+      uri: "/id/document/1007"
+    - uri: "/id/document/1007"
+      type: http://eprints.org/relation/hasVolatileVersion
+    - type: http://eprints.org/relation/haspreviewThumbnailVersion
+      uri: "/id/document/1007"
+    format: application/pdf
+    mime_type: application/pdf
+    uri: http://publications.imp.fu-berlin.de/id/document/241
+    main: Science_2001_VenterThe_sequence_of_the_human.pdf
+    docid: 241
+    eprintid: 411
+    pos: 1
+    security: public
+  abstract: A 2.91-billion base pair (bp) consensus sequence of the euchromatic portion
+    of the human genome was generated by the whole-genome shotgun sequencing method.
+    The 14.8-billion bp DNA sequence was generated over 9 months from 27,271,853 high-quality
+    sequence reads (5.11-fold coverage of the genome) from both ends of plasmid clones
+    made from the DNA of five individuals. Two assembly strategies—a whole-genome
+    assembly and a regional chromosome assembly—were used, each combining sequence
+    data from Celera and the publicly funded genome effort. The public data were shredded
+    into 550-bp segments to create a 2.9-fold coverage of those genome regions that
+    had been sequenced, without including biases inherent in the cloning and assembly
+    procedure used by the publicly funded group. This brought the effective cov- erage
+    in the assemblies to eightfold, reducing the number and size of gaps in the final
+    assembly over what would be obtained with 5.11-fold coverage. The two assembly
+    strategies yielded very similar results that largely agree with independent mapping
+    data. The assemblies effectively cover the euchromatic regions of the human chromosomes.
+    More than 90% of the genome is in scaffold assemblies of 100,000 bp or more, and
+    25% of the genome is in scaffolds of 10 million bp or larger. Analysis of the
+    genome sequence revealed 26,588 protein-encoding transcripts for which there was
+    strong corroborating evidence and an additional
+  status_changed: '2009-03-11 11:27:33'
+  title: The Sequence of the Human Genome
+  rev_number: 10
+  type: article
+  userid: 1
+  keywords: ASSEMBLY
+  lastmod: '2017-03-03 14:40:15'
+  ispublished: pub
+  uri: http://publications.imp.fu-berlin.de/id/eprint/411
+- rev_number: 7
+  type: article
+  userid: 132
+  abstract: "Quality control is increasingly recognized as a crucial\r\naspect of
+    mass spectrometry based proteomics. Several\r\nrecent papers discuss relevant
+    parameters for quality\r\ncontrol and present applications to extract these from
+    the\r\ninstrumental raw data. What has been missing, however,\r\nis a standard
+    data exchange format for reporting these\r\nperformance metrics. We therefore
+    developed the qcML\r\nformat, an XML-based standard that follows the design\r\nprinciples
+    of the related mzML, mzIdentML, mzQuantML,\r\nand TraML standards from the HUPO-PSI
+    (Proteomics\r\nStandards Initiative). In addition to the XML format, we\r\nalso
+    provide tools for the calculation of a wide range of\r\nquality metrics as well
+    as a database format and interconversion tools, so that existing LIMS systems
+    can easily add relational storage of the quality control data to their existing
+    schema. We here describe the qcML specification, along with possible use cases
+    and an illustrative example of the subsequent analysis possibilities. All information
+    about qcML is available at http://code.google.com/p/qcml. Molecular & Cellular
+    Proteomics 13: 10.1074/mcp.M113.035907, 1905–1913, 2014."
+  status_changed: '2014-08-25 19:14:40'
+  title: 'qcML: An Exchange Format for Quality Control Metrics from Mass Spectrometry
+    Experiments'
+  publication: Molecular & Cellular Proteomics
+  datestamp: '2014-08-25 19:14:40'
+  creators:
+  - name:
+      family: Walzer
+      given: M.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      family: Pernas
+      given: L. E.
+      honourific:
+  - name:
+      family: Nasso
+      given: S.
+      honourific:
+      lineage:
+  - name:
+      honourific:
+      given: W.
+      family: Bittremieux
+      lineage:
+  - name:
+      lineage:
+      family: Nahnsen
+      given: S.
+      honourific:
+  - name:
+      lineage:
+      given: P.
+      honourific:
+      family: Kelchtermans
+  - name:
+      family: Pichler
+      given: P.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      family: van den Toorn
+      given: H. W. P.
+      honourific:
+  - name:
+      family: Staes
+      given: A.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: J.
+      family: Vandenbussche
+  - name:
+      family: Mazanek
+      given: M.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: T.
+      family: Taus
+  - name:
+      lineage:
+      family: Scheltema
+      given: R. A.
+      honourific:
+  - name:
+      honourific:
+      given: C. D.
+      family: Kelstrup
+      lineage:
+  - name:
+      family: Gatto
+      given: L.
+      honourific:
+      lineage:
+  - name:
+      family: van Breukelen
+      given: B.
+      honourific:
+      lineage:
+  - name:
+      family: Aiche
+      given: S.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      family: Valkenborg
+      honourific:
+      given: D.
+  - name:
+      lineage:
+      honourific:
+      given: K.
+      family: Laukens
+  - name:
+      lineage:
+      family: Lilley
+      given: K. S.
+      honourific:
+  - name:
+      family: Olsen
+      given: J. V.
+      honourific:
+      lineage:
+  - name:
+      family: Heck
+      honourific:
+      given: A. J. R.
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: K.
+      family: Mechtler
+  - name:
+      given: R.
+      honourific:
+      family: Aebersold
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: K.
+      family: Gevaert
+  - name:
+      family: Vizcaino
+      honourific:
+      given: J. A.
+      lineage:
+  - name:
+      family: Hermjakob
+      given: H.
+      honourific:
+      lineage:
+  - name:
+      family: Kohlbacher
+      given: O.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      family: Martens
+      honourific:
+      given: L.
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1449
+  ispublished: pub
+  lastmod: '2014-08-25 19:14:40'
+  official_url: http://dx.doi.org/10.1074/mcp.M113.035907
+  volume: 13
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  date: '2014-08-01'
+  pagerange: 1905-1913
+  issn: 1535-9476
+  dir: disk0/00/00/14/49
+  eprint_status: archive
+  full_text_status: none
+  date_type: published
+  metadata_visibility: show
+  id_number: doi:10.1074/mcp.M113.035907
+  item_issues_count: 0
+  number: 8
+  refereed: 'TRUE'
+  eprintid: 1449
+- metadata_visibility: show
+  date_type: published
+  full_text_status: none
+  item_issues_count: 0
+  eprintid: 1401
+  refereed: 'TRUE'
+  number: 1
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  volume: 43
+  date: 2014-03
+  dir: disk0/00/00/14/01
+  eprint_status: archive
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1401
+  lastmod: '2014-08-19 16:41:18'
+  ispublished: pub
+  official_url: http://www.sigmod.org/publications/sigmod-record/1403/index.html
+  userid: 132
+  type: article
+  rev_number: 11
+  title: State-of-the-art in String Similarity Search and Join
+  status_changed: '2014-08-19 16:41:18'
+  related_url:
+  - url: http://www2.informatik.hu-berlin.de/~wandelt/searchjoincompetition2013/
+  publication: SIGMOD Record
+  datestamp: '2014-03-18 16:51:01'
+  creators:
+  - id:
+    name:
+      family: Wandelt
+      honourific:
+      given: S.
+      lineage:
+  - name:
+      given: D.
+      honourific:
+      family: Deng
+      lineage:
+    id:
+  - id:
+    name:
+      lineage:
+      family: Gerdjikov
+      given: S.
+      honourific:
+  - id:
+    name:
+      lineage:
+      given: S.
+      honourific:
+      family: Mishra
+  - name:
+      family: Mitankin
+      given: P.
+      honourific:
+      lineage:
+    id:
+  - id:
+    name:
+      lineage:
+      family: Patil
+      honourific:
+      given: M.
+  - name:
+      lineage:
+      family: Siragusa
+      honourific:
+      given: E.
+    id: enrico.siragusa@fu-berlin.de
+  - id:
+    name:
+      lineage:
+      given: A.
+      honourific:
+      family: Tiskin
+  - name:
+      lineage:
+      family: Wang
+      given: W.
+      honourific:
+    id:
+  - id:
+    name:
+      lineage:
+      family: Wang
+      given: J.
+      honourific:
+  - name:
+      lineage:
+      given: U.
+      honourific:
+      family: Leser
+    id:
+- pagerange: 374-388
+  date: 2008-07
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  eprint_status: archive
+  dir: disk0/00/00/04/12
+  item_issues_count: 0
+  full_text_status: none
+  metadata_visibility: show
+  eprintid: 412
+  refereed: 'TRUE'
+  editors:
+  - name:
+      family: Perner
+      honourific:
+      given: P.
+      lineage:
+  abstract: " We propose a general approach for frequency based string mining,\twhich
+    has many applications, e.g. in contrast data mining. Our contribution\n\tis a
+    novel algorithm based on a deferred data structure. Despite\n\tits simplicity,
+    our approach is up to 4 times faster and uses about\n\thalf the memory compared
+    to the best-known algorithm of Fischer et\n\tal. Applications in various string
+    domains, e.g. natural language,\n\tDNA or protein sequences, demonstrate the improvement
+    of our algorithm."
+  status_changed: '2009-03-11 11:27:34'
+  title: "Efficient String Mining under Constraints via the Deferred Frequency\tIndex"
+  publisher: Springer Verlag
+  type: conference_item
+  rev_number: 3
+  userid: 1
+  creators:
+  - name:
+      given: D.
+      honourific:
+      family: Weese
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: M. H.
+      family: Schulz
+  datestamp: '2017-03-03 14:40:15'
+  lastmod: '2017-03-03 14:40:15'
+  ispublished: pub
+  uri: http://publications.imp.fu-berlin.de/id/eprint/412
+  event_title: Proceedings of the 8th Industrial Conference on Data Mining (ICDM'08)
+  official_url: http://www.springerlink.com/content/xr2q4w73m623xl52/
+- full_text_status: public
+  date_type: published
+  metadata_visibility: show
+  item_issues_count: 0
+  institution: Humboldt-University
+  eprintid: 457
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  date: '2006-05-02'
+  dir: disk0/00/00/04/57
+  eprint_status: archive
+  uri: http://publications.imp.fu-berlin.de/id/eprint/457
+  lastmod: '2017-03-03 14:40:19'
+  ispublished: pub
+  pages: 99
+  department: Computer Science
+  type: thesis
+  rev_number: 18
+  userid: 31
+  status_changed: '2009-05-06 09:48:11'
+  title: Entwurf und Implementierung eines generischen Substring-Index
+  datestamp: '2009-05-06 09:48:11'
+  thesis_type: other
+  documents:
+  - eprintid: 457
+    pos: 1
+    security: public
+    format: text/html
+    mime_type: application/pdf
+    main: weese06.pdf
+    uri: http://publications.imp.fu-berlin.de/id/document/183
+    docid: 183
+    files:
+    - fileid: 5704
+      filename: weese06.pdf
+      objectid: 183
+      datasetid: document
+      mtime: '2017-03-03 14:40:19'
+      uri: http://publications.imp.fu-berlin.de/id/file/5704
+      mime_type: application/pdf
+      filesize: 703072
+    language: en
+    relation:
+    - type: http://eprints.org/relation/hasVersion
+      uri: "/id/document/1022"
+    - type: http://eprints.org/relation/haspreviewThumbnailVersion
+      uri: "/id/document/1022"
+    - type: http://eprints.org/relation/hasVolatileVersion
+      uri: "/id/document/1022"
+    rev_number: 5
+  - content: accepted
+    mime_type: application/pdf
+    formatdesc: Diploma Thesis
+    uri: http://publications.imp.fu-berlin.de/id/document/184
+    main: weese06.pdf
+    docid: 184
+    format: application/pdf
+    security: public
+    license: cc_gnu_lgpl
+    eprintid: 457
+    pos: 2
+    rev_number: 4
+    files:
+    - mime_type: application/pdf
+      uri: http://publications.imp.fu-berlin.de/id/file/5707
+      filesize: 703072
+      fileid: 5707
+      objectid: 184
+      filename: weese06.pdf
+      datasetid: document
+      mtime: '2017-03-03 14:40:19'
+    language: en
+    relation:
+    - type: http://eprints.org/relation/hasVersion
+      uri: "/id/document/1023"
+    - uri: "/id/document/1023"
+      type: http://eprints.org/relation/haspreviewThumbnailVersion
+    - type: http://eprints.org/relation/hasVolatileVersion
+      uri: "/id/document/1023"
+  creators:
+  - id: weese@inf.fu-berlin.de
+    name:
+      lineage:
+      family: Weese
+      honourific:
+      given: D.
+- eprintid: 1288
+  institution: Freie Universität Berlin
+  item_issues_count: 0
+  metadata_visibility: show
+  date_type: published
+  full_text_status: public
+  eprint_status: archive
+  dir: disk0/00/00/12/88
+  date: '2013-06-05'
+  subjects:
+  - C
+  - G
+  divisions:
+  - group_algbioinf
+  keywords: HTS; full-text index; frequency string mining; read mapping; SeqAn
+  official_url: http://www.diss.fu-berlin.de/diss/receive/FUDISS_thesis_000000094456
+  department: Department of Mathematics and Computer Science
+  pages: 196
+  ispublished: pub
+  lastmod: '2017-03-03 14:41:25'
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1288
+  creators:
+  - id: david.weese@fu-berlin.de
+    name:
+      family: Weese
+      given: D.
+      honourific:
+      lineage:
+  documents:
+  - security: public
+    pos: 1
+    eprintid: 1288
+    docid: 554
+    uri: http://publications.imp.fu-berlin.de/id/document/554
+    main: thesis_weese12.pdf
+    mime_type: application/pdf
+    content: published
+    formatdesc: PhD Thesis
+    format: application/pdf
+    relation:
+    - type: http://eprints.org/relation/haspreviewThumbnailVersion
+      uri: "/id/document/1246"
+    - uri: "/id/document/1246"
+      type: http://eprints.org/relation/hasVolatileVersion
+    - type: http://eprints.org/relation/hasVersion
+      uri: "/id/document/1246"
+    language: en
+    files:
+    - uri: http://publications.imp.fu-berlin.de/id/file/16089
+      mime_type: application/pdf
+      filesize: 2839678
+      fileid: 16089
+      objectid: 554
+      filename: thesis_weese12.pdf
+      datasetid: document
+      mtime: '2017-03-03 14:41:25'
+    rev_number: 5
+  thesis_type: phd
+  datestamp: '2013-06-15 19:50:31'
+  title: Indices and Applications in High-Throughput Sequencing
+  status_changed: '2013-06-15 19:54:07'
+  abstract: "Recent advances in sequencing technology allow to produce billions of
+    base pairs per day in the form of reads of length 100 bp an longer and current
+    developments promise the personal $1,000 genome in a couple of years. The analysis
+    of these unprecedented amounts of data demands for efficient data structures and
+    algorithms. One such data structures is the substring index, that represents all
+    substrings or substrings up to a certain length contained in a given text.\r\nIn
+    this thesis we propose 3 substring indices, which we extend to be applicable to
+    millions of sequences. We devise internal and external memory construction algorithms
+    and a uniform framework for accessing the generalized suffix tree. Additionally
+    we propose different index-based applications, e.g. exact and approximate pattern
+    matching and different repeat search algorithms.\r\nSecond, we present the read
+    mapping tool RazerS, which aligns millions of single or paired-end reads of arbitrary
+    lengths to their potential genomic origin using either Hamming or edit distance.
+    Our tool can work either lossless or with a user-defined loss rate at higher speeds.
+    Given the loss rate, we present a novel approach that guarantees not to lose more
+    reads than specified. This enables the user to adapt to the problem at hand and
+    provides a seamless tradeoff between sensitivity and running time. We compare
+    RazerS with other state-of-the-art read mappers and show that it has the highest
+    sensitivity and a comparable performance on various real-world datasets.\r\nAt
+    last, we propose a general approach for frequency based string mining, which has
+    many applications, e.g. in contrast data mining. Our contribution is a novel and
+    lightweight algorithm that is faster and uses less memory than the best available
+    algorithms. We show its applicability for mining multiple databases with a variety
+    of frequency constraints. As such, we use the notion of entropy from information
+    theory to generalize the emerging substring mining problem to multiple databases.
+    To demonstrate the improvement of our algorithm we compared to recent approaches
+    on real-world experiments of various string domains, e.g. natural language, DNA,
+    or protein sequences."
+  userid: 30
+  type: thesis
+  rev_number: 19
+- full_text_status: public
+  date_type: published
+  id_number: 10.1101/gr.088823.108
+  metadata_visibility: show
+  item_issues_count: 0
+  number: 9
+  eprintid: 453
+  refereed: 'TRUE'
+  volume: 19
+  subjects:
+  - G400
+  divisions:
+  - group_algbioinf
+  date: '2009-07-10'
+  pagerange: 1646-1654
+  dir: disk0/00/00/04/53
+  eprint_status: archive
+  uri: http://publications.imp.fu-berlin.de/id/eprint/453
+  lastmod: '2017-03-03 14:40:18'
+  ispublished: pub
+  official_url: http://genome.cshlp.org/content/19/9/1646.abstract
+  type: article
+  rev_number: 17
+  userid: 31
+  status_changed: '2009-10-28 12:38:26'
+  abstract: Second-generation sequencing technologies deliver DNA sequence data at
+    unprecedented high throughput. Common to most biological applications is a mapping
+    of the reads to an almost identical or highly similar reference genome. Due to
+    the large amounts of data, eﬃcient algorithms and implementations are crucial
+    for this task. We present an eﬃcient read mapping tool called RazerS. It allows
+    the user to align sequencing reads of arbitrary length using either the Hamming
+    distance or the edit distance. Our tool can work either lossless or with a user-deﬁned
+    loss rate at higher speeds. Given the loss rate, we present an approach that guarantees
+    not to lose more reads than speciﬁed. This enables the user to adapt to the problem
+    at hand and provides a seamless tradeoﬀ between sensitivity and running time.
+  title: RazerS - Fast Read Mapping with Sensitivity Control
+  datestamp: '2009-05-06 09:46:43'
+  publication: Genome Research
+  documents:
+  - rev_number: 4
+    language: en
+    files:
+    - datasetid: document
+      mtime: '2017-03-03 14:40:18'
+      fileid: 5640
+      filename: Genome_Research_2009_WeeseRazerS--fast_read_mapping_with_sensitivity.pdf
+      objectid: 236
+      uri: http://publications.imp.fu-berlin.de/id/file/5640
+      mime_type: application/pdf
+      filesize: 477177
+    relation:
+    - type: http://eprints.org/relation/hasVolatileVersion
+      uri: "/id/document/1020"
+    - uri: "/id/document/1020"
+      type: http://eprints.org/relation/haspreviewThumbnailVersion
+    - uri: "/id/document/1020"
+      type: http://eprints.org/relation/hasVersion
+    format: application/pdf
+    content: published
+    mime_type: application/pdf
+    main: Genome_Research_2009_WeeseRazerS--fast_read_mapping_with_sensitivity.pdf
+    uri: http://publications.imp.fu-berlin.de/id/document/236
+    docid: 236
+    eprintid: 453
+    pos: 1
+    security: public
+  creators:
+  - name:
+      lineage:
+      given: D.
+      honourific:
+      family: Weese
+  - name:
+      family: Emde
+      given: A.-K.
+      honourific:
+      lineage:
+  - name:
+      honourific:
+      given: T.
+      family: Rausch
+      lineage:
+  - name:
+      lineage:
+      family: Döring
+      given: A.
+      honourific:
+  - name:
+      honourific:
+      given: K.
+      family: Reinert
+      lineage:
+- official_url: http://bioinformatics.oxfordjournals.org/content/28/20/2592
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1159
+  lastmod: '2017-03-03 14:41:14'
+  ispublished: pub
+  documents:
+  - eprintid: 1159
+    pos: 1
+    security: public
+    format: application/pdf
+    content: published
+    mime_type: application/pdf
+    formatdesc: Main Article
+    docid: 569
+    uri: http://publications.imp.fu-berlin.de/id/document/569
+    main: razers3.pdf
+    files:
+    - filesize: 195431
+      uri: http://publications.imp.fu-berlin.de/id/file/14153
+      mime_type: application/pdf
+      filename: razers3.pdf
+      objectid: 569
+      fileid: 14153
+      mtime: '2017-03-03 14:41:14'
+      datasetid: document
+    language: en
+    relation:
+    - type: http://eprints.org/relation/haspreviewThumbnailVersion
+      uri: "/id/document/1225"
+    - uri: "/id/document/1225"
+      type: http://eprints.org/relation/hasVolatileVersion
+    - type: http://eprints.org/relation/hasVersion
+      uri: "/id/document/1225"
+    rev_number: 4
+  - rev_number: 4
+    files:
+    - datasetid: document
+      mtime: '2017-03-03 14:41:14'
+      fileid: 14156
+      filename: supplement.pdf
+      objectid: 570
+      mime_type: application/pdf
+      uri: http://publications.imp.fu-berlin.de/id/file/14156
+      filesize: 324632
+    language: en
+    relation:
+    - uri: "/id/document/1226"
+      type: http://eprints.org/relation/hasVersion
+    - uri: "/id/document/1226"
+      type: http://eprints.org/relation/haspreviewThumbnailVersion
+    - uri: "/id/document/1226"
+      type: http://eprints.org/relation/hasVolatileVersion
+    formatdesc: Supplemental Material
+    content: supplemental
+    mime_type: application/pdf
+    uri: http://publications.imp.fu-berlin.de/id/document/570
+    main: supplement.pdf
+    docid: 570
+    format: application/pdf
+    security: public
+    eprintid: 1159
+    pos: 2
+  datestamp: '2012-09-11 14:33:09'
+  publication: Bioinformatics
+  creators:
+  - name:
+      family: Weese
+      honourific:
+      given: D.
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: M.
+      family: Holtgrewe
+  - name:
+      honourific:
+      given: K.
+      family: Reinert
+      lineage:
+  userid: 30
+  publisher: Oxford University Press
+  rev_number: 26
+  type: article
+  title: 'RazerS 3: Faster, fully sensitive read mapping'
+  abstract: "Motivation: During the last years NGS sequencing has become a key technology
+    for many applications in the biomedical sciences. Throughput continues to increase
+    and new protocols provide longer reads than currently available. In almost all
+    applications, read mapping is a first step. Hence, it is crucial to have algorithms
+    and implementations that perform fast, with high sensitivity, and are able to
+    deal with long reads and a large absolute number of indels.\r\n\r\nResults: RazerS
+    is a read mapping program with adjustable sensitivity based on counting q-grams.
+    In this work we propose the successor RazerS 3 which now supports shared-memory
+    parallelism, an additional seed-based filter with adjustable sensitivity, a much
+    faster, banded version of the Myers’ bit-vector algorithm for verification, memory
+    saving measures and support for the SAM output format. This leads to a much improved
+    performance for mapping reads, in particular long reads with many errors. We extensively
+    compare RazerS 3 with other popular read mappers and show that its results are
+    often superior to them in terms of sensitivity while exhibiting practical and
+    often competetive run times. In addition, RazerS 3 works without a precomputed
+    index.\r\n\r\nAvailability and Implementation: Source code and binaries are freely
+    available for download at http://www.seqan.de/projects/razers. RazerS 3 is implemented
+    in C++ and OpenMP under a GPL license using the SeqAn library and supports Linux,
+    Mac OS X, and Windows."
+  status_changed: '2013-08-10 09:35:00'
+  eprintid: 1159
+  refereed: 'TRUE'
+  number: 20
+  metadata_visibility: show
+  id_number: 10.1093/bioinformatics/bts505
+  date_type: published
+  full_text_status: public
+  item_issues_count: 0
+  dir: disk0/00/00/11/59
+  eprint_status: archive
+  subjects:
+  - C
+  - G
+  divisions:
+  - group_algbioinf
+  volume: 28
+  date: '2012-08-24'
+  pagerange: 2592-2599
+- publication: Toxicology in Vitro
+  datestamp: '2015-01-21 12:15:51'
+  creators:
+  - name:
+      lineage:
+      family: Wilmes
+      honourific:
+      given: Anja
+  - name:
+      lineage:
+      honourific:
+      given: Chris
+      family: Bielow
+  - name:
+      family: Ranninger
+      given: Christina
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      given: Patricia
+      honourific:
+      family: Bellwon
+  - name:
+      honourific:
+      given: Lydia
+      family: Aschauer
+      lineage:
+  - name:
+      lineage:
+      family: Limonciel
+      given: Alice
+      honourific:
+  - name:
+      lineage:
+      honourific:
+      given: Hubert
+      family: Chassaigne
+  - name:
+      lineage:
+      honourific:
+      given: Theresa
+      family: Kristl
+  - name:
+      given: Stephan
+      honourific:
+      family: Aiche
+      lineage:
+  - name:
+      family: Huber
+      honourific:
+      given: Christian G.
+      lineage:
+  - name:
+      lineage:
+      family: Guillou
+      honourific:
+      given: Claude
+  - name:
+      honourific:
+      given: Philipp
+      family: Hewitt
+      lineage:
+  - name:
+      lineage:
+      family: Leonard
+      given: Martin O.
+      honourific:
+  - name:
+      lineage:
+      given: Wolfgang
+      honourific:
+      family: Dekant
+  - name:
+      lineage:
+      family: Bois
+      given: Frederic
+      honourific:
+  - name:
+      family: Jennings
+      honourific:
+      given: Paul
+      lineage:
+  userid: 132
+  type: article
+  publisher: Elsevier B.V.
+  rev_number: 13
+  title: Mechanism of cisplatin proximal tubule toxicity revealed by integrating transcriptomics,
+    proteomics, metabolomics and biokinetics
+  abstract: Cisplatin is one of the most widely used chemotherapeutic agents for the
+    treatment of solid tumours. The major dose-limiting factor is nephrotoxicity,
+    in particular in the proximal tubule. Here, we use an integrated omics approach,
+    including transcriptomics, proteomics and metabolomics coupled to biokinetics
+    to identify cell stress response pathways induced by cisplatin. The human renal
+    proximal tubular cell line RPTEC/TERT1 was treated with sub-cytotoxic concentrations
+    of cisplatin (0.5 and 2μM) in a daily repeat dose treating regime for up to 14days.
+    Biokinetic analysis showed that cisplatin was taken up from the basolateral compartment,
+    transported to the apical compartment, and accumulated in cells over time. This
+    is in line with basolateral uptake of cisplatin via organic cation transporter
+    2 and bioactivation via gamma-glutamyl transpeptidase located on the apical side
+    of proximal tubular cells. Cisplatin affected several pathways including, p53
+    signalling, Nrf2 mediated oxidative stress response, mitochondrial processes,
+    mTOR and AMPK signalling. In addition, we identified novel pathways changed by
+    cisplatin, including eIF2 signalling, actin nucleation via the ARP/WASP complex
+    and regulation of cell polarization. In conclusion, using an integrated omic approach
+    together with biokinetics we have identified both novel and established mechanisms
+    of cisplatin toxicity.
+  status_changed: '2016-02-23 16:10:47'
+  official_url: http://dx.doi.org/10.1016/j.tiv.2014.10.006
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1488
+  ispublished: pub
+  lastmod: '2016-02-23 16:10:47'
+  dir: disk0/00/00/14/88
+  issn: 8872333
+  eprint_status: archive
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  volume: 30
+  date: '2015-12-25'
+  pagerange: 117-127
+  eprintid: 1488
+  refereed: 'TRUE'
+  number: 1, Part A
+  metadata_visibility: show
+  id_number: doi:10.1016/j.tiv.2014.10.006
+  date_type: published
+  full_text_status: none
+  item_issues_count: 0
+- uri: http://publications.imp.fu-berlin.de/id/eprint/2430
+  lastmod: '2020-04-02 11:57:40'
+  ispublished: pub
+  keywords: CRISPR-Cas9, Off-target detection, Variants, Genome editing
+  official_url: http://doi.org/10.1186/s12896-019-0535-5
+  userid: 132
+  type: article
+  rev_number: 5
+  title: 'VARSCOT: variant-aware detection and scoring enables sensitive and personalized
+    off-target detection for CRISPR-Cas9'
+  status_changed: '2020-04-02 11:57:40'
+  abstract: "Background\r\n\r\nNatural variations in a genome can drastically alter
+    the CRISPR-Cas9 off-target landscape by creating or removing sites. Despite the
+    resulting potential side-effects from such unaccounted for sites, current off-target
+    detection pipelines are not equipped to include variant information. To address
+    this, we developed VARiant-aware detection and SCoring of Off-Targets (VARSCOT).\r\n\r\nResults\r\n\r\nVARSCOT
+    identifies only 0.6% of off-targets to be common between 4 individual genomes
+    and the reference, with an average of 82% of off-targets unique to an individual.
+    VARSCOT is the most sensitive detection method for off-targets, finding 40 to
+    70% more experimentally verified off-targets compared to other popular software
+    tools and its machine learning model allows for CRISPR-Cas9 concentration aware
+    off-target activity scoring.\r\n\r\nConclusions\r\n\r\nVARSCOT allows researchers
+    to take genomic variation into account when designing individual or population-wide
+    targeting strategies. VARSCOT is available from https://github.com/BauerLab/VARSCOT."
+  publication: BMC Biotechnology
+  datestamp: '2020-04-02 11:57:40'
+  creators:
+  - name:
+      honourific:
+      given: Laurence O. W.
+      family: Wilson
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: Sara
+      family: Hetzel
+  - name:
+      family: Pockrandt
+      given: Christopher
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      given: Knut
+      honourific:
+      family: Reinert
+  - name:
+      lineage:
+      family: Bauer
+      honourific:
+      given: Denis C.
+  metadata_visibility: show
+  id_number: doi:10.1186/s12896-019-0535-5
+  full_text_status: none
+  date_type: published
+  refereed: 'TRUE'
+  eprintid: 2430
+  number: 1
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  volume: 19
+  date: '2019-06-27'
+  dir: disk0/00/00/24/30
+  issn: 1472-6750
+  eprint_status: archive
+- divisions:
+  - group_algbioinf
+  volume: 6
+  date: 2005
+  pagerange: http://www.biomedcentral.com/1471-2105/6/285
+  dir: disk0/00/00/04/14
+  eprint_status: archive
+  metadata_visibility: show
+  full_text_status: none
+  item_issues_count: 0
+  eprintid: 414
+  refereed: 'TRUE'
+  number: 285
+  userid: 1
+  type: article
+  rev_number: 3
+  title: "Transformation and other factors of the peptide mass spectormetry\tpairwise
+    peaklist comparison process"
+  status_changed: '2009-03-11 11:27:35'
+  publication: BMC Bioinformatics
+  datestamp: '2010-09-01 13:31:44'
+  creators:
+  - name:
+      lineage:
+      honourific:
+      given: E.
+      family: Wolski
+  - name:
+      lineage:
+      family: Lalowski
+      given: M.
+      honourific:
+  - name:
+      family: Martus
+      given: P.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: P.
+      family: Giavalisco
+  - name:
+      given: J.
+      honourific:
+      family: Gobom
+      lineage:
+  - name:
+      family: Sickmann
+      honourific:
+      given: A.
+      lineage:
+  - name:
+      family: Lehrach
+      given: H.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      family: Reinert
+      honourific:
+      given: K.
+  uri: http://publications.imp.fu-berlin.de/id/eprint/414
+  ispublished: pub
+  lastmod: '2010-09-01 13:31:44'
+- eprintid: 413
+  refereed: 'TRUE'
+  number: 203
+  item_issues_count: 0
+  metadata_visibility: show
+  full_text_status: none
+  eprint_status: archive
+  dir: disk0/00/00/04/13
+  date: 2005
+  pagerange: http://www.biomedcentral.com/1471-2105/6/203
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  volume: 6
+  ispublished: pub
+  lastmod: '2017-03-03 14:40:15'
+  uri: http://publications.imp.fu-berlin.de/id/eprint/413
+  creators:
+  - name:
+      lineage:
+      honourific:
+      given: W. E.
+      family: Wolski
+  - name:
+      family: Lalowski
+      given: M.
+      honourific:
+      lineage:
+  - name:
+      family: Jungblut
+      given: P.
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      honourific:
+      given: K.
+      family: Reinert
+  publication: BMC Bioinformatics
+  datestamp: '2017-03-03 14:40:15'
+  title: "Calibration of mass spectrometric peptide mass fingerprint data without\tspecific
+    external or internal calibrants"
+  status_changed: '2009-03-11 11:27:34'
+  userid: 1
+  type: article
+  rev_number: 3
+- number: 18
+  eprintid: 415
+  refereed: 'TRUE'
+  date_type: published
+  full_text_status: none
+  metadata_visibility: show
+  item_issues_count: 0
+  dir: disk0/00/00/04/15
+  eprint_status: archive
+  volume: 4
+  subjects:
+  - G400
+  divisions:
+  - group_algbioinf
+  pagerange: doi:10.1186/1477-5956
+  date: 2006
+  uri: http://publications.imp.fu-berlin.de/id/eprint/415
+  lastmod: '2010-09-01 13:22:44'
+  ispublished: pub
+  publication: Proteome Science
+  datestamp: '2009-03-11 12:37:50'
+  creators:
+  - name:
+      lineage:
+      honourific:
+      given: W. E.
+      family: Wolski
+  - name:
+      lineage:
+      family: Farrow
+      given: M.
+      honourific:
+  - name:
+      honourific:
+      given: A.-K.
+      family: Emde
+      lineage:
+  - name:
+      family: Maciej
+      given: L.
+      honourific:
+      lineage:
+  - name:
+      given: H.
+      honourific:
+      family: Lehrach
+      lineage:
+  - name:
+      family: Reinert
+      given: K.
+      honourific:
+      lineage:
+  rev_number: 9
+  type: article
+  userid: 1
+  status_changed: '2009-03-11 12:37:50'
+  title: Analytical model of peptide mass cluster centres with applications
+- id_number: 'doi: 10.1186/1471-2105-14-56'
+  metadata_visibility: show
+  full_text_status: none
+  date_type: published
+  item_issues_count: 0
+  eprintid: 1400
+  refereed: 'TRUE'
+  number: 1
+  subjects:
+  - G400
+  divisions:
+  - group_algbioinf
+  volume: 14
+  pagerange: 56
+  date: '2013-02-18'
+  dir: disk0/00/00/14/00
+  issn: 1471-2105
+  eprint_status: archive
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1400
+  lastmod: '2014-03-18 16:04:51'
+  ispublished: pub
+  official_url: http://www.biomedcentral.com/1471-2105/14/56
+  userid: 132
+  publisher: BioMed Central
+  rev_number: 9
+  type: article
+  title: Optimal precursor ion selection for LC-MALDI MS/MS
+  abstract: "Background\r\nLiquid chromatography mass spectrometry (LC-MS) maps in
+    shotgun proteomics are often too complex to select every detected peptide signal
+    for fragmentation by tandem mass spectrometry (MS/MS). Standard methods for precursor
+    ion selection, commonly based on data dependent acquisition, select highly abundant
+    peptide signals in each spectrum. However, these approaches produce redundant
+    information and are biased towards high-abundance proteins.\r\n\r\nResults\r\nWe
+    present two algorithms for inclusion list creation that formulate precursor ion
+    selection as an optimization problem. Given an LC-MS map, the first approach maximizes
+    the number of selected precursors given constraints such as a limited number of
+    acquisitions per RT fraction. Second, we introduce a protein sequence-based inclusion
+    list that can be used to monitor proteins of interest. Given only the protein
+    sequences, we create an inclusion list that optimally covers the whole protein
+    set. Additionally, we propose an iterative precursor ion selection that aims at
+    reducing the redundancy obtained with data dependent LC-MS/MS. We overcome the
+    risk of erroneous assignments by including methods for retention time and proteotypicity
+    predictions. We show that our method identifies a set of proteins requiring fewer
+    precursors than standard approaches. Thus, it is well suited for precursor ion
+    selection in experiments with limited sample amount or analysis time.\r\n\r\nConclusions\r\nWe
+    present three approaches to precursor ion selection with LC-MALDI MS/MS. Using
+    a well-defined protein standard and a complex human cell lysate, we demonstrate
+    that our methods outperform standard approaches. Our algorithms are implemented
+    as part of OpenMS and are available under http://www.openms.de.\r\n"
+  status_changed: '2014-03-18 16:04:51'
+  datestamp: '2014-03-18 15:56:36'
+  publication: BMC Bioinformatics
+  creators:
+  - name:
+      given: A.
+      honourific:
+      family: Zerck
+      lineage:
+    id:
+  - name:
+      lineage:
+      family: Nordhoff
+      honourific:
+      given: E.
+    id: nordhoff@molgen.mpg.de
+  - id: lehrach@molgen.mpg.de
+    name:
+      given: H.
+      honourific:
+      family: Lehrach
+      lineage:
+  - name:
+      family: Reinert
+      honourific:
+      given: K.
+      lineage:
+    id: knut.reinert@fu-berlin.de
+- status_changed: '2009-10-28 12:43:45'
+  abstract: Currently, the precursor ion selection strategies in LC-MS mainly choose
+    the most prominent peptide signals for MS/MS analysis. Consequently, high abundant
+    proteins are identified by MS/MS of many peptides whereas proteins of lower abundance
+    might elude identification. We present a novel, iterative and result-driven approach
+    for precursor ion selection that significantly increases the efficiency of an
+    MS/MS analysis by decreasing data redundancy and analysis time. By simulating
+    different strategies for precursor ion selection on an existing dataset we compare
+    our method to existing result-driven strategies and evaluate its performance with
+    regard to mass accuracy, database size, and sample complexity.
+  title: An iterative strategy for precursor ion selection for LC-MS/MS based shotgun
+    proteomics
+  publisher: American Chemical Society
+  type: article
+  rev_number: 21
+  userid: 29
+  creators:
+  - id: zerck@molgen.mpg.de
+    name:
+      lineage:
+      family: Zerck
+      given: A.
+      honourific:
+  - id: nordhoff@molgen.mpg.de
+    name:
+      lineage:
+      family: Nordhoff
+      given: E.
+      honourific:
+  - id:
+    name:
+      lineage:
+      family: Reseman
+      honourific:
+      given: A.
+  - name:
+      family: Mirgorodskaya
+      given: E.
+      honourific:
+      lineage:
+    id:
+  - name:
+      family: Suckau
+      given: D.
+      honourific:
+      lineage:
+    id:
+  - id: knut.reinert@fu-berlin.de
+    name:
+      honourific:
+      given: K.
+      family: Reinert
+      lineage:
+  - id: lehrach@molgen.mpg.de
+    name:
+      lineage:
+      family: Lehrach
+      given: H.
+      honourific:
+  - id:
+    name:
+      family: Gobom
+      given: J.
+      honourific:
+      lineage:
+  datestamp: '2009-06-02 23:02:45'
+  publication: Journal of Proteome Research
+  lastmod: '2010-09-01 13:27:23'
+  ispublished: pub
+  uri: http://publications.imp.fu-berlin.de/id/eprint/456
+  official_url: http://pubs.acs.org/doi/abs/10.1021/pr800835x
+  date: '2009-04-30'
+  divisions:
+  - group_algbioinf
+  subjects:
+  - C790
+  - C730
+  - G490
+  eprint_status: archive
+  dir: disk0/00/00/04/56
+  item_issues_count: 0
+  date_type: published
+  full_text_status: none
+  id_number: " 10.1021/pr800835x"
+  metadata_visibility: show
+  eprintid: 456
+  refereed: 'TRUE'
+- eprintid: 2128
+  refereed: 'TRUE'
+  number: 24
+  id_number: doi:10.1002/jssc.201600749
+  metadata_visibility: show
+  full_text_status: none
+  date_type: published
+  eprint_status: archive
+  dir: disk0/00/00/21/28
+  issn: 16159306
+  pagerange: 4756-4764
+  date: '2016-11-28'
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  volume: 39
+  official_url: http://doi.org/10.1002/jssc.201600749
+  ispublished: pub
+  lastmod: '2017-11-22 13:19:29'
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2128
+  creators:
+  - name:
+      lineage:
+      given: Martin
+      honourific:
+      family: Zühlke
+  - name:
+      lineage:
+      honourific:
+      given: Daniel
+      family: Riebe
+  - name:
+      family: Beitz
+      honourific:
+      given: Toralf
+      lineage:
+  - name:
+      honourific:
+      given: Hans-Gerd
+      family: Löhmannsröben
+      lineage:
+  - name:
+      honourific:
+      given: Sandro
+      family: Andreotti
+      lineage:
+  - name:
+      lineage:
+      family: Reinert
+      honourific:
+      given: Knut
+  - name:
+      given: Karl
+      honourific:
+      family: Zenichowski
+      lineage:
+  - name:
+      family: Diener
+      honourific:
+      given: Marc
+      lineage:
+  datestamp: '2017-11-22 13:04:29'
+  publication: Journal of Separation Science
+  title: 'High-performance liquid chromatography with electrospray ionization ion
+    mobility spectrometry: Characterization, data management, and applications'
+  abstract: The combination of high-performance liquid chromatography and electrospray
+    ionization ion mobility spectrometry facilitates the two-dimensional separation
+    of complex mixtures in the retention and drift time plane. The ion mobility spectrometer
+    presented here was optimized for flow rates customarily used in high-performance
+    liquid chromatography between 100 and 1500 μL/min. The characterization of the
+    system with respect to such parameters as the peak capacity of each time dimension
+    and of the 2D spectrum was carried out based on a separation of a pesticide mixture
+    containing 24 substances. While the total ion current chromatogram is coarsely
+    resolved, exhibiting coelutions for a number of compounds, all substances can
+    be separately detected in the 2D plane due to the orthogonality of the separations
+    in retention and drift dimensions. Another major advantage of the ion mobility
+    detector is the identification of substances based on their characteristic mobilities.
+    Electrospray ionization allows the detection of substances lacking a chromophore.
+    As an example, the separation of a mixture of 18 amino acids is presented. A software
+    built upon the free mass spectrometry package OpenMS was developed for processing
+    the extensive 2D data. The different processing steps are implemented as separate
+    modules which can be arranged in a graphic workflow facilitating automated processing
+    of data.
+  status_changed: '2017-11-22 13:04:29'
+  userid: 132
+  publisher: Wiley
+  type: article
+  rev_number: 6
+- metadata_visibility: show
+  full_text_status: none
+  date_type: published
+  item_issues_count: 0
+  event_type: workshop
+  pres_type: paper
+  eprintid: 1441
+  refereed: 'TRUE'
+  subjects:
+  - G400
+  divisions:
+  - group_algbioinf
+  date: 2013
+  dir: disk0/00/00/14/41
+  eprint_status: archive
+  event_dates: 3-5 June 2013
+  event_title: IWSG (International Workshop on Science Gateways)
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1441
+  lastmod: '2014-08-19 14:26:35'
+  ispublished: pub
+  event_location: Zurich, Switzerland
+  official_url: http://www.informatik.uni-trier.de/~ley/db/conf/iwsg/iwsg2013.html
+  userid: 132
+  rev_number: 17
+  type: conference_item
+  title: 'From the Desktop to the Grid: conversion of KNIME Workflows to gUSE'
+  abstract: "The Konstanz Information Miner is a user-friendly\r\ngraphical workflow
+    designer with a broad user base in industry and academia. Its broad range of embedded
+    tools and its powerful data mining and visualization tools render it ideal for
+    scientific workflows. It is thus used more and more in a broad range of applications.
+    However, the free version typically runs on a desktop computer, restricting users
+    if they want to tap into computing power. The grid and cloud User Support Environment
+    is a free and open source project created for parallelized and distributed systems,
+    but the creation of workflows with the included components has a steeper learning
+    curve.\r\nIn this work we suggest an easy to implement solution\r\ncombining the
+    ease-of-use of the Konstanz Information Miner\r\nwith the computational power
+    of distributed computing infrastructures. We present a solution permitting the
+    conversion of workflows between the two platforms. This enables a convenient development,
+    debugging, and maintenance of scientific workflows on the desktop. These workflows
+    can then be deployed on a cloud or grid, thus permitting large-scale computation.\r\nTo
+    achieve our goals, we relied on a Common Tool Description\r\nXML file format which
+    describes the execution of arbitrary\r\nprograms in a structured and easily readable
+    and parseable way. In order to integrate external programs into we employed the
+    Generic KNIME Nodes extension."
+  status_changed: '2014-08-19 14:26:35'
+  contact_email: stephan.aiche@fu-berlin.de
+  datestamp: '2014-08-19 14:26:35'
+  creators:
+  - name:
+      family: de la Garza
+      given: L.
+      honourific:
+      lineage:
+    id:
+  - name:
+      family: Krüger
+      given: J.
+      honourific:
+      lineage:
+    id:
+  - name:
+      lineage:
+      family: Schärfe
+      honourific:
+      given: Ch.
+    id:
+  - id:
+    name:
+      lineage:
+      family: Röttig
+      honourific:
+      given: M.
+  - id:
+    name:
+      lineage:
+      family: Aiche
+      honourific:
+      given: S.
+  - name:
+      family: Reinert
+      honourific:
+      given: K.
+      lineage:
+    id: knut.reinert@fu-berlin.de
+  - name:
+      lineage:
+      family: Kohlbacher
+      honourific:
+      given: O.
+    id:
+- id_number: doi:10.1186/s12859-016-0978-9
+  metadata_visibility: show
+  date_type: published
+  full_text_status: none
+  refereed: 'TRUE'
+  eprintid: 2130
+  number: 1
+  divisions:
+  - group_algbioinf
+  subjects:
+  - G400
+  volume: 17
+  date: '2016-03-12'
+  dir: disk0/00/00/21/30
+  issn: 1471-2105
+  eprint_status: archive
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2130
+  lastmod: '2017-11-22 13:42:20'
+  ispublished: pub
+  official_url: http://doi.org/10.1186/s12859-016-0978-9
+  userid: 132
+  publisher: Springer Nature
+  type: article
+  rev_number: 5
+  title: 'From the desktop to the grid: scalable bioinformatics via workflow conversion'
+  status_changed: '2017-11-22 13:42:20'
+  abstract: "Background\r\n\r\nReproducibility is one of the tenets of the scientific
+    method. Scientific experiments often comprise complex data flows, selection of
+    adequate parameters, and analysis and visualization of intermediate and end results.
+    Breaking down the complexity of such experiments into the joint collaboration
+    of small, repeatable, well defined tasks, each with well defined inputs, parameters,
+    and outputs, offers the immediate benefit of identifying bottlenecks, pinpoint
+    sections which could benefit from parallelization, among others. Workflows rest
+    upon the notion of splitting complex work into the joint effort of several manageable
+    tasks.\r\n\r\nThere are several engines that give users the ability to design
+    and execute workflows. Each engine was created to address certain problems of
+    a specific community, therefore each one has its advantages and shortcomings.
+    Furthermore, not all features of all workflow engines are royalty-free —an aspect
+    that could potentially drive away members of the scientific community.\r\n\r\nResults\r\n\r\nWe
+    have developed a set of tools that enables the scientific community to benefit
+    from workflow interoperability. We developed a platform-free structured representation
+    of parameters, inputs, outputs of command-line tools in so-called Common Tool
+    Descriptor documents. We have also overcome the shortcomings and combined the
+    features of two royalty-free workflow engines with a substantial user community:
+    the Konstanz Information Miner, an engine which we see as a formidable workflow
+    editor, and the Grid and User Support Environment, a web-based framework able
+    to interact with several high-performance computing resources. We have thus created
+    a free and highly accessible way to design workflows on a desktop computer and
+    execute them on high-performance computing resources.\r\n\r\nConclusions\r\n\r\nOur
+    work will not only reduce time spent on designing scientific workflows, but also
+    make executing workflows on remote high-performance computing resources more accessible
+    to technically inexperienced users. We strongly believe that our efforts not only
+    decrease the turnaround time to obtain scientific results but also have a positive
+    impact on reproducibility, thus elevating the quality of obtained scientific results."
+  publication: BMC Bioinformatics
+  datestamp: '2017-11-22 13:42:20'
+  creators:
+  - name:
+      lineage:
+      family: de la Garza
+      given: Luis
+      honourific:
+  - name:
+      family: Veit
+      given: Johannes
+      honourific:
+      lineage:
+  - name:
+      lineage:
+      family: Szolek
+      given: Andras
+      honourific:
+  - name:
+      lineage:
+      given: Marc
+      honourific:
+      family: Röttig
+  - name:
+      lineage:
+      honourific:
+      given: Stephan
+      family: Aiche
+  - name:
+      lineage:
+      honourific:
+      given: Sandra
+      family: Gesing
+  - name:
+      lineage:
+      family: Reinert
+      given: Knut
+      honourific:
+  - name:
+      lineage:
+      given: Oliver
+      honourific:
+      family: Kohlbacher

--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -18,7 +18,7 @@
   abstract: "This proceedings volume contains papers presented at the 17th Workshop
     on Algorithms in Bioinformatics (WABI 2017), which was held in Boston, MA, USA
     in conjunction with the 8th ACM Conference on Bioinformatics, Computational Biology,
-    and Health Informatics (ACM BCB) from August 21–23, 2017.\r\nThe Workshop on Algorithms
+    and Health Informatics (ACM BCB) from August 21–23, 2017.The Workshop on Algorithms
     in Bioinformatics is an annual conference established in 2001 to cover all aspects
     of algorithmic work in bioinformatics, computational biology, and systems biology.
     The workshop is intended as a forum for discrete algorithms and machine-learning
@@ -26,29 +26,29 @@
     on sound models, that are computationally efficient, and that have been implemented
     and tested in simulations and on real datasets. The meeting’s focus is on recent
     research results, including significant work-in-progress, as well as identifying
-    and explore directions of future research.\r\nWABI 2017 is grateful for the support
+    and explore directions of future research.WABI 2017 is grateful for the support
     of ACM-BCB in allowing us to cohost the meetings, as well as to ACM-BCB’s sponsors:
-    the Association for Computing Machinery (ACM) and ACM’s SIGBIO.\r\nIn 2017, a
+    the Association for Computing Machinery (ACM) and ACM’s SIGBIO.In 2017, a
     total of 55 manuscripts were submitted to WABI from which 27 were selected for
     presentation at the conference. This year, WABI is adopting a new proceedings
     form, publishing the conference proceedings through the LIPIcs (Leibniz International
     Proceedings in Informatics) proceedings series. Extended versions of selected
     papers will be invited for publication in a thematic series in the journal Algorithms
-    for Molecular Biology (AMB), published by BioMed Central.\r\nThe 27 papers were
+    for Molecular Biology (AMB), published by BioMed Central.The 27 papers were
     selected based on a thorough peer review, involving at least three independent
     reviewers per submitted paper, followed by discussions among the WABI Program
     Committee members. The selected papers cover a wide range of topics, including
     statistical inference, phylogenetic studies, sequence and genome analysis, comparative
-    genomics, and mass spectrometry data analysis.\r\nWe thank all the authors of
+    genomics, and mass spectrometry data analysis.We thank all the authors of
     submitted papers and the members of the WABI Program Committee and their reviewers
     for their efforts that made this conference possible. We are also grateful to
     the WABI Steering Committee for their help and advice. We also thank all the conference
-    participants and speakers who contribute to a great scientific program. In\r\nparticular,
+    participants and speakers who contribute to a great scientific program. Inparticular,
     we are indebted to the keynote speaker of the conference, Tandy Warnow, for her
-    presentation. We also thank Christopher Pockrandt for setting up the WABI webpage\r\nand
+    presentation. We also thank Christopher Pockrandt for setting up the WABI webpageand
     Umit Acar for his help with coordinating the WABI and ACM-BCB pages. Finally,
     we thank the ACM-BCB Organizing Committee, especially Nurit Haspel and Lenore
-    Cowen,\r\nfor their hard work in making all of the local arrangements and working
+    Cowen,for their hard work in making all of the local arrangements and working
     closely with us to ensure a successful and exciting WABI and ACM-BCB."
   editors:
   - id:
@@ -108,28 +108,28 @@
   uri: http://publications.imp.fu-berlin.de/id/eprint/1143
   official_url: http://dx.plos.org/10.1371/journal.pone.0040656
   abstract: "Background: Proteases play an essential part in a variety of biological
-    processes. Beside their importance\r\nunder healthy conditions they are also known
-    to have a crucial role in complex diseases like cancer.\r\nIt was shown in the
-    last years that not only the fragments produced by proteases but also their dynamics,\r\nespecially
+    processes. Beside their importanceunder healthy conditions they are also known
+    to have a crucial role in complex diseases like cancer.It was shown in the
+    last years that not only the fragments produced by proteases but also their dynamics,especially
     ex vivo, can serve as biomarkers. But so far, only a few approaches were taken
-    to explicitly\r\nmodel the dynamics of proteolysis in the context of mass spectrometry.\r\n\r\nResults:
+    to explicitlymodel the dynamics of proteolysis in the context of mass spectrometry.Results:
     We introduce a new concept model proteolytic processes, the degradation graph.
-    The degra-\r\ndation graph is an extension of the cleavage graph, a data structure
-    to reconstruct and visualize the\r\nproteolytic process. In contrast to previous
-    approaches we extended the model to incorporate endoproteolytic\r\nprocesses and
-    present a method to construct a degradation graph from mass spectrometry\r\ntime-series
+    The degra-dation graph is an extension of the cleavage graph, a data structure
+    to reconstruct and visualize theproteolytic process. In contrast to previous
+    approaches we extended the model to incorporate endoproteolyticprocesses and
+    present a method to construct a degradation graph from mass spectrometrytime-series
     data. Based on a degradation graph and the intensities extracted from the mass
-    spectra it is\r\npossible to estimate reaction rates of the underlying processes.
-    We further suggest a score to rate different\r\ndegradation graphs in their ability
-    to explain the observed data. This score is used in an iterative\r\nheuristic
-    to improve the structure of the initially constructed degradation graph.\r\n\r\nConclusion:
-    We show that the proposed method is able to recover all degraded and generated\r\npeptides,
+    spectra it ispossible to estimate reaction rates of the underlying processes.
+    We further suggest a score to rate differentdegradation graphs in their ability
+    to explain the observed data. This score is used in an iterativeheuristic
+    to improve the structure of the initially constructed degradation graph.Conclusion:
+    We show that the proposed method is able to recover all degraded and generatedpeptides,
     the underlying reactions, and the reaction rates of proteolytic processes based
-    on mass spectrometry\r\ntime-series data. We use simulated and real data to demonstrate
-    that a given process can be\r\nreconstructed even in the presence of extensive
-    noise, isobaric signals and false identications. While the\r\nmodel is currently
+    on mass spectrometrytime-series data. We use simulated and real data to demonstrate
+    that a given process can bereconstructed even in the presence of extensive
+    noise, isobaric signals and false identications. While themodel is currently
     only validated on peptide data it is also applicable to proteins, as long as the
-    necessary\r\ntime series data can be produced."
+    necessarytime series data can be produced."
   status_changed: '2013-04-10 11:52:42'
   title: Inferring Proteolytic Processes from Mass Spectrometry Time Series Data Using
     Degradation Graphs
@@ -389,14 +389,14 @@
   dir: disk0/00/00/03/26
   eprint_status: archive
   uri: http://publications.imp.fu-berlin.de/id/eprint/326
-  event_title: "Proceedings of the 1st European Conference on Computational Biology\t(ECCB
+  event_title: "Proceedings of the 1st European Conference on Computational Biology(ECCB
     2002)"
   lastmod: '2017-03-03 14:40:13'
   ispublished: pub
   userid: 1
   type: conference_item
   rev_number: 3
-  title: "Multiple Sequence alignment with arbitrary gap costs: Computing an\toptimal
+  title: "Multiple Sequence alignment with arbitrary gap costs: Computing anoptimal
     solution using polyhedral combinatorics"
   status_changed: '2009-03-11 11:26:44'
   datestamp: '2017-03-03 14:40:13'
@@ -853,11 +853,11 @@
   type: monograph
   title: Approximating Minimum Spanning Sets in Hypergraphs and Polymatroids
   status_changed: '2009-03-11 11:26:46'
-  keywords: "Hypergraphs, set systems, and designs, Steiner trees, Approximation\talgorithms,
-    Colouring, packing and covering, Combinatorial optimization,\r\n\tGraph algorithms"
+  keywords: "Hypergraphs, set systems, and designs, Steiner trees, Approximationalgorithms,
+    Colouring, packing and covering, Combinatorial optimization,Graph algorithms"
   uri: http://publications.imp.fu-berlin.de/id/eprint/329
-  note: "This paper was already accepted for ICALP 2000 but we did not present\tit
-    since later we were informed that the main result had already\r\n\tbeen proven
+  note: "This paper was already accepted for ICALP 2000 but we did not presentit
+    since later we were informed that the main result had alreadybeen proven
     in a different way."
   lastmod: '2009-04-14 14:41:05'
   ispublished: pub
@@ -887,7 +887,7 @@
   eprintid: 331
   refereed: 'TRUE'
   status_changed: '2009-03-11 11:26:47'
-  title: "An Exact Mathematical Programming Approach to Multiple RNA Sequence-Structure\tAlignment."
+  title: "An Exact Mathematical Programming Approach to Multiple RNA Sequence-StructureAlignment."
   type: article
   rev_number: 3
   userid: 1
@@ -917,7 +917,7 @@
   rev_number: 3
   userid: 1
   status_changed: '2009-03-11 11:26:49'
-  title: "Fast and Accurate Structural RNA Alignment by Progressive Lagrangian\tRelaxation"
+  title: "Fast and Accurate Structural RNA Alignment by Progressive LagrangianRelaxation"
   datestamp: '2017-03-03 14:40:13'
   creators:
   - name:
@@ -936,7 +936,7 @@
       family: Reinert
       lineage:
   uri: http://publications.imp.fu-berlin.de/id/eprint/334
-  event_title: "Proceedings of the 1st International Symposium on Computational Life\tScience
+  event_title: "Proceedings of the 1st International Symposium on Computational LifeScience
     (CompLife-05)"
   lastmod: '2017-03-03 14:40:13'
   ispublished: pub
@@ -1008,7 +1008,7 @@
   - G400
   lastmod: '2017-03-03 14:40:13'
   ispublished: pub
-  event_title: "Proceedings of the 15th International Symposium, ISAAC 2004, Hong\tKong"
+  event_title: "Proceedings of the 15th International Symposium, ISAAC 2004, HongKong"
   uri: http://publications.imp.fu-berlin.de/id/eprint/330
   creators:
   - name:
@@ -1047,7 +1047,7 @@
   datestamp: '2017-03-03 14:40:13'
   publication: BMC Bioinformatics
   status_changed: '2009-03-11 11:26:48'
-  title: "Accurate multiple sequence-structure alignment of RNA sequences using\tcombinatorial
+  title: "Accurate multiple sequence-structure alignment of RNA sequences usingcombinatorial
     optimization."
   rev_number: 3
   type: article
@@ -1135,18 +1135,18 @@
   publication: Algorithms and Molecular Sciences
   status_changed: '2009-10-28 12:51:35'
   abstract: "This work presents a generalized approach for the fast structural alignment
-    \r\nof thousands of macromolecular structures. The method uses string representations
+    of thousands of macromolecular structures. The method uses string representations
     of a macromolecular structure and a hash table that stores n-grams of a certain
-    size for searching. \r\nTo this end, macromolecular structure-to-string translators
+    size for searching. To this end, macromolecular structure-to-string translators
     were implemented for protein and RNA structures. A query against the index is
     performed in two hierarchical steps to unite speed and precision. In the ﬁrst
     step the query structure is translated into n-grams, and all target structures
-    containing these n-grams are retrieved from the hash table. In the second \r\nstep
+    containing these n-grams are retrieved from the hash table. In the second step
     all corresponding n-grams of the query and each target structure are subsequently
     aligned, and after each alignment a score is calculated based on the matching
     n-grams of query and target. The extendable framework enables the user to query
     and structurally align thousands of protein and RNA structures on a commodity
-    machine and is available as \r\nopen source from http://la jolla.sf.net. "
+    machine and is available as open source from http://la jolla.sf.net. "
   title: Fast Structural Alignment of Biomolecules Using a Hash Table, N-Grams and
     String Descriptors
   type: article
@@ -1344,38 +1344,38 @@
   title: Quantification and Simulation of Liquid Chromatography-Mass Spectrometry
     Data
   abstract: "Computational mass spectrometry is a fast evolving field that has attracted
-    increased attention over the last couple of years.\r\nThe performance of software
+    increased attention over the last couple of years.The performance of software
     solutions determines the success of analysis to a great extent. New algorithms
     are required to reflect new experimental procedures and deal with new instrument
-    generations.\r\n\r\nOne essential component of algorithm development is the validation
-    (as well as comparison) of software on a broad range of\r\ndata sets. This requires
+    generations.One essential component of algorithm development is the validation
+    (as well as comparison) of software on a broad range ofdata sets. This requires
     a gold standard (or so-called ground truth), which is usually obtained by manual
-    annotation of a real data set.\r\nComprehensive manually annotated public data
+    annotation of a real data set.Comprehensive manually annotated public data
     sets for mass spectrometry data are labor-intensive to produce and their quality
-    strongly depends on \r\nthe skill of the human expert. Some parts of the data
-    may even be impossible to annotate due to high levels of noise or other ambiguities.\r\nFurthermore,
+    strongly depends on the skill of the human expert. Some parts of the data
+    may even be impossible to annotate due to high levels of noise or other ambiguities.Furthermore,
     manually annotated data is usually not available for all steps in a typical computational
-    analysis pipeline.\r\nWe thus developed the most comprehensive simulation software
-    to date, which allows to generate multiple levels of ground truth\r\nand features
-    a plethora of settings to reflect experimental conditions and instrument settings.\r\nThe
+    analysis pipeline.We thus developed the most comprehensive simulation software
+    to date, which allows to generate multiple levels of ground truthand features
+    a plethora of settings to reflect experimental conditions and instrument settings.The
     simulator is used to generate several distinct types of data. The data are subsequently
-    employed to evaluate existing algorithms.\r\nAdditionally, we employ simulation
+    employed to evaluate existing algorithms.Additionally, we employ simulation
     to determine the influence of instrument attributes and sample complexity on the
-    ability of\r\nalgorithms to recover information. The results give valuable hints
-    on how to optimize experimental setups.\r\n\r\nFurthermore, this thesis introduces
+    ability ofalgorithms to recover information. The results give valuable hints
+    on how to optimize experimental setups.Furthermore, this thesis introduces
     two quantitative approaches, namely a decharging algorithm based on integer linear
-    programming \r\nand a new workflow for identification of differentially expressed
-    proteins for a large in vitro study on toxic compounds.\r\nDecharging infers the
+    programming and a new workflow for identification of differentially expressed
+    proteins for a large in vitro study on toxic compounds.Decharging infers the
     uncharged mass of a peptide (or protein) by clustering all its charge variants.
-    The latter occur frequently under certain experimental conditions.\r\nWe employ
+    The latter occur frequently under certain experimental conditions.We employ
     simulation to show that decharging is robust against missing values even for high
-    complexity data and that the algorithm outperforms\r\nother solutions in terms
-    of mass accuracy and run time on real data.\r\nThe last part of this thesis deals
+    complexity data and that the algorithm outperformsother solutions in terms
+    of mass accuracy and run time on real data.The last part of this thesis deals
     with a new state-of-the-art workflow for protein quantification based on isobaric
-    tags for relative and absolute quantitation (iTRAQ). We devise\r\na new approach
+    tags for relative and absolute quantitation (iTRAQ). We devisea new approach
     to isotope correction, propose an experimental design, introduce new metrics of
-    iTRAQ data quality, and\r\nconfirm putative properties of iTRAQ data using a novel
-    approach.\r\n\r\nAll tools developed as part of this thesis are implemented in
+    iTRAQ data quality, andconfirm putative properties of iTRAQ data using a novel
+    approach.All tools developed as part of this thesis are implemented in
     OpenMS, a C++ library for computational mass spectrometry."
   status_changed: '2014-08-20 09:50:37'
   official_url: http://www.diss.fu-berlin.de/diss/receive/FUDISS_thesis_000000040013
@@ -1536,7 +1536,7 @@
 - userid: 1
   type: monograph
   rev_number: 3
-  title: "Efficient ordering of state variables and transition relation partitions\tin
+  title: "Efficient ordering of state variables and transition relation partitionsin
     symbolic model checking"
   status_changed: '2009-03-11 11:26:49'
   datestamp: '2009-04-14 14:44:15'
@@ -1570,8 +1570,8 @@
   uri: http://publications.imp.fu-berlin.de/id/eprint/335
   lastmod: '2009-04-14 14:44:15'
   ispublished: pub
-  keywords: "Randomized algorithms and probabilistic analysis, VLSI-Design and\tlayout,
-    Binary Decision Diagrams, Hardware verification, Local search\r\n\tand metaheuristics"
+  keywords: "Randomized algorithms and probabilistic analysis, VLSI-Design andlayout,
+    Binary Decision Diagrams, Hardware verification, Local searchand metaheuristics"
   divisions:
   - group_algbioinf
   subjects:
@@ -1600,7 +1600,7 @@
   pagerange: 15 pages
   date: 2007
   place_of_pub: Taormina
-  keywords: "Three-Connected Planar Graph, Cnet, Planar Graph, Enumeration, Random\tgraphs,
+  keywords: "Three-Connected Planar Graph, Cnet, Planar Graph, Enumeration, Randomgraphs,
     Random Generation, Dynamic Programming, Graph Theory"
   uri: http://publications.imp.fu-berlin.de/id/eprint/336
   lastmod: '2009-04-14 14:18:17'
@@ -1660,12 +1660,12 @@
   userid: 1
   type: conference_item
   rev_number: 3
-  keywords: "Three-Connected Planar Graph, Cnet, Planar Graph, Enumeration, Random\tgraphs,
+  keywords: "Three-Connected Planar Graph, Cnet, Planar Graph, Enumeration, Randomgraphs,
     Random Generation, Dynamic Programming, Graph Theory"
   ispublished: pub
   lastmod: '2009-04-14 14:32:56'
   uri: http://publications.imp.fu-berlin.de/id/eprint/337
-  event_title: "Proceedings of the 17th Annual International Conference on Formal\tPower
+  event_title: "Proceedings of the 17th Annual International Conference on FormalPower
     Series and Algebraic Combinatorics (FPSAC05)"
   eprint_status: archive
   dir: disk0/00/00/03/37
@@ -1682,22 +1682,22 @@
   full_text_status: none
 - title: Decomposing, Counting, and Generating Unlabeled Cubic Planar Graphs
   status_changed: '2009-03-11 11:26:53'
-  abstract: "We present an expected polynomial time algorithm to generate an unlabeled\tconnected
-    cubic planar graph uniformly at random. We first consider\r\n\trooted cubic planar
-    graphs, i.e., we count connected cubic planar\r\n\tgraphs up to isomorphisms that
-    fix a certain directed edge. Based\r\n\ton decompositions along the connectivity
-    structure, we derive recurrence\r\n\tformulas for counting the exact number of
-    rooted cubic planar graphs.\r\n\tThis leads to 3-connected planar graphs, which
-    have a unique embedding\r\n\ton the sphere; but special care has to be taken for
-    rooted graphs\r\n\tthat have a sense-reversing automorphism. Therefore we introduce\r\n\tthe
-    concept of colored networks, which stand in bijective correspondence\r\n\tto rooted
-    graphs with given symmetries. Colored networks can again\r\n\tbe decomposed along
-    their connectivity structure. For rooted 3-connected\r\n\tcubic planar graphs
-    embedded in the plane, we switch to the dual\r\n\tand count rooted triangulations.
-    All these numbers can be evaluated\r\n\tin polynomial time by dynamic programming.
-    We can use them to generate\r\n\trooted cubic planar graphs uniformly at random.
-    To generate connected\r\n\tcubic planar graphs without a root uniformly at random,
-    we apply\r\n\trejection sampling and obtain an expected polynomial time algorithm."
+  abstract: "We present an expected polynomial time algorithm to generate an unlabeledconnected
+    cubic planar graph uniformly at random. We first considerrooted cubic planar
+    graphs, i.e., we count connected cubic planargraphs up to isomorphisms that
+    fix a certain directed edge. Basedon decompositions along the connectivity
+    structure, we derive recurrenceformulas for counting the exact number of
+    rooted cubic planar graphs.This leads to 3-connected planar graphs, which
+    have a unique embeddingon the sphere; but special care has to be taken for
+    rooted graphsthat have a sense-reversing automorphism. Therefore we introducethe
+    concept of colored networks, which stand in bijective correspondenceto rooted
+    graphs with given symmetries. Colored networks can againbe decomposed along
+    their connectivity structure. For rooted 3-connectedcubic planar graphs
+    embedded in the plane, we switch to the dualand count rooted triangulations.
+    All these numbers can be evaluatedin polynomial time by dynamic programming.
+    We can use them to generaterooted cubic planar graphs uniformly at random.
+    To generate connectedcubic planar graphs without a root uniformly at random,
+    we applyrejection sampling and obtain an expected polynomial time algorithm."
   userid: 1
   type: conference_item
   rev_number: 3
@@ -1720,10 +1720,10 @@
   datestamp: '2009-04-14 14:36:27'
   lastmod: '2009-04-14 14:36:27'
   ispublished: pub
-  event_title: "European Conference on Combinatorics, Graph Theory, and Applications\tEUROCOMB'03
+  event_title: "European Conference on Combinatorics, Graph Theory, and ApplicationsEUROCOMB'03
     Prague"
   uri: http://publications.imp.fu-berlin.de/id/eprint/342
-  keywords: "Cubic Planar Graph, Planar Graph, Cubic Graph, Enumeration, Random\tgraphs,
+  keywords: "Cubic Planar Graph, Planar Graph, Cubic Graph, Enumeration, Randomgraphs,
     Random Generation, Dynamic Programming, Graph Theory"
   date: 2003
   divisions:
@@ -1752,7 +1752,7 @@
   volume: 379
   date: 2007
   pagerange: 377-386
-  keywords: "Labeled planar graph, Enumeration, Decomposition, Sampling algorithm,\tDynamic
+  keywords: "Labeled planar graph, Enumeration, Decomposition, Sampling algorithm,Dynamic
     programming, Graph theory"
   official_url: http://www.sciencedirect.com/science/article/B6V1G-4N4PY45-5/2 /4c06fbabe635c3a288cbf0427e0b395d
   uri: http://publications.imp.fu-berlin.de/id/eprint/339
@@ -1781,11 +1781,11 @@
   rev_number: 3
   title: Generating labeled planar graphs uniformly at random
   status_changed: '2009-03-11 11:26:52'
-  abstract: "We present a deterministic polynomial time algorithm to sample a labeled\tplanar
-    graph uniformly at random. Our approach uses recursive formulae\r\n\tfor the exact
-    number of labeled planar graphs with n vertices and\r\n\tm edges, based on a decomposition
-    into 1-, 2-, and 3-connected components.\r\n\tWe can then use known sampling algorithms
-    and counting formulae for\r\n\t3-connected planar graphs."
+  abstract: "We present a deterministic polynomial time algorithm to sample a labeledplanar
+    graph uniformly at random. Our approach uses recursive formulaefor the exact
+    number of labeled planar graphs with n vertices andm edges, based on a decomposition
+    into 1-, 2-, and 3-connected components.We can then use known sampling algorithms
+    and counting formulae for3-connected planar graphs."
 - datestamp: '2009-04-14 14:37:56'
   creators:
   - name:
@@ -1808,20 +1808,20 @@
   publisher: Springer Verlag
   type: conference_item
   title: Generating labeled planar graphs uniformly at random
-  abstract: "We present an expected polynomial time algorithm to generate a labeled\tplanar
-    graph uniformly at random. To generate the planar graphs,\r\n\twe derive recurrence
-    formulas that count all such graphs with n vertices\r\n\tand m edges, based on
-    a decomposition into 1-, 2-, and 3-connected\r\n\tcomponents. For 3-connected
-    graphs we apply a recent random generation\r\n\talgorithm by Schaeffer and a counting
+  abstract: "We present an expected polynomial time algorithm to generate a labeledplanar
+    graph uniformly at random. To generate the planar graphs,we derive recurrence
+    formulas that count all such graphs with n verticesand m edges, based on
+    a decomposition into 1-, 2-, and 3-connectedcomponents. For 3-connected
+    graphs we apply a recent random generationalgorithm by Schaeffer and a counting
     formula by Mullin and Schellenberg."
   status_changed: '2009-03-11 11:26:53'
-  keywords: "Planar Graph, Enumeration, Random graphs, Random Generation, Dynamic\tProgramming,
+  keywords: "Planar Graph, Enumeration, Random graphs, Random Generation, DynamicProgramming,
     Graph Theory"
   uri: http://publications.imp.fu-berlin.de/id/eprint/341
   event_title: Proceedings of ICALP 2003
-  note: "Appeared 2008 in Theoretical Computer Science. { The download is\tthe journal
-    submission &lt;br&gt; From time to time we receive requests\r\n\tfor source code,
-    so here it is: See the files BGK03b.README and GBK03b.tar.bz2\r\n\t}"
+  note: "Appeared 2008 in Theoretical Computer Science. { The download isthe journal
+    submission &lt;br&gt; From time to time we receive requestsfor source code,
+    so here it is: See the files BGK03b.README and GBK03b.tar.bz2}"
   lastmod: '2009-04-14 14:37:56'
   ispublished: pub
   dir: disk0/00/00/03/41
@@ -1844,23 +1844,23 @@
   uri: http://publications.imp.fu-berlin.de/id/eprint/338
   title: Generating unlabeled connected cubic planar graphs uniformly at random
   status_changed: '2009-03-11 11:26:51'
-  abstract: "We present an expected polynomial time algorithm to generate an unlabeled\tconnected
-    cubic planar graph uniformly at random. We first consider\r\n\trooted connected
-    cubic planar graphs, i.e., we count connected cubic\r\n\tplanar graphs up to isomorphisms
-    that fix a certain directed edge.\r\n\tBased on decompositions along the connectivity
-    structure, we derive\r\n\trecurrence formulas for the exact number of rooted cubic
-    planar graphs.\r\n\tThis leads to rooted 3-connected cubic planar graphs, which
-    have\r\n\ta unique embedding on the sphere. Special care has to be taken for\r\n\trooted
-    graphs that have a sense-reversing automorphism. Therefore\r\n\twe introduce the
-    concept of colored networks, which stand in bijective\r\n\tcorrespondence to rooted
-    3-connected cubic planar graphs with given\r\n\tsymmetries. Colored networks can
-    again be decomposed along the connectivity\r\n\tstructure. For rooted 3-connected
-    cubic planar graphs embedded in\r\n\tthe plane, we switch to the dual and count
-    rooted triangulations.\r\n\tSince all these numbers can be evaluated in polynomial
-    time using\r\n\tdynamic programming, rooted connected cubic planar graphs can
-    be\r\n\tgenerated uniformly at random in polynomial time by inverting the\r\n\tdecomposition
-    along the connectivity structure. To generate connected\r\n\tcubic planar graphs
-    without a root uniformly at random, we apply\r\n\trejection sampling and obtain
+  abstract: "We present an expected polynomial time algorithm to generate an unlabeledconnected
+    cubic planar graph uniformly at random. We first considerrooted connected
+    cubic planar graphs, i.e., we count connected cubicplanar graphs up to isomorphisms
+    that fix a certain directed edge.Based on decompositions along the connectivity
+    structure, we deriverecurrence formulas for the exact number of rooted cubic
+    planar graphs.This leads to rooted 3-connected cubic planar graphs, which
+    havea unique embedding on the sphere. Special care has to be taken forrooted
+    graphs that have a sense-reversing automorphism. Thereforewe introduce the
+    concept of colored networks, which stand in bijectivecorrespondence to rooted
+    3-connected cubic planar graphs with givensymmetries. Colored networks can
+    again be decomposed along the connectivitystructure. For rooted 3-connected
+    cubic planar graphs embedded inthe plane, we switch to the dual and count
+    rooted triangulations.Since all these numbers can be evaluated in polynomial
+    time usingdynamic programming, rooted connected cubic planar graphs can
+    begenerated uniformly at random in polynomial time by inverting thedecomposition
+    along the connectivity structure. To generate connectedcubic planar graphs
+    without a root uniformly at random, we applyrejection sampling and obtain
     an expected polynomial time algorithm"
   userid: 1
   rev_number: 3
@@ -1910,11 +1910,11 @@
   - group_algbioinf
   subjects:
   - G400
-  keywords: "Planar Graph, Enumeration, Random graphs, Random Generation, Graph\tTheory"
+  keywords: "Planar Graph, Enumeration, Random graphs, Random Generation, GraphTheory"
   ispublished: pub
   lastmod: '2010-09-01 13:43:09'
   uri: http://publications.imp.fu-berlin.de/id/eprint/340
-  event_title: "Proceedings of the 16th Annual International Symposium on Algorithms\tand
+  event_title: "Proceedings of the 16th Annual International Symposium on Algorithmsand
     Computation (ISAAC05)"
   creators:
   - name:
@@ -1955,7 +1955,7 @@
   userid: 1
   status_changed: '2009-03-11 11:26:54'
   title: Lower Bounds for Row Minima Searching
-  event_title: "Proceedings of the 23rd International Colloquium on Automata, Languages,\tand
+  event_title: "Proceedings of the 23rd International Colloquium on Automata, Languages,and
     Programming 1996 (ICALP-96), LNCS 1099"
   uri: http://publications.imp.fu-berlin.de/id/eprint/343
   ispublished: pub
@@ -2324,7 +2324,7 @@
   type: article
   title: 'DREAM-Yara: an exact read mapper for very large databases with short update
     time'
-  abstract: "Motivation\r\n\r\nMapping-based approaches have become limited in their
+  abstract: "MotivationMapping-based approaches have become limited in their
     application to very large sets of references since computing an FM-index for very
     large databases (e.g. >10 GB) has become a bottleneck. This affects many analyses
     that need such index as an essential step for approximate matching of the NGS
@@ -2333,7 +2333,7 @@
     full-text index on standard machines. Even on large memory machines, computing
     such index takes about 1 day of computing time. As a result, updates of indices
     are rarely performed. Hence, it is desirable to create an alternative way of indexing
-    while preserving fast search times.\r\n\r\nResults\r\n\r\nTo solve the index construction
+    while preserving fast search times.ResultsTo solve the index construction
     and update problem we propose the DREAM (Dynamic seaRchablE pArallel coMpressed
     index) framework and provide an implementation. The main contributions are the
     introduction of an approximate search distributor via a novel use of Bloom filters.
@@ -2342,8 +2342,8 @@
     cannot match. This allows us to keep the databases in several indices which can
     be easily rebuilt if parts are updated while maintaining a fast search time. The
     second main contribution is an implementation of DREAM-Yara a distributed version
-    of a fully sensitive read mapper under the DREAM framework.\r\n\r\nAvailability
-    and implementation: \r\nhttps://gitlab.com/pirovc/dream_yara/"
+    of a fully sensitive read mapper under the DREAM framework.Availability
+    and implementation: https://gitlab.com/pirovc/dream_yara/"
   status_changed: '2018-11-08 11:49:07'
   official_url: http://doi.org/10.1093/bioinformatics/bty567
   uri: http://publications.imp.fu-berlin.de/id/eprint/2282
@@ -2615,7 +2615,7 @@
   abstract: "Motivation: The reliable detection of genomic variation in resequencing
     data is still a major challenge, especially for variants larger than a few base
     pairs. Sequencing reads crossing boundaries of structural variation carry the
-    potential for their identification, but are difficult to map.\r\n\r\nResults:
+    potential for their identification, but are difficult to map.Results:
     Here we present a method for ‘split’ read mapping, where prefix and suffix match
     of a read may be interrupted by a longer gap in the read-to-reference alignment.
     We use this method to accurately detect medium-sized insertions and long deletions
@@ -2627,7 +2627,7 @@
     is a versatile tool applicable to unanchored or single-end as well as anchored
     paired-end reads. In addition, application of SplazerS to targeted resequencing
     data led to the interesting discovery of a complete, possibly functional gene
-    retrocopy variant.\r\n\r\nAvailability: SplazerS is available from http://www.seqan.de/projects/
+    retrocopy variant.Availability: SplazerS is available from http://www.seqan.de/projects/
     splazers."
   status_changed: '2012-09-12 08:40:15'
   eprintid: 1160
@@ -2691,17 +2691,17 @@
   publisher: Springer Verlag
   type: conference_item
   userid: 1
-  abstract: "Mass spectrometry (MS) is becoming a popular approach for quantifying\tthe
-    protein composition of complex samples. A great challenge for\r\n\tcomparative
-    proteomic profiling is to match corresponding peptide\r\n\tfeatures from different
-    experiments to ensure that the same protein\r\n\tintensities are correctly identified.
-    Multi-dimensional data acquisition\r\n\tfrom liquid-chromatography mass spectrometry
-    (LC-MS) makes the alignment\r\n\tproblem harder. We propose a general paradigm
-    for aligning peptide\r\n\tfeatures using a bounded error model. Our method is
-    tolerant of imperfect\r\n\tmeasurements, missing peaks, and extraneous peaks.
-    It can handle\r\n\tan arbitrary number of dimensions of separation, and is very
-    fast\r\n\tin practice even for large data sets. Finally, its parameters are\r\n\tintuitive
-    and we describe a heuristic for estimating them automatically.\r\n\tWe demonstrate
+  abstract: "Mass spectrometry (MS) is becoming a popular approach for quantifyingthe
+    protein composition of complex samples. A great challenge forcomparative
+    proteomic profiling is to match corresponding peptidefeatures from different
+    experiments to ensure that the same proteinintensities are correctly identified.
+    Multi-dimensional data acquisitionfrom liquid-chromatography mass spectrometry
+    (LC-MS) makes the alignmentproblem harder. We propose a general paradigm
+    for aligning peptidefeatures using a bounded error model. Our method is
+    tolerant of imperfectmeasurements, missing peaks, and extraneous peaks.
+    It can handlean arbitrary number of dimensions of separation, and is very
+    fastin practice even for large data sets. Finally, its parameters areintuitive
+    and we describe a heuristic for estimating them automatically.We demonstrate
     results on single- and multi-dimensional data."
   status_changed: '2009-03-11 11:26:55'
   title: Alignment of Mass Spectrometry Data by Clique Finding and Optimization
@@ -2731,25 +2731,25 @@
   rev_number: 3
   type: article
   userid: 1
-  abstract: "Motivation: The Dictionary of Interfaces in Proteins (DIP) is a database\tcollecting
-    the 3D structure of interacting parts of proteins that\r\n\tare called patches.
-    It serves as a repository, in which patches similar\r\n\tto given query patches
-    can be found. The computation of the similarity\r\n\tof two patches is time consuming
-    and traversing the entire DIP requires\r\n\tsome hours. In this work we address
-    the question of how the patches\r\n\tsimilar to a given query can be identified
-    by scanning only a small\r\n\tpart of DIP. The answer to this question requires
-    the investigation\r\n\tof the distribution of the similarity of patches. Results:
-    The score\r\n\tvalues describing the similarity of two patches can roughly be
-    divided\r\n\tinto three ranges that correspond to different levels of spatial\r\n\tsimilarity.
-    Interestingly, the two iso-score lines separating the\r\n\tthree classes can be
-    determined by two different approaches. Applying\r\n\ta concept of the theory
-    of random graphs reveals significant structural\r\n\tproperties of the data in
-    DIP. These can be used to accelerate scanning\r\n\tthe DIP for patches similar
-    to a given query. Searches for very similar\r\n\tpatches could be accelerated
-    by a factor of more than 25. Patches\r\n\twith a medium similarity could be found
-    10 times faster than by brute-force\r\n\tsearch. 10.1093/bioinformatics/btg343"
+  abstract: "Motivation: The Dictionary of Interfaces in Proteins (DIP) is a databasecollecting
+    the 3D structure of interacting parts of proteins thatare called patches.
+    It serves as a repository, in which patches similarto given query patches
+    can be found. The computation of the similarityof two patches is time consuming
+    and traversing the entire DIP requiressome hours. In this work we address
+    the question of how the patchessimilar to a given query can be identified
+    by scanning only a smallpart of DIP. The answer to this question requires
+    the investigationof the distribution of the similarity of patches. Results:
+    The scorevalues describing the similarity of two patches can roughly be
+    dividedinto three ranges that correspond to different levels of spatialsimilarity.
+    Interestingly, the two iso-score lines separating thethree classes can be
+    determined by two different approaches. Applyinga concept of the theory
+    of random graphs reveals significant structuralproperties of the data in
+    DIP. These can be used to accelerate scanningthe DIP for patches similar
+    to a given query. Searches for very similarpatches could be accelerated
+    by a factor of more than 25. Patcheswith a medium similarity could be found
+    10 times faster than by brute-forcesearch. 10.1093/bioinformatics/btg343"
   status_changed: '2009-03-11 11:26:55'
-  title: "Accelerating screening of 3D protein data with a graph theoretical\tapproach"
+  title: "Accelerating screening of 3D protein data with a graph theoreticalapproach"
   publication: Bioinformatics
   datestamp: '2009-04-14 14:35:22'
   creators:
@@ -2822,7 +2822,7 @@
     a comprehensive, easy-to-use, open source C++ library of efficient algorithms
     and data structures for the analysis of biological sequences. Written by the founders
     of this project, Biological Sequence Analysis Using the SeqAn C++ Library covers
-    the SeqAn library, its documentation, and the supporting infrastructure.\r\n\r\n\r\nThe
+    the SeqAn library, its documentation, and the supporting infrastructure.The
     first part of the book describes the general library design. It introduces biological
     sequence analysis problems, discusses the benefit of using software libraries,
     summarizes the design principles and goals of SeqAn, details the main programming
@@ -2831,10 +2831,10 @@
     part explores basic functionality, sequence data structures, alignments, pattern
     and motif searching, string indices, and graphs. The last part illustrates applications
     of SeqAn to genome alignment, consensus sequence in assembly projects, suffix
-    array construction, and more.\r\n\r\n\r\nThis handy book describes a user-friendly
+    array construction, and more.This handy book describes a user-friendly
     library of efficient data types and algorithms for sequence analysis in computational
     biology. SeqAn enables not only the implementation of new algorithms, but also
-    the sound analysis and comparison of existing algorithms.\r\n"
+    the sound analysis and comparison of existing algorithms."
   datestamp: '2010-03-04 12:10:11'
   creators:
   - id: andreas.doering@mdc-berlin.de
@@ -2963,7 +2963,7 @@
       family: Pieper
       lineage:
 - official_url: http://www.dagstuhl.de/05471/
-  note: "Extended abstract for talk given at Dagstuhl Seminar 05471 on Computational\tProteomics,
+  note: "Extended abstract for talk given at Dagstuhl Seminar 05471 on ComputationalProteomics,
     20.-25. November 2005"
   lastmod: '2009-04-14 14:26:41'
   ispublished: pub
@@ -3021,10 +3021,10 @@
   uri: http://publications.imp.fu-berlin.de/id/eprint/348
   ispublished: pub
   lastmod: '2009-04-14 14:36:34'
-  note: "Skript zu meiner Vorlesung im Wintersemester 2002/03 am Institut\tfür Informatik
+  note: "Skript zu meiner Vorlesung im Wintersemester 2002/03 am Institutfür Informatik
     der Humboldt-Universität zu Berlin"
 - official_url: http://dochost.rz.hu-berlin.de/dissertationen/informatik/groepl-clemens
-  keywords: "Binary decision diagram, Boolean function, probabilistic analysis,\tShannon
+  keywords: "Binary decision diagram, Boolean function, probabilistic analysis,Shannon
     effect"
   ispublished: unpub
   lastmod: '2009-04-14 14:41:14'
@@ -3038,41 +3038,41 @@
   datestamp: '2009-04-14 14:41:14'
   thesis_type: phd
   status_changed: '2009-03-11 11:26:57'
-  abstract: "(deutsche Zusammenfassung siehe unten)&lt;p&gt; Binary Decision Diagrams\t(BDDs)
-    are a data structure for Boolean functions which are also\r\n\tknown as branching
-    programs. In ordered binary decision diagrams\r\n\t(OBDDs), the tests have to
-    obey a fixed variable ordering. In free\r\n\tbinary decision diagrams (FBDDs),
-    each variable can be tested at\r\n\tmost once. The efficiency of new variants
-    of the BDD concept is usually\r\n\tdemonstrated with spectacular (worst-case)
-    examples. We pursue another\r\n\tapproach and compare the representation sizes
-    of almost all Boolean\r\n\tfunctions. Whereas I. Wegener proved that for `most'
-    values of n\r\n\tthe expected OBDD size of a random Boolean function of n variables\r\n\tis
-    equal to the worst-case size up to terms of lower order, we show\r\n\tthat this
-    is not the case for n within intervals of constant length\r\n\taround the values
-    n = 2h + h. Furthermore, ranges of n exist for\r\n\twhich minimal FBDDs are almost
-    always at least a constant factor\r\n\tsmaller than minimal OBDDs. Our main theorems
-    have doubly exponentially\r\n\tsmall probability bounds (in n). We also investigate
-    the evolution\r\n\tof random OBDDs and their worst-case size, revealing an oscillating\r\n\tbehaviour
-    that explains why certain results cannot be improved in\r\n\tgeneral. &lt;p&gt;
-    &lt;b&gt;Zusammenfassung:&lt;/b&gt;&lt;p&gt; Binary Decision Diagrams\r\n\t(BDDs)
-    sind eine Datenstruktur für Boolesche Funktionen, die\r\n\tauch unter dem Namen
-    branching program bekannt ist. In ordered binary\r\n\tdecision diagrams (OBDDs)
-    müssen die Tests einer festen Variablenordnung\r\n\tgenügen. In free binary decision
-    diagrams (FBDDs) darf jede Variable\r\n\thöchstens einmal getestet werden. Die
-    Effizienz neuer Varianten\r\n\tdes BDD-Konzepts wird gewöhnlich anhand spektakulärer
-    (worst-case)\r\n\tBeispiele aufgezeigt. Wir verfolgen einen anderen Ansatz und
-    vergleichen\r\n\tdie Darstellungsgrößen für fast alle Booleschen Funktionen.\r\n\tWährend
-    I. Wegener bewiesen hat, daß für die `meisten'\r\n\tn die erwartete OBDD-Größe
-    einer zufälligen Booleschen\r\n\tFunktion von n Variablen gleich der worst-case
-    Größe bis\r\n\tauf Terme kleinerer Ordnung ist, zeigen wir daß dies nicht der\r\n\tFall
-    ist für n innerhalb von Intervallen konstanter Länge\r\n\tum die Werte n = 2h
-    + h. Ferner gibt es Bereiche von n, in denen\r\n\tminimale FBDDs fast immer um
-    mindestens einen konstanten Faktor kleiner\r\n\tsind als minimale OBDDs. Unsere
-    Hauptsätze ha ben doppelt exponentielle\r\n\tWahrschein- lichkeitsschranken (in
-    n). Außerdem untersuchen wir\r\n\tdie Entwicklung zufälliger OBDDs und ihrer worst-case
-    Größe\r\n\tund decken dabei ein oszillierendes Verhalten auf, das erklärt,\r\n\twarum
-    gewisse Aussagen im allgemeinen nicht verstärkt werden\r\n\tkönnen. &lt;p&gt;Schlagwörter:&lt;p&gt;
-    Binäres Entscheidungsdiagramm,\r\n\tBoolesche Funktion,probabilistische Analyse,
+  abstract: "(deutsche Zusammenfassung siehe unten)&lt;p&gt; Binary Decision Diagrams(BDDs)
+    are a data structure for Boolean functions which are alsoknown as branching
+    programs. In ordered binary decision diagrams(OBDDs), the tests have to
+    obey a fixed variable ordering. In freebinary decision diagrams (FBDDs),
+    each variable can be tested atmost once. The efficiency of new variants
+    of the BDD concept is usuallydemonstrated with spectacular (worst-case)
+    examples. We pursue anotherapproach and compare the representation sizes
+    of almost all Booleanfunctions. Whereas I. Wegener proved that for `most'
+    values of nthe expected OBDD size of a random Boolean function of n variablesis
+    equal to the worst-case size up to terms of lower order, we showthat this
+    is not the case for n within intervals of constant lengtharound the values
+    n = 2h + h. Furthermore, ranges of n exist forwhich minimal FBDDs are almost
+    always at least a constant factorsmaller than minimal OBDDs. Our main theorems
+    have doubly exponentiallysmall probability bounds (in n). We also investigate
+    the evolutionof random OBDDs and their worst-case size, revealing an oscillatingbehaviour
+    that explains why certain results cannot be improved ingeneral. &lt;p&gt;
+    &lt;b&gt;Zusammenfassung:&lt;/b&gt;&lt;p&gt; Binary Decision Diagrams(BDDs)
+    sind eine Datenstruktur für Boolesche Funktionen, dieauch unter dem Namen
+    branching program bekannt ist. In ordered binarydecision diagrams (OBDDs)
+    müssen die Tests einer festen Variablenordnunggenügen. In free binary decision
+    diagrams (FBDDs) darf jede Variablehöchstens einmal getestet werden. Die
+    Effizienz neuer Variantendes BDD-Konzepts wird gewöhnlich anhand spektakulärer
+    (worst-case)Beispiele aufgezeigt. Wir verfolgen einen anderen Ansatz und
+    vergleichendie Darstellungsgrößen für fast alle Booleschen Funktionen.Während
+    I. Wegener bewiesen hat, daß für die `meisten'n die erwartete OBDD-Größe
+    einer zufälligen BooleschenFunktion von n Variablen gleich der worst-case
+    Größe bisauf Terme kleinerer Ordnung ist, zeigen wir daß dies nicht derFall
+    ist für n innerhalb von Intervallen konstanter Längeum die Werte n = 2h
+    + h. Ferner gibt es Bereiche von n, in denenminimale FBDDs fast immer um
+    mindestens einen konstanten Faktor kleinersind als minimale OBDDs. Unsere
+    Hauptsätze ha ben doppelt exponentielleWahrschein- lichkeitsschranken (in
+    n). Außerdem untersuchen wirdie Entwicklung zufälliger OBDDs und ihrer worst-case
+    Größeund decken dabei ein oszillierendes Verhalten auf, das erklärt,warum
+    gewisse Aussagen im allgemeinen nicht verstärkt werdenkönnen. &lt;p&gt;Schlagwörter:&lt;p&gt;
+    Binäres Entscheidungsdiagramm,Boolesche Funktion,probabilistische Analyse,
     Shannon Effekt."
   title: Binary Decision Diagrams for Random Boolean Functions
   rev_number: 3
@@ -3106,7 +3106,7 @@
   userid: 1
   rev_number: 3
   type: thesis
-  title: "Über Approximationsalgorithmen zur Färbung k-färbbarer\tGraphen, die vektorchromatische
+  title: "Über Approximationsalgorithmen zur Färbung k-färbbarerGraphen, die vektorchromatische
     Zahl und andere Varianten der vartheta-Funktion"
   status_changed: '2009-03-11 11:26:57'
   refereed: 'TRUE'
@@ -3255,7 +3255,7 @@
   rev_number: 3
   type: book_section
   userid: 1
-  keywords: "Approximation algorithms, Combinatorial optimization, Graph algorithms,\tSteiner
+  keywords: "Approximation algorithms, Combinatorial optimization, Graph algorithms,Steiner
     trees"
   ispublished: pub
   lastmod: '2009-04-14 14:39:16'
@@ -3291,24 +3291,24 @@
   ispublished: pub
   lastmod: '2009-04-14 14:40:07'
   uri: http://publications.imp.fu-berlin.de/id/eprint/355
-  event_title: "Proceedings of the 27th International Workshop on Graph-Theoretic\tConcepts
+  event_title: "Proceedings of the 27th International Workshop on Graph-TheoreticConcepts
     in Computer Science (2001)"
-  keywords: "Steiner trees, Approximation algorithms, Combinatorial optimization,\tGraph
+  keywords: "Steiner trees, Approximation algorithms, Combinatorial optimization,Graph
     algorithms, Hypergraphs, set systems, and designs"
-  title: "Lower bounds for approximation algorithms for the Steiner tree\tproblem"
+  title: "Lower bounds for approximation algorithms for the Steiner treeproblem"
   status_changed: '2009-03-11 11:27:00'
-  abstract: "The Steiner tree problem asks for a shortest subgraph connecting a\tgiven
-    set of terminals in a graph. It is known to be APX-complete,\r\n\twhich means
-    that no polynomial time approximation scheme can exist\r\n\tfor this problem,
-    unless P=NP. Currently, the best approximation\r\n\talgorithm for the Steiner
-    tree problem has a performance ratio of\r\n\t<span class='mathrm'>1.55</span>,
-    whereas the corresponding lower bound is smaller than <span class='mathrm'>1.01</span>.\r\n\tIn
-    this paper, we provide for several Steiner tree approximation\r\n\talgorithms
-    lower bounds on their performance ratio that are much\r\n\tlarger. For two algorithms
-    that solve the Steiner tree problem on\r\n\tquasi-bipartite instances, we even
-    prove lower bounds that match\r\n\tthe upper bounds. Quasi-bipartite instances
-    are of special interest,\r\n\tas currently all known lower bound reductions for
-    the Steiner tree\r\n\tproblem in graphs produce such instances."
+  abstract: "The Steiner tree problem asks for a shortest subgraph connecting agiven
+    set of terminals in a graph. It is known to be APX-complete,which means
+    that no polynomial time approximation scheme can existfor this problem,
+    unless P=NP. Currently, the best approximationalgorithm for the Steiner
+    tree problem has a performance ratio of<span class='mathrm'>1.55</span>,
+    whereas the corresponding lower bound is smaller than <span class='mathrm'>1.01</span>.In
+    this paper, we provide for several Steiner tree approximationalgorithms
+    lower bounds on their performance ratio that are muchlarger. For two algorithms
+    that solve the Steiner tree problem onquasi-bipartite instances, we even
+    prove lower bounds that matchthe upper bounds. Quasi-bipartite instances
+    are of special interest,as currently all known lower bound reductions for
+    the Steiner treeproblem in graphs produce such instances."
   userid: 1
   publisher: Springer Verlag
   type: conference_item
@@ -3367,18 +3367,18 @@
   rev_number: 3
   title: Steiner trees in uniformly quasi-bipartite graphs
   status_changed: '2009-03-11 11:27:00'
-  abstract: "The area of approximation algorithms for the Steiner tree problem\tin
-    graphs has seen continuous progress over the last years. Currently\r\n\tthe best
-    approximation algorithm has a performance ratio of 1.550.\r\n\tThis is still far
-    away from 1.0074, the largest known lower bound\r\n\ton the achievable performance
-    ratio. As all instances resulting from\r\n\tknown lower bound reductions are uniformly
-    quasi-bipartite, it is\r\n\tinteresting whether this special case can be approximated
-    better\r\n\tthan the general case. We present an approximation algorithm with\r\n\tperformance
-    ratio 73/60 &lt; 1.217 for the uniformly quasi-bipartite\r\n\tcase. This improves
-    on the previously known ratio of 1.279 of Robins\r\n\tand Zelikovsky. We use a
-    new method of analysis that combines ideas\r\n\tfrom the greedy algorithm for
-    set cover with a matroid-style exchange\r\n\targument to model the connectivity
-    constraint. As a consequence,\r\n\twe are able to provide a tight instance."
+  abstract: "The area of approximation algorithms for the Steiner tree problemin
+    graphs has seen continuous progress over the last years. Currentlythe best
+    approximation algorithm has a performance ratio of 1.550.This is still far
+    away from 1.0074, the largest known lower boundon the achievable performance
+    ratio. As all instances resulting fromknown lower bound reductions are uniformly
+    quasi-bipartite, it isinteresting whether this special case can be approximated
+    betterthan the general case. We present an approximation algorithm withperformance
+    ratio 73/60 &lt; 1.217 for the uniformly quasi-bipartitecase. This improves
+    on the previously known ratio of 1.279 of Robinsand Zelikovsky. We use a
+    new method of analysis that combines ideasfrom the greedy algorithm for
+    set cover with a matroid-style exchangeargument to model the connectivity
+    constraint. As a consequence,we are able to provide a tight instance."
   refereed: 'TRUE'
   eprintid: 354
   metadata_visibility: show
@@ -3494,25 +3494,25 @@
   rev_number: 3
   userid: 1
   status_changed: '2009-03-11 11:27:02'
-  abstract: "HPLC-ESI-MS is rapidly becoming an established standard method for\tshotgun
-    proteomics. Currently, its major drawbacks are twofold: quantification\r\n\tis
-    mostly limited to relative quantification and the large amount\r\n\tof data produced
-    by every individual experiment can make manual analysis\r\n\tquite difficult.
-    Here we present a new, combined experimental and\r\n\talgorithmic approach to
-    absolutely quantify proteins from samples\r\n\twith unprecedented precision. We
-    apply the method to the analysis\r\n\tof myoglobin in human blood serum, which
-    is an important diagnostic\r\n\tmarker for myocardial infarction. Our approach
-    was able to determine\r\n\tthe absolute amount of myoglobin in a serum sample
-    through a series\r\n\tof standard addition experiments with a relative error of
-    2.5 percent.\r\n\tCompared to a manual analysis of the same dataset we could improve\r\n\tthe
-    precision and conduct it in a fraction of the time needed for\r\n\tthe manual
-    analysis. We anticipate that our automatic quantitation\r\n\tmethod will facilitate
-    further absolute or relative quantitation\r\n\tof even more complex peptide samples.
-    The algorithm was developed\r\n\tusing our publically available software framework
+  abstract: "HPLC-ESI-MS is rapidly becoming an established standard method forshotgun
+    proteomics. Currently, its major drawbacks are twofold: quantificationis
+    mostly limited to relative quantification and the large amountof data produced
+    by every individual experiment can make manual analysisquite difficult.
+    Here we present a new, combined experimental andalgorithmic approach to
+    absolutely quantify proteins from sampleswith unprecedented precision. We
+    apply the method to the analysisof myoglobin in human blood serum, which
+    is an important diagnosticmarker for myocardial infarction. Our approach
+    was able to determinethe absolute amount of myoglobin in a serum sample
+    through a seriesof standard addition experiments with a relative error of
+    2.5 percent.Compared to a manual analysis of the same dataset we could improvethe
+    precision and conduct it in a fraction of the time needed forthe manual
+    analysis. We anticipate that our automatic quantitationmethod will facilitate
+    further absolute or relative quantitationof even more complex peptide samples.
+    The algorithm was developedusing our publically available software framework
     OpenMS (www.openms.de)."
-  title: "Algorithms for the automated absolute quantification of diagnostic\tmarkers
+  title: "Algorithms for the automated absolute quantification of diagnosticmarkers
     in complex proteomics samples"
-  event_title: "Proceedings of the 1st International Symposium on Computational Life\tScience
+  event_title: "Proceedings of the 1st International Symposium on Computational LifeScience
     (CompLife05)"
   uri: http://publications.imp.fu-berlin.de/id/eprint/358
   lastmod: '2009-04-14 14:27:04'
@@ -3540,7 +3540,7 @@
   publication: Information Processing Letters
   datestamp: '2009-04-14 14:40:13'
   title: On the Evolution of the Worst-Case OBDD Size
-  abstract: "We prove matching lower and upper bounds on the worst-case OBDD size\tof
+  abstract: "We prove matching lower and upper bounds on the worst-case OBDD sizeof
     a Boolean function, revealing an interesting ocillating behaviour."
   status_changed: '2009-03-11 11:27:04'
   userid: 1
@@ -3564,16 +3564,16 @@
   rev_number: 3
   type: article
   title: Ordered binary decision diagrams and the Shannon effect
-  abstract: "We investigate the size and structure of ordered binary decision diagrams\t(OBDDs)
-    for random Boolean functions. It was known that for most\r\n\tvalues of n, the
-    expected OBDD size of a random Boolean function\r\n\twith n variables is equal
-    to the worst-case size up to terms of lower\r\n\torder. Such a phenomenon is generally
-    called strong Shannon effect.\r\n\tHere we show that the strong Shannon effect
-    is not valid for all\r\n\tn. Instead it undergoes a certain periodic `phase transition':
-    If\r\n\tn lies within intervals of constant width around the values n = 2h\r\n\t+
-    h, then the strong Shannon effect does not hold, whereas it does\r\n\thold outside
-    these intervals. Our analysis provides doubly exponential\r\n\tprobability bounds
-    and generalises to ordered Kronecker functional\r\n\tdecision diagrams (OKFDDs). "
+  abstract: "We investigate the size and structure of ordered binary decision diagrams(OBDDs)
+    for random Boolean functions. It was known that for mostvalues of n, the
+    expected OBDD size of a random Boolean functionwith n variables is equal
+    to the worst-case size up to terms of lowerorder. Such a phenomenon is generally
+    called strong Shannon effect.Here we show that the strong Shannon effect
+    is not valid for alln. Instead it undergoes a certain periodic `phase transition':
+    Ifn lies within intervals of constant width around the values n = 2h+
+    h, then the strong Shannon effect does not hold, whereas it doeshold outside
+    these intervals. Our analysis provides doubly exponentialprobability bounds
+    and generalises to ordered Kronecker functionaldecision diagrams (OKFDDs). "
   status_changed: '2009-03-11 11:27:03'
   datestamp: '2009-04-14 14:35:30'
   publication: Discrete Applied Mathematics
@@ -3596,9 +3596,9 @@
   uri: http://publications.imp.fu-berlin.de/id/eprint/360
   ispublished: pub
   lastmod: '2009-04-14 14:35:30'
-  keywords: "VLSI-Design and layout, Binary Decision Diagrams, Graph theory (other),\tHardware
-    verification, Probability theory, Random graphs, Randomized\r\n\talgorithms and
-    probabilistic analysis, Theoretical computer science\r\n\t(other)"
+  keywords: "VLSI-Design and layout, Binary Decision Diagrams, Graph theory (other),Hardware
+    verification, Probability theory, Random graphs, Randomizedalgorithms and
+    probabilistic analysis, Theoretical computer science(other)"
   subjects:
   - G400
   divisions:
@@ -3647,7 +3647,7 @@
       given: M.
       lineage:
   status_changed: '2009-03-11 11:27:03'
-  title: "Size and Structure of Random Ordered Binary Decision Diagrams (Extended\tAbstract)"
+  title: "Size and Structure of Random Ordered Binary Decision Diagrams (ExtendedAbstract)"
   publisher: Springer Verlag
   type: conference_item
   rev_number: 3
@@ -3722,7 +3722,7 @@
       honourific:
       given: A.
       family: Steger
-  keywords: "Theoretical computer science (other), Approximation algorithms, PCP\tand
+  keywords: "Theoretical computer science (other), Approximation algorithms, PCPand
     non-approximability"
   uri: http://publications.imp.fu-berlin.de/id/eprint/363
   note: The book grow out of a Dagstuhl Seminar, April 21-25, 1997
@@ -3797,9 +3797,9 @@
     this work we present Lambda, our own alternative for BLAST in the context of sequence
     classification. In our tests, Lambda often outperforms the best tools at reproducing
     BLAST's results and is the fastest compared with the current state of the art
-    at comparable levels of sensitivity.\r\nAVAILABILITY AND IMPLEMENTATION:Lambda
+    at comparable levels of sensitivity.AVAILABILITY AND IMPLEMENTATION:Lambda
     was implemented in the SeqAn open-source C++ library for sequence analysis and
-    is publicly available for download at http://www.seqan.de/projects/lambda.\r\nCONTACT:hannes.hauswedell@fu-berlin.de\r\nSUPPLEMENTARY
+    is publicly available for download at http://www.seqan.de/projects/lambda.CONTACT:hannes.hauswedell@fu-berlin.deSUPPLEMENTARY
     INFORMATION:Supplementary data are available at Bioinformatics online."
   title: 'Lambda: the local aligner for massive biological data'
   datestamp: '2014-09-23 18:00:01'
@@ -3829,16 +3829,16 @@
   uri: http://publications.imp.fu-berlin.de/id/eprint/1072
   official_url: http://dx.doi.org/10.1186/1471-2105-12-210
   status_changed: '2011-06-27 13:44:14'
-  abstract: "Background\r\nSecond generation sequencing technologies yield DNA sequence
+  abstract: "BackgroundSecond generation sequencing technologies yield DNA sequence
     data at ultra high-throughput. Common to most biological applications is a mapping
     of the reads to an almost identical or highly similar reference genome. The assessment
     of the quality of read mapping results is not straightforward and has not been
     formalized so far. Hence, it has not been easy to compare different read mapping
     approaches in a unified way and to determine which program is the best for what
-    task.\r\n\r\nResults\r\nWe present a new benchmark method, called Rabema (Read
+    task.ResultsWe present a new benchmark method, called Rabema (Read
     Alignment BEnchMArk), for read mappers. It consists of a strict definition of
     the read mapping problem and of tools to evaluate the result of arbitrary read
-    mappers supporting the SAM output format.\r\n\r\nConclusions\r\nWe show the usefulness
+    mappers supporting the SAM output format.ConclusionsWe show the usefulness
     of the benchmark program by performing a comparison of popular read mappers. The
     tools supporting the benchmark are licensed under the GPL and available from http://www.seqan.de/projects/rabema.html."
   title: A Novel And Well-Defined Benchmarking Method For Second Generation Read Mapping
@@ -3898,11 +3898,11 @@
   title: Methods for the Detection and Assembly of Novel Sequence in High-Throughput
     Sequencing Data
   status_changed: '2016-02-25 11:13:53'
-  abstract: "Motivation: \r\nLarge insertions of novel sequence are an important type
+  abstract: "Motivation: Large insertions of novel sequence are an important type
     of structural variants. Previous studies used traditional de novo assemblers for
     assembling non-mapping high-throughput sequencing (HTS) or capillary reads and
-    then tried to anchor them in the reference using paired read information.\r\n\r\nResults:
-    \r\nWe present approaches for detecting insertion breakpoints and targeted assembly
+    then tried to anchor them in the reference using paired read information.Results:
+    We present approaches for detecting insertion breakpoints and targeted assembly
     of large insertions from HTS paired data: BASIL and ANISE. On near identity repeats
     that are hard for assemblers, ANISE employs a repeat resolution step. This results
     in far better reconstructions than obtained by the compared methods. On simulated
@@ -3911,9 +3911,9 @@
     unanchored contigs as from ABYSS/SGA. On real-world data, we detected novel sequence
     in a human individual and thoroughly validated the assembled sequence. ANISE was
     found to be superior to the competing tool MindTheGap on both simulated and real-world
-    data.\r\n\r\nAvailability and implementation: ANISE and BASIL are available for
+    data.Availability and implementation: ANISE and BASIL are available for
     download at http://www.seqan.de/projects/herbarium under a permissive open source
-    license. \r\n\r\nContact: manuel.holtgrewe@fu-berlin.de or knut.reinert@fu-berlin.de"
+    license. Contact: manuel.holtgrewe@fu-berlin.de or knut.reinert@fu-berlin.de"
   userid: 132
   type: article
   rev_number: 14
@@ -4101,7 +4101,7 @@
     across species attracts a lot of attention in computational biology. Network alignments
     provide a systematic way to solve this problem. However, most existing alignment
     tools encounter limitations in tackling this problem. Therefore, the demand for
-    faster and more efficient alignment tools is growing.\r\n\r\nResults: We present
+    faster and more efficient alignment tools is growing.Results: We present
     a fast and accurate algorithm, NetCoffee, which allows to find a global alignment
     of multiple protein–protein interaction networks. NetCoffee searches for a global
     alignment by maximizing a target function using simulated annealing on a set of
@@ -4109,7 +4109,7 @@
     to T-Coffee. To assess its performance, NetCoffee was applied to four real datasets.
     Our results suggest that NetCoffee remedies several limitations of previous algorithms,
     outperforms all existing alignment tools in terms of speed and nevertheless identifies
-    biologically meaningful alignments.\r\n\r\nAvailability: The source code and data
+    biologically meaningful alignments.Availability: The source code and data
     are freely available for download under the GNU GPL v3 license at https://code.google.com/p/netcoffee/. "
   status_changed: '2014-08-19 14:46:18'
   userid: 132
@@ -4167,7 +4167,7 @@
     modules, and understanding the phylogeny from these data. Most of currently existing
     tools, however, encounter their limitations which are mainly concerned with scoring
     scheme, speed and scalability. Therefore, there are growing demands for sophisticated
-    network evolution models and efficient local alignment algorithms.\r\nRESULTS:We
+    network evolution models and efficient local alignment algorithms.RESULTS:We
     developed a fast and scalable local network alignment tool so-called LocalAli
     for the identification of functionally conserved modules in multiple networks.
     In this algorithm, we firstly proposed a new framework to reconstruct the evolution
@@ -4180,9 +4180,9 @@
     and the statistical significance, LocalAli were tested on a total of 26 real datasets
     and 1040 randomly generated datasets. The results suggest that LocalAli outperforms
     all existing algorithms in terms of coverage, consistency and scalability, meanwhile
-    retains a high precision in the identification of functionally coherent subnetworks.\r\n\r\nAVAILABILITY:The
+    retains a high precision in the identification of functionally coherent subnetworks.AVAILABILITY:The
     source code and test datasets are freely available for download under the GNU
-    GPL v3 license at https://code.google.com/p/localali/.\r\n\r\nCONTACT:jialu.hu@fu-berlin.de
+    GPL v3 license at https://code.google.com/p/localali/.CONTACT:jialu.hu@fu-berlin.de
     or knut.reinert@fu-berlin.de."
   status_changed: '2016-11-15 14:02:22'
   refereed: 'TRUE'
@@ -4279,7 +4279,7 @@
       lineage:
       family: Remington
       honourific:
-      given: "K.\tA."
+      given: "K.A."
   - name:
       lineage:
       family: Delcher
@@ -4326,7 +4326,7 @@
   title: Design of a compartmentalized Shotgun Assembler for the Human Genome
   status_changed: '2009-03-11 11:27:07'
   uri: http://publications.imp.fu-berlin.de/id/eprint/366
-  event_title: "Proceedings of the Ninth International Conference on Intelligent\tSystems
+  event_title: "Proceedings of the Ninth International Conference on IntelligentSystems
     for Molecular Biology (ISMB-01)"
   ispublished: pub
   lastmod: '2017-03-03 14:40:14'
@@ -4407,7 +4407,7 @@
       family: Myers
       lineage:
   uri: http://publications.imp.fu-berlin.de/id/eprint/368
-  event_title: "Proceedings of the Fifth Annual International Conference on Computational\tMolecular
+  event_title: "Proceedings of the Fifth Annual International Conference on ComputationalMolecular
     Biology (RECOMB-01)"
   ispublished: pub
   lastmod: '2017-03-03 14:40:14'
@@ -4877,16 +4877,16 @@
   type: article
   title: Alternate-locus aware variant calling in whole genome sequencing
   status_changed: '2017-01-12 09:36:57'
-  abstract: "\r\nBackground\r\n\r\nThe last two human genome assemblies have extended
+  abstract: "BackgroundThe last two human genome assemblies have extended
     the previous linear golden-path paradigm of the human genome to a graph-like model
     to better represent regions with a high degree of structural variability. The
     new model offers opportunities to improve the technical validity of variant calling
-    in whole-genome sequencing (WGS).\r\nMethods\r\n\r\nWe developed an algorithm
+    in whole-genome sequencing (WGS).MethodsWe developed an algorithm
     that analyzes the patterns of variant calls in the 178 structurally variable regions
     of the GRCh38 genome assembly, and infers whether a given sample is most likely
     to contain sequences from the primary assembly, an alternate locus, or their heterozygous
     combination at each of these 178 regions. We investigate 121 in-house WGS datasets
-    that have been aligned to the GRCh37 and GRCh38 assemblies.\r\n\r\nResults\r\n\r\nWe
+    that have been aligned to the GRCh37 and GRCh38 assemblies.ResultsWe
     show that stretches of sequences that are largely but not entirely identical between
     the primary assembly and an alternate locus can result in multiple variant calls
     against regions of the primary assembly. In WGS analysis, this results in characteristic
@@ -4896,7 +4896,7 @@
     than the primary assembly sequence, and filtering these genomes with our algorithm
     led to the identification of 7863 variant calls per genome that colocalized with
     ASDPs. Additionally, we found that 437 of 791 genome-wide association study hits
-    located within one of the regions corresponded to ASDPs.\r\n\r\nConclusions\r\n\r\nOur
+    located within one of the regions corresponded to ASDPs.ConclusionsOur
     algorithm uses the information contained in the 178 structurally variable regions
     of the GRCh38 genome assembly to avoid spurious variant calls in cases where samples
     contain an alternate locus rather than the corresponding segment of the primary
@@ -5010,13 +5010,13 @@
     gain and loss occurs in addition to other types of rearrangement, breakpoints
     of rearrangement can exist that are only detectable by comparison of three or
     more genomes. An arbitrarily large number of these “hidden” breakpoints can exist
-    among genomes that exhibit no rearrangements in pairwise comparisons. \r\n\r\nWe
+    among genomes that exhibit no rearrangements in pairwise comparisons. We
     present an extension of the multichromosomal breakpoint median problem to genomes
     that have undergone gene gain and loss. We then demonstrate that the median distance
     among three genomes can be used to calculate a lower bound on the number of hidden
     breakpoints present. We provide an implementation of this calculation including
     the median distance, along with some practical improvements on the time complexity
-    of the underlying algorithm. \r\n\r\nWe apply our approach to measure the abundance
+    of the underlying algorithm. We apply our approach to measure the abundance
     of hidden breakpoints in simulated data sets under a wide range of evolutionary
     scenarios. We demonstrate that in simulations the hidden breakpoint counts depend
     strongly on relative rates of inversion and gene gain/loss. Finally we apply current
@@ -5055,21 +5055,21 @@
   ispublished: pub
   uri: http://publications.imp.fu-berlin.de/id/eprint/1437
   official_url: http://www.biomedcentral.com/1471-2105/15/99/abstract
-  abstract: "Background\r\n\r\nRecent advances in rapid, low-cost sequencing have
+  abstract: "BackgroundRecent advances in rapid, low-cost sequencing have
     opened up the opportunity to study complete genome sequences. The computational
     approach of multiple genome alignment allows investigation of evolutionarily related
     genomes in an integrated fashion, providing a basis for downstream analyses such
-    as rearrangement studies and phylogenetic inference.\r\n\r\nGraphs have proven
+    as rearrangement studies and phylogenetic inference.Graphs have proven
     to be a powerful tool for coping with the complexity of genome-scale sequence
     alignments. The potential of graphs to intuitively represent all aspects of genome
     alignments led to the development of graph-based approaches for genome alignment.
     These approaches construct a graph from a set of local alignments, and derive
     a genome alignment through identification and removal of graph substructures that
-    indicate errors in the alignment.\r\n\r\nResults\r\n\r\nWe compare the structures
+    indicate errors in the alignment.ResultsWe compare the structures
     of commonly used graphs in terms of their abilities to represent alignment information.
     We describe how the graphs can be transformed into each other, and identify and
     classify graph substructures common to one or more graphs. Based on previous approaches,
-    we compile a list of modifications that remove these substructures.\r\n\r\nConclusion\r\n\r\nWe
+    we compile a list of modifications that remove these substructures.ConclusionWe
     show that crucial pieces of alignment information, associated with inversions
     and duplications, are not visible in the structure of all graphs. If we neglect
     vertex or edge labels, the graphs differ in their information content. Still,
@@ -5114,16 +5114,16 @@
   rev_number: 11
   type: article
   title: 'STELLAR: fast and exact local alignments'
-  abstract: "Background\r\nLarge-scale comparison of genomic sequences requires reliable
+  abstract: "BackgroundLarge-scale comparison of genomic sequences requires reliable
     tools for the search of local alignments. Practical local aligners are in general
-    fast, but heuristic, and hence sometimes miss significant matches.\r\n\r\nResults\r\nWe
+    fast, but heuristic, and hence sometimes miss significant matches.ResultsWe
     present here the local pairwise aligner STELLAR that has full sensitivity for
     ε-alignments, i.e. guarantees to report all local alignments of a given minimal
     length and maximal error rate. The aligner is composed of two steps, filtering
     and verification. We apply the SWIFT algorithm for lossless filtering, and have
     developed a new verification strategy that we prove to be exact. Our results on
     simulated and real genomic data confirm and quantify the conjecture that heuristic
-    tools like BLAST or BLAT miss a large percentage of significant local alignments.\r\n\r\nConclusions\r\nSTELLAR
+    tools like BLAST or BLAT miss a large percentage of significant local alignments.ConclusionsSTELLAR
     is very practical and fast on very long sequences which makes it a suitable new
     tool for finding local alignments between genomic sequences under the edit distance
     model. Binaries are freely available for Linux, Windows, and Mac OS X at http://www.seqan.de/projects/stellar.
@@ -5291,13 +5291,13 @@
       family: Reinert
   type: book_section
   userid: 132
-  abstract: "Motivation: \r\nComprehensive identification of structural variations
+  abstract: "Motivation: Comprehensive identification of structural variations
     (SVs) is a crucial task for studying genetic diversity and diseases. However,
     it remains challenging. There is only a marginal consensus between different methods,
     and our understanding of SVs is substantially limited.In general, integration
     of multiple pieces of evidence including split-read, read-pair, soft-clip, and
     read-depth yields the best result regarding accuracy. However, doing this step
-    by step is usually cumbersome and computationally expensive. \r\nResult: \r\nWe
+    by step is usually cumbersome and computationally expensive. Result: We
     present Vaquita, an accurate and fast tool for the identification of structural
     variations, which leverages all four types of evidence in a single program. After
     merging SVs from split-reads and discordant read-pairs, Vaquita realigns the soft-clipped
@@ -5309,8 +5309,8 @@
     insertion size of the library, and read length, and is comparable or even better
     for the identification of deletions, inversions, duplications, and translocations
     than state-of-the-art tools, using both simulated and real datasets. In addition,
-    Vaquita is more than eight times faster than any other tools in comparison. \r\nAvailability:
-    \r\nVaquita is implemented in C++ using the SeqAn library. The source code is
+    Vaquita is more than eight times faster than any other tools in comparison. Availability:
+    Vaquita is implemented in C++ using the SeqAn library. The source code is
     distributed under the BSD license and can be downloaded at http://github.com/seqan/vaquita"
   title: 'Vaquita: Fast and Accurate Identification of Structural Variation Using
     Combined Evidence'
@@ -5377,7 +5377,7 @@
 - ispublished: pub
   lastmod: '2017-03-03 14:40:14'
   uri: http://publications.imp.fu-berlin.de/id/eprint/372
-  event_title: "Proceedings of the Twelfth International Conference on Intelligent\tSystems
+  event_title: "Proceedings of the Twelfth International Conference on IntelligentSystems
     for Molecular Biology (ISMB-04)"
   creators:
   - name:
@@ -5441,7 +5441,7 @@
   datestamp: '2017-03-03 14:40:14'
   publication: FEBS Journal
   status_changed: '2009-03-11 11:27:11'
-  title: "Reference methods and materials in standardisation and quality assurance\t(abstract)"
+  title: "Reference methods and materials in standardisation and quality assurance(abstract)"
   rev_number: 3
   type: article
   userid: 1
@@ -5477,30 +5477,30 @@
   rev_number: 3
   title: TOPP - The OpenMS Proteomics Pipeline
   status_changed: '2009-03-11 11:27:12'
-  abstract: "Motivation: Experimental techniques in proteomics have seen rapid\tdevelopment
-    over the last few years. Volume and complexity of the\r\n\tdata have both been
-    growing at a similar rate. Accordingly, data\r\n\tmanagement and analysis are
-    one of the major challenges in proteomics.\r\n\tFlexible algorithms are required
-    to handle changing experimental\r\n\tsetups and to assist in developing and validating
-    new methods. In\r\n\torder to facilitate these studies, it would be desirable
-    to have\r\n\ta flexible `toolbox' of versatile and user-friendly applications\r\n\tallowing
-    for rapid construction of computational workflows in proteomics.\r\n\tResults:
-    We describe a set of tools for proteomics data analysis\r\n\t-- TOPP, The OpenMS
-    Proteomics Pipeline. TOPP provides a set of computational\r\n\ttools which can
-    be easily combined into analysis pipelines even by\r\n\tnon-experts and can be
-    used in proteomics workflows. These applications\r\n\trange from useful utilities
-    (file format conversion, peak picking)\r\n\tover wrapper applications for known
-    applications (e.g. Mascot) to\r\n\tcompletely new algorithmic techniques for data
-    reduction and data\r\n\tanalysis. We anticipate that TOPP will greatly facilitate
-    rapid prototyping\r\n\tof proteomics data evaluation pipelines. As such, we describe
-    the\r\n\tbasic concepts and the current abilities of TOPP and illustrate these\r\n\tconcepts
-    in the context of two example applications: the identification\r\n\tof peptides
-    from a raw data set through database search and the complex\r\n\tanalysis of a
-    standard addition experiment for the absolute quantitation\r\n\tof biomarkers.
-    The latter example demonstrates TOPP's ability to\r\n\tconstruct flexible analysis
-    pipelines in support of complex experimental\r\n\tsetups. Availability: The TOPP
-    components are available as open-source\r\n\tsoftware under the lesser GNU public
-    license (LGPL). Source code\r\n\tis available from the project web site at www.OpenMS.de"
+  abstract: "Motivation: Experimental techniques in proteomics have seen rapiddevelopment
+    over the last few years. Volume and complexity of thedata have both been
+    growing at a similar rate. Accordingly, datamanagement and analysis are
+    one of the major challenges in proteomics.Flexible algorithms are required
+    to handle changing experimentalsetups and to assist in developing and validating
+    new methods. Inorder to facilitate these studies, it would be desirable
+    to havea flexible `toolbox' of versatile and user-friendly applicationsallowing
+    for rapid construction of computational workflows in proteomics.Results:
+    We describe a set of tools for proteomics data analysis-- TOPP, The OpenMS
+    Proteomics Pipeline. TOPP provides a set of computationaltools which can
+    be easily combined into analysis pipelines even bynon-experts and can be
+    used in proteomics workflows. These applicationsrange from useful utilities
+    (file format conversion, peak picking)over wrapper applications for known
+    applications (e.g. Mascot) tocompletely new algorithmic techniques for data
+    reduction and dataanalysis. We anticipate that TOPP will greatly facilitate
+    rapid prototypingof proteomics data evaluation pipelines. As such, we describe
+    thebasic concepts and the current abilities of TOPP and illustrate theseconcepts
+    in the context of two example applications: the identificationof peptides
+    from a raw data set through database search and the complexanalysis of a
+    standard addition experiment for the absolute quantitationof biomarkers.
+    The latter example demonstrates TOPP's ability toconstruct flexible analysis
+    pipelines in support of complex experimentalsetups. Availability: The TOPP
+    components are available as open-sourcesoftware under the lesser GNU public
+    license (LGPL). Source codeis available from the project web site at www.OpenMS.de"
   datestamp: '2009-04-14 14:25:23'
   creators:
   - name:
@@ -5539,7 +5539,7 @@
       given: M.
       family: Sturm
   uri: http://publications.imp.fu-berlin.de/id/eprint/375
-  event_title: "Proceedings of the 5th European Conference on Computational Biology\t(ECCB
+  event_title: "Proceedings of the 5th European Conference on Computational Biology(ECCB
     2006)"
   lastmod: '2009-04-14 14:25:23'
   ispublished: pub
@@ -5547,7 +5547,7 @@
   lastmod: '2017-03-03 14:40:14'
   uri: http://publications.imp.fu-berlin.de/id/eprint/374
   status_changed: '2009-03-11 11:27:12'
-  title: "Differenzielle Proteomanalyse -- Experimentelle Methoden, Algorithmische\tHerausforderungen"
+  title: "Differenzielle Proteomanalyse -- Experimentelle Methoden, AlgorithmischeHerausforderungen"
   type: article
   rev_number: 3
   userid: 1
@@ -5643,7 +5643,7 @@
     efficient and unambiguous clonotype assignment to a large number of NGS read sequences,
     including the identification of the incorporated V and J gene segments and the
     CDR3 sequence. Current tools have deficits with respect to performance, accuracy
-    and documentation of their underlying algorithms and usage.\r\n\r\nResults: We
+    and documentation of their underlying algorithms and usage.Results: We
     present IMSEQ, a method to derive clonotype repertoires from next generation sequencing
     data with sophisticated routines for handling errors stemming from PCR and sequencing
     artefacts. The application can handle different kinds of input data originating
@@ -5651,7 +5651,7 @@
     regarding the species and gene of interest. We have carefully evaluated our method
     with simulated and real world data and show that IMSEQ is superior to other tools
     with respect to its clonotyping as well as standalone error correction and runtime
-    performance.\r\n\r\nAvailability: IMSEQ was implemented in C++ using the SeqAn
+    performance.Availability: IMSEQ was implemented in C++ using the SeqAn
     library for efficient sequence analysis. It is freely available under the GPLv2
     open source license and can be downloaded at www.imtools.org. "
   userid: 132
@@ -5673,21 +5673,21 @@
   rev_number: 3
   userid: 1
   status_changed: '2009-03-11 11:26:54'
-  abstract: "High throughput analysis of proteins using mass spectrometry requires\tan
-    efficient signal preprocessing which reduces the amount of data\r\n\twith minimal
-    loss of information. Therefore the peaks that belong\r\n\tto a peptide have to
-    be detected, and important features like their\r\n\tpeak centroid position, the
-    height and the area have to be determined.\r\n\tHere we present a peak picking
-    algorithm which detects peaks in a\r\n\tnoisy mass spectrum using its continuous
-    wavelet transform. By adapting\r\n\tthe wavelet to the theoretical peak shape,
-    each peaks centroid position\r\n\tis precisely identified; thus, overlapping peaks
-    (e.g. caused by\r\n\telectronspray ionization) are well separated. Representing
-    each peak\r\n\tnot only by its centroid position and area but also by the parameters\r\n\tof
-    the best fitting asymmetric lorentzian or hyperbolic secant squared\r\n\tfunctions,
-    yields valuable information about the original peak shape\r\n\tfor further analysis.
-    Given a mass spectrum with 100,000 raw data\r\n\tpoints representing 200 peaks,
-    our algorithm stored 5 parameters\r\n\tper peak, and was able to reduce the memory
-    requirement down to 1\r\n\tpercent."
+  abstract: "High throughput analysis of proteins using mass spectrometry requiresan
+    efficient signal preprocessing which reduces the amount of datawith minimal
+    loss of information. Therefore the peaks that belongto a peptide have to
+    be detected, and important features like theirpeak centroid position, the
+    height and the area have to be determined.Here we present a peak picking
+    algorithm which detects peaks in anoisy mass spectrum using its continuous
+    wavelet transform. By adaptingthe wavelet to the theoretical peak shape,
+    each peaks centroid positionis precisely identified; thus, overlapping peaks
+    (e.g. caused byelectronspray ionization) are well separated. Representing
+    each peaknot only by its centroid position and area but also by the parametersof
+    the best fitting asymmetric lorentzian or hyperbolic secant squaredfunctions,
+    yields valuable information about the original peak shapefor further analysis.
+    Given a mass spectrum with 100,000 raw datapoints representing 200 peaks,
+    our algorithm stored 5 parametersper peak, and was able to reduce the memory
+    requirement down to 1percent."
   title: Peak picking in mass spectra
   uri: http://publications.imp.fu-berlin.de/id/eprint/344
   ispublished: pub
@@ -5793,14 +5793,14 @@
   uri: http://publications.imp.fu-berlin.de/id/eprint/377
   lastmod: '2009-04-14 14:33:24'
   ispublished: pub
-  note: "Extended abstract for talk given at Dagstuhl Seminar 05471 on Computational\tProteomics,
+  note: "Extended abstract for talk given at Dagstuhl Seminar 05471 on ComputationalProteomics,
     20.-25. November 2005"
-- event_title: "Proceedings of the 15th Annual International Conference on Intelligent\tSystems
-    for Molecular Biology (ISMB) &amp; 6th European Conference on \tComputational
+- event_title: "Proceedings of the 15th Annual International Conference on IntelligentSystems
+    for Molecular Biology (ISMB) &amp; 6th European Conference on Computational
     Biology (ECCB)"
   userid: 132
   type: article
-  title: "A Geometric Approach for the Alignment of Liquid Chromatography-Mass\tSpectrometry
+  title: "A Geometric Approach for the Alignment of Liquid Chromatography-MassSpectrometry
     Data"
   abstract: "Motivation: Liquid chromatography coupled to mass spectrometry (LC-MS)
     and combined with tandem mass spectrometry (LC-MS/MS) have become a prominent
@@ -5809,7 +5809,7 @@
     confidence in the obtained measurements or to compare results from different samples.
     To do so, a suitable mapping or alignment between the data sets needs to be estimated.
     The alignment has to correct for variations in mass and elution time which are
-    present in all mass spectrometry experiments. \r\n\r\nResults: We propose a novel
+    present in all mass spectrometry experiments. Results: We propose a novel
     algorithm to align LC-MS samples and to match corresponding ion species across
     samples. Our algorithm matches landmark signals between two data sets using a
     geometric technique based on pose clustering. Variations in mass and retention
@@ -5819,7 +5819,7 @@
     approaches. It is robust in the presence of noise and able to accurately align
     samples with only few common ion species. In addition, we can easily handle different
     kinds of LC-MS data and adopt our algorithm to new mass spectrometry technologies.
-    \r\n\r\nAvailability: This algorithm is implemented as part of the OpenMS software
+    Availability: This algorithm is implemented as part of the OpenMS software
     library for shotgun proteomics and available under the Lesser GNU Public License
     (LGPL) at www.openms.de"
   datestamp: '2012-04-10 14:34:51'
@@ -5911,7 +5911,7 @@
   datestamp: '2009-04-14 14:12:16'
   publication: BMC Bioinformatics
   status_changed: '2009-03-11 11:27:15'
-  title: "Critical assessment of alignment procedures for LC-MS proteomics\tand metabolomic
+  title: "Critical assessment of alignment procedures for LC-MS proteomicsand metabolomic
     measurements"
   rev_number: 3
   type: article
@@ -5952,7 +5952,7 @@
   userid: 1
   type: article
   rev_number: 3
-  title: "An exact solution for the segment-to-segment multiple sequence alignment\tproblem"
+  title: "An exact solution for the segment-to-segment multiple sequence alignmentproblem"
   status_changed: '2009-03-11 11:27:16'
   datestamp: '2017-03-03 14:40:14'
   publication: BIOINFORMATICS
@@ -6038,7 +6038,7 @@
   type: conference_item
   title: A polyhedral approach to RNA sequence structure alignment
   status_changed: '2010-11-02 13:46:56'
-  event_title: "Proceedings of the Second Annual International Conference on Computational\tMolecular
+  event_title: "Proceedings of the Second Annual International Conference on ComputationalMolecular
     Biology (RECOMB-98)"
   uri: http://publications.imp.fu-berlin.de/id/eprint/380
   lastmod: '2010-11-02 13:46:56'
@@ -6082,7 +6082,7 @@
       lineage:
   datestamp: '2017-03-03 14:40:14'
   publication: Journal of Computational Biology
-  title: "The Practical Use of the A* Algorithm for Exact Multiple Sequence\tAlignment"
+  title: "The Practical Use of the A* Algorithm for Exact Multiple SequenceAlignment"
   status_changed: '2009-03-11 11:27:17'
   userid: 1
   type: article
@@ -6204,10 +6204,10 @@
   type: conference_item
   userid: 1
   status_changed: '2009-03-11 11:27:17'
-  title: "Accelerated microRNA Precursor Detection Using the Smith-Waterman\tAlgorithm
+  title: "Accelerated microRNA Precursor Detection Using the Smith-WatermanAlgorithm
     on FPGAs"
-- title: "Absolute Myoglobin Quantitation in Serum by Combining Two-Dimensional\tLiquid
-    Chromatography-Electrospray Ionization Mass Spectrometry and\r\n\tNovel Data Analysis
+- title: "Absolute Myoglobin Quantitation in Serum by Combining Two-DimensionalLiquid
+    Chromatography-Electrospray Ionization Mass Spectrometry andNovel Data Analysis
     Algorithms"
   status_changed: '2009-03-11 11:27:18'
   userid: 1
@@ -6284,8 +6284,8 @@
   rev_number: 3
   userid: 1
   status_changed: '2009-03-11 11:27:18'
-  title: "Bioinformatik: Aktuelle Proteinausstattung erlaubt Aussagen\tüber den Gesundheitszustand.
-    Software hilft Ärzten künftig\n\tbei der Diagnose."
+  title: "Bioinformatik: Aktuelle Proteinausstattung erlaubt Aussagenüber den Gesundheitszustand.
+    Software hilft Ärzten künftigbei der Diagnose."
   datestamp: '2017-03-03 14:40:14'
   creators:
   - name:
@@ -6296,7 +6296,7 @@
   uri: http://publications.imp.fu-berlin.de/id/eprint/386
   lastmod: '2017-03-03 14:40:14'
   ispublished: pub
-  note: "Der Artikel eines freien Medienjournalisten beschreibt den Einsatz\tvon OpenMS
+  note: "Der Artikel eines freien Medienjournalisten beschreibt den Einsatzvon OpenMS
     in der Proteomik"
 - date_type: published
   full_text_status: none
@@ -6373,7 +6373,7 @@
     portions of the human genome, 44 are likely paralogous to these genes, and 164
     genes have homologs elsewhere in the human genome; there are 14 genes for which
     we could find no human counterpart.
-  title: "A Comparison of Whole-Genome Shotgun-Derived Mouse Chromosome 16\tand the
+  title: "A Comparison of Whole-Genome Shotgun-Derived Mouse Chromosome 16and the
     Human Genome"
   datestamp: '2009-11-24 15:48:00'
   publication: Science
@@ -6768,20 +6768,20 @@
   title: Ultrahigh-performance liquid chromatography-ultraviolet absorbance detection-high-resolution-mass
     spectrometry combined with automated data processing for studying the kinetics
     of oxidative thermal degradation of thyroxine in the solid state
-  abstract: "Received 29 June 2014\r\nReceived in revised form\r\n29 September 2014\r\nAccepted
-    24 October 2014 Available online 30 October 2014\r\nKeywords:\r\nThyroxine\r\nUltrahigh-performance
-    liquid chromatography\r\nElectrospray ionization Orbitrap mass spectrometry\r\nKinetics\r\nDrug
-    degradation\r\nBioinformatics\r\n1. Introduction\r\nLevothyroxine (T4) is a well-known
+  abstract: "Received 29 June 2014Received in revised form29 September 2014Accepted
+    24 October 2014 Available online 30 October 2014Keywords:ThyroxineUltrahigh-performance
+    liquid chromatographyElectrospray ionization Orbitrap mass spectrometryKineticsDrug
+    degradationBioinformatics1. IntroductionLevothyroxine (T4) is a well-known
     and widely used drug for the treatment of hypothyroidism. The therapy is usually
     based on substitution of the natural hormone by a long-term treatment with synthetic
     levothyroxine [1]. It is a narrow therapeutic index drug, for which individual
     dosage levels of patients need to be established over several weeks. Consequently,
     products differing in content of levothyroxine due to compound instability or
     problems in formu- lation can lead to wrong medication and potentially cause severe
-    health problems [2,3].\r\n∗ Corresponding author. Tel.:+43 0 662 8044 5704; fax:
+    health problems [2,3].∗ Corresponding author. Tel.:+43 0 662 8044 5704; fax:
     +43 0 662 8044 5751. E-mail addresses: volker.a.neu@basf.com (V. Neu), chris.bielow@fu-berlin.de
-    (C. Bielow), reinert@inf.fu-berlin.de (K. Reinert), c.huber@sbg.ac.at (C.G. Huber).\r\nhttp://dx.doi.org/10.1016/j.chroma.2014.10.071\r\n0021-9673/©
-    2014 Elsevier B.V. All rights reserved.\r\nabstract\r\nLevothyroxine as active
+    (C. Bielow), reinert@inf.fu-berlin.de (K. Reinert), c.huber@sbg.ac.at (C.G. Huber).http://dx.doi.org/10.1016/j.chroma.2014.10.0710021-9673/©
+    2014 Elsevier B.V. All rights reserved.abstractLevothyroxine as active
     pharmaceutical ingredient of formulations used for the treatment of hypothy- roidism
     is distributed worldwide and taken by millions of people. An important issue in
     terms of compound stability is its capability to react with ambient oxygen, especially
@@ -6946,7 +6946,7 @@
   type: article
   rev_number: 5
   userid: 132
-  abstract: "Background\r\n\r\nIn recent years, several mass spectrometry-based omics
+  abstract: "BackgroundIn recent years, several mass spectrometry-based omics
     technologies emerged to investigate qualitative and quantitative changes within
     thousands of biologically active components such as proteins, lipids and metabolites.
     The research enabled through these methods potentially contributes to the diagnosis
@@ -6954,14 +6954,14 @@
     and interactions between biomolecules. Simultaneously, technological advances
     in the field of mass spectrometry leading to an ever increasing amount of data,
     demand high standards in efficiency, accuracy and reproducibility of potential
-    analysis software.\r\n\r\nResults\r\n\r\nThis article presents the current state
+    analysis software.ResultsThis article presents the current state
     and ongoing developments in OpenMS, a versatile open-source framework aimed at
     enabling reproducible analyses of high-throughput mass spectrometry data. It provides
     implementations of frequently occurring processing operations on MS data through
     a clean application programming interface in C++ and Python. A collection of 185
     tools and ready-made workflows for typical MS-based experiments enable convenient
     analyses for non-developers and facilitate reproducible research without losing
-    flexibility.\r\n\r\nConclusions\r\n\r\nOpenMS will continue to increase its ease
+    flexibility.ConclusionsOpenMS will continue to increase its ease
     of use for developers as well as users with improved continuous integration/deployment
     strategies, regular trainings with updated training materials and multiple sources
     of support. The active developer community ensures the incorporation of new features
@@ -7140,11 +7140,11 @@
     step in time O(σ) while needing space O(σ⋅n) using constant time rank queries
     on bit vectors. Schnattinger and colleagues improved this time to O(logσ) while
     using O(logσ⋅n) bits of space for both, the FM and 2FM index. This is achieved
-    by the use of binary wavelet trees.\r\n\r\nIn this paper we introduce a new, practical
+    by the use of binary wavelet trees.In this paper we introduce a new, practical
     method for conducting an exact search in a uni- and bidirectional FM index in
-    O(1) time per step while using O(logσ⋅n)+o(logσ⋅σ⋅n) \r\nbits of space. This is
+    O(1) time per step while using O(logσ⋅n)+o(logσ⋅σ⋅n) bits of space. This is
     done by replacing the binary wavelet tree by a new data structure, the Enhanced
-    Prefixsum Rank dictionary (EPR-dictionary).\r\n\r\nWe implemented this method
+    Prefixsum Rank dictionary (EPR-dictionary).We implemented this method
     in the SeqAn C++ library and experimentally validated our theoretical results.
     In addition we compared our implementation with other freely available implementations
     of bidirectional indices and show that we are between ≈2.2−4.2 times faster. This
@@ -7199,13 +7199,13 @@
     that stem from closely related species or are indeed individuals of the same species.
     Hence, the analyzed sequences are similar. For analyses where local changes in
     the examined sequence induce only local changes in the results, it is obviously
-    desirable to examine identical or similar regions not repeatedly.\r\n\r\nResults:
+    desirable to examine identical or similar regions not repeatedly.Results:
     In this work, we provide a datatype that exploits data parallelism inherent in
     a set of similar sequences by analyzing shared regions only once. In real-world
     experiments, we show that algorithms that otherwise would scan each reference
-    sequentially can be speeded up by a factor of 115.\r\n\r\nAvailability: The data
+    sequentially can be speeded up by a factor of 115.Availability: The data
     structure and associated tools are publicly available at http://www.seqan.de/projects/jst
-    and are part of SeqAn, the C++ template library for sequence analysis.\r\n\r\nContact:
+    and are part of SeqAn, the C++ template library for sequence analysis.Contact:
     rene.rahn@fu-berlin.de"
   status_changed: '2014-08-25 18:46:21'
   title: Journaled string tree--a scalable data structure for analyzing thousands
@@ -7267,7 +7267,7 @@
   datestamp: '2018-05-31 11:28:35'
   publication: Bioinformatics
   title: Generic accelerated sequence alignment in SeqAn using vectorization and multi-threading
-  abstract: "Motivation\r\n\r\nPairwise sequence alignment is undoubtedly a central
+  abstract: "MotivationPairwise sequence alignment is undoubtedly a central
     tool in many bioinformatics analyses. In this paper, we present a generically
     accelerated module for pairwise sequence lignments applicable for a broad range
     of applications. In our module, we unified the standard dynamic programming kernel
@@ -7277,14 +7277,14 @@
     We then extended the module by adding two layers of thread-level parallelization,
     where we a) distribute many independent alignments on multiple threads and b)
     inherently parallelize a single alignment computation using a work stealing approach
-    producing a dynamic wavefront progressing along the minor diagonal.\r\n\r\nResults\r\n\r\nWe
+    producing a dynamic wavefront progressing along the minor diagonal.ResultsWe
     evaluated our alignment vectorization and parallelization on different processors,
     including the newest Intel® Xeon® (Skylake) and Intel® Xeon Phi™ (KNL) processors,
     and use cases. The instruction set AVX512-BW (Byte and Word), available on Skylake
     processors, can genuinely improve the performance of vectorized alignments. We
     could run single alignments 1600 times faster on the Xeon Phi™ and 1400 times
     faster on the Xeon® than executing them with our previous sequential alignment
-    module.\r\n\r\nAvailability\r\n\r\nThe module is programmed in C++ using the SeqAn
+    module.AvailabilityThe module is programmed in C++ using the SeqAn
     (Reinert et al., 2017) library and distributed with version 2.4. under the BSD
     license. We support SSE4, AVX2, AVX512 instructions and included UME::SIMD, a
     SIMD-instruction wrapper library, to extend our module for further instruction
@@ -7421,7 +7421,7 @@
   - G400
   divisions:
   - group_algbioinf
-  institution: "Hasso-Plattner-Institut für Softwaresystemtechnik GmbH, Universität\tPotsdam"
+  institution: "Hasso-Plattner-Institut für Softwaresystemtechnik GmbH, UniversitätPotsdam"
   refereed: 'TRUE'
   eprintid: 389
   item_issues_count: 0
@@ -7457,27 +7457,27 @@
   metadata_visibility: show
   eprintid: 394
   refereed: 'TRUE'
-  abstract: "This paper describes a novel algorithm to analyze genetic linkage\tdata
-    using pattern recognition techniques and genetic algorithms\n\t(GA). The method
-    allows a search for regions of the chromosome that\n\tmay contain genetic variations
-    that jointly predispose individuals\n\tfor a particular disease. The method uses
-    correlation analysis, filtering\n\ttheory and genetic algorithms to achieve this
-    goal. Because current\n\tgenome scans use from hundreds to hundreds of thousands
-    of markers,\n\ttwo versions of the method have been implemented. The first is
-    an\n\texhaustive analysis version that can be used to visualize, explore,\n\tand
-    analyze small genetic data sets for two marker correlations;\n\tthe second is
-    a GA version, which uses a parallel implementation\n\tallowing searches of higher-order
-    correlations in large data sets.\n\tResults on simulated data sets indicate that
-    the method can be informative\n\tin the identification of major disease loci and
-    geneâ\x80\x93gene interactions\n\tin genome-wide linkage data and that further
-    exploration of these\n\ttechniques is justified. The results presented for both
-    variants\n\tof the method show that it can help genetic epidemiologists to identify\n\tpromising
-    combinations of genetic factors that might predispose to\n\tcomplex disorders.
-    In particular, the correlation analysis of IBD\n\texpression patterns might hint
-    to possible geneâ\x80\x93gene interactions\n\tand the filtering might be a fruitful
-    approach to distinguish true\n\tcorrelation signals from noise."
+  abstract: "This paper describes a novel algorithm to analyze genetic linkagedata
+    using pattern recognition techniques and genetic algorithms(GA). The method
+    allows a search for regions of the chromosome thatmay contain genetic variations
+    that jointly predispose individualsfor a particular disease. The method uses
+    correlation analysis, filteringtheory and genetic algorithms to achieve this
+    goal. Because currentgenome scans use from hundreds to hundreds of thousands
+    of markers,two versions of the method have been implemented. The first is
+    anexhaustive analysis version that can be used to visualize, explore,and
+    analyze small genetic data sets for two marker correlations;the second is
+    a GA version, which uses a parallel implementationallowing searches of higher-order
+    correlations in large data sets.Results on simulated data sets indicate that
+    the method can be informativein the identification of major disease loci and
+    geneâ\x80\x93gene interactionsin genome-wide linkage data and that further
+    exploration of thesetechniques is justified. The results presented for both
+    variantsof the method show that it can help genetic epidemiologists to identifypromising
+    combinations of genetic factors that might predispose tocomplex disorders.
+    In particular, the correlation analysis of IBDexpression patterns might hint
+    to possible geneâ\x80\x93gene interactionsand the filtering might be a fruitful
+    approach to distinguish truecorrelation signals from noise."
   status_changed: '2009-03-11 11:27:23'
-  title: "A parallel genetic algorithm to discover patterns in genetic markers\tthat
+  title: "A parallel genetic algorithm to discover patterns in genetic markersthat
     indicate predisposition to multifactorial disease"
   type: article
   rev_number: 3
@@ -7511,22 +7511,22 @@
   official_url: http://www.ncbi.nlm.nih.gov/pubmed/18547558
 - title: Segment-based multiple sequence alignment
   status_changed: '2009-03-11 11:27:21'
-  abstract: "Motivation: Many multiple sequence alignment tools have been developed\tin
-    the past, progressing either in speed or alignment accuracy. Given\r\n\tthe importance
-    and wide-spread use of alignment tools, progress in\r\n\tboth categories is a
-    contribution to the community and has driven\r\n\tresearch in the field so far.
-    Results: We introduce a graph-based\r\n\textension to the consistency-based, progressive
-    alignment strategy.\r\n\tWe apply the consistency notion to segments instead of
-    single characters.\r\n\tThe main problem we solve in this context is to define
-    segments of\r\n\tthe sequences in such a way that a graph-based alignment is possible.\r\n\tWe
-    implemented the algorithm using the SeqAn library and report results\r\n\ton amino
-    acid and DNA sequences. The benefit of our approach is threefold:\r\n\t(1) sequences
-    with conserved blocks can be rapidly aligned, (2) the\r\n\timplementation is conceptually
-    easy, generic and fast and (3) the\r\n\tconsistency idea can be extended to align
-    multiple genomic sequences.\r\n\tAvailability: The segment-based multiple sequence
-    alignment tool\r\n\tcan be downloaded from http://www.seqan.de/projects/msa.html.
-    A novel\r\n\tversion of T-Coffee interfaced with the tool is available from http://www.tcoffee.org.\r\n\tThe
-    usage of the tool is described in both documentations. Contact:\r\n\trausch@inf.fu-berlin.de"
+  abstract: "Motivation: Many multiple sequence alignment tools have been developedin
+    the past, progressing either in speed or alignment accuracy. Giventhe importance
+    and wide-spread use of alignment tools, progress inboth categories is a
+    contribution to the community and has drivenresearch in the field so far.
+    Results: We introduce a graph-basedextension to the consistency-based, progressive
+    alignment strategy.We apply the consistency notion to segments instead of
+    single characters.The main problem we solve in this context is to define
+    segments ofthe sequences in such a way that a graph-based alignment is possible.We
+    implemented the algorithm using the SeqAn library and report resultson amino
+    acid and DNA sequences. The benefit of our approach is threefold:(1) sequences
+    with conserved blocks can be rapidly aligned, (2) theimplementation is conceptually
+    easy, generic and fast and (3) theconsistency idea can be extended to align
+    multiple genomic sequences.Availability: The segment-based multiple sequence
+    alignment toolcan be downloaded from http://www.seqan.de/projects/msa.html.
+    A novelversion of T-Coffee interfaced with the tool is available from http://www.tcoffee.org.The
+    usage of the tool is described in both documentations. Contact:rausch@inf.fu-berlin.de"
   userid: 1
   rev_number: 7
   type: article
@@ -7624,7 +7624,7 @@
     scenarios as well as the usage of the tool are described in the documentation.
     Contact: rausch@inf.fu-berlin.de'
   status_changed: '2010-02-04 14:00:19'
-  title: "A consistency-based consensus algorithm for de novo and reference-guided\tsequence
+  title: "A consistency-based consensus algorithm for de novo and reference-guidedsequence
     assembly of short reads"
   publication: Bioinformatics
   datestamp: '2009-04-14 13:41:05'
@@ -7716,7 +7716,7 @@
   type: conference_item
   userid: 1
   status_changed: '2009-03-11 11:27:24'
-  title: "A general paradigm for fast and adaptive clustering of biological\tsequences"
+  title: "A general paradigm for fast and adaptive clustering of biologicalsequences"
   datestamp: '2009-04-14 13:45:54'
   creators:
   - name:
@@ -7775,9 +7775,9 @@
   ispublished: pub
   lastmod: '2009-04-14 14:22:33'
   note: "<span class='mathrm'>&lt;</span>http://drops.dagstuhl.de/opus/volltexte/2006/546<span
-    class='mathrm'>&gt;</span> [date of citation:\t2006-01-01]"
+    class='mathrm'>&gt;</span> [date of citation:2006-01-01]"
   rev_number: 3
-  publisher: "Internationales Begegnungs- und Forschungszentrum fÃ¼r Informatik\t(IBFI),
+  publisher: "Internationales Begegnungs- und Forschungszentrum fÃ¼r Informatik(IBFI),
     Schloss Dagstuhl, Germany"
   type: conference_item
   userid: 1
@@ -7892,7 +7892,7 @@
   type: conference_item
   rev_number: 3
   official_url: http://www.dagstuhl.de/05471/
-  note: "Extended abstract for talk given at Dagstuhl Seminar 05471 on Computational\tProteomics,
+  note: "Extended abstract for talk given at Dagstuhl Seminar 05471 on ComputationalProteomics,
     20.-25. November 2005"
   ispublished: pub
   lastmod: '2009-04-14 14:33:46'
@@ -7928,7 +7928,7 @@
   abstract: "High-throughput DNA sequencing has considerably changed the possibilities
     for conducting biomedical research by measuring billions of short DNA or RNA fragments.
     A central computational problem, and for many applications a first step, consists
-    of determining where the fragments came from\r\nin the original genome. In this
+    of determining where the fragments came fromin the original genome. In this
     article, we review the main techniques for generating the fragments, the main
     applications, and the main algorithmic ideas for computing a solution to the read
     alignment problem. In addition, we describe pitfalls and difficulties connected
@@ -8034,7 +8034,7 @@
   uri: http://publications.imp.fu-berlin.de/id/eprint/396
   ispublished: pub
   lastmod: '2017-03-03 14:40:15'
-- event_title: "Proceedings of the First Annual International Conference on Computational\tMolecular
+- event_title: "Proceedings of the First Annual International Conference on ComputationalMolecular
     Biology (RECOMB-97)"
   uri: http://publications.imp.fu-berlin.de/id/eprint/399
   lastmod: '2017-03-03 14:40:15'
@@ -8159,7 +8159,7 @@
   datestamp: '2017-09-12 14:16:48'
   publication: Journal of Biotechnology
   status_changed: '2017-09-12 14:16:48'
-  abstract: "Background\r\n\r\nThe use of novel algorithmic techniques is pivotal
+  abstract: "BackgroundThe use of novel algorithmic techniques is pivotal
     to many important problems in life science. For example the sequencing of the
     human genome (Venter et al., 2001) would not have been possible without advanced
     assembly algorithms and the development of practical BWT based read mappers have
@@ -8168,12 +8168,12 @@
     between state-of-the-art algorithmic techniques and the actual algorithmic components
     of tools that are in widespread use. We previously addressed this by introducing
     the SeqAn library of efficient data types and algorithms in 2008 (Döring et al.,
-    2008).\r\n\r\nResults\r\n\r\nThe SeqAn library has matured considerably since
+    2008).ResultsThe SeqAn library has matured considerably since
     its first publication 9 years ago. In this article we review its status as an
     established resource for programmers in the field of sequence analysis and its
-    contributions to many analysis tools.\r\n\r\nConclusions\r\n\r\nWe anticipate
+    contributions to many analysis tools.ConclusionsWe anticipate
     that SeqAn will continue to be a valuable resource, especially since it started
-    to actively support various hardware acceleration techniques in a systematic manner.\r\n\r\nKeywords\r\n\r\nNGS
+    to actively support various hardware acceleration techniques in a systematic manner.KeywordsNGS
     analysis; Software libraries; C++; Data structures"
   title: 'The SeqAn C++ template library for efficient sequence analysis: A resource
     for programmers'
@@ -8207,22 +8207,22 @@
   type: article
   rev_number: 5
   title: Flexbar 3.0 – SIMD and multicore parallelization
-  abstract: "Motivation: \r\nHigh-throughput sequencing machines can process many
+  abstract: "Motivation: High-throughput sequencing machines can process many
     samples in a single run. For Illumina systems, sequencing reads are barcoded with
     an additional DNA tag that is contained in the respective sequencing adapters.
     The recognition of barcode and adapter sequences is hence commonly needed for
     the analysis of next-generation sequencing data. Flexbar performs demultiplexing
     based on barcodes and adapter trimming for such data. The massive amounts of data
     generated on modern sequencing machines demand that this preprocessing is done
-    as efficiently as possible.\r\n\r\nResults: \r\nWe present Flexbar 3.0, the successor
+    as efficiently as possible.Results: We present Flexbar 3.0, the successor
     of the popular program Flexbar. It employs now twofold parallelism: multi-threading
     and additionally SIMD vectorization. Both types of parallelism are used to speed-up
     the computation of pair-wise sequence alignments, which are used for the detection
     of barcodes and adapters. Furthermore, new features were included to cover a wide
     range of applications. We evaluated the performance of Flexbar based on a simulated
     sequencing dataset. Our program outcompetes other tools in terms of speed and
-    is among the best tools in the presented quality benchmark.\r\n\r\nAvailability
-    and implementation:\r\nhttps://github.com/seqan/flexbar\r\n\r\nContact:\r\njohannes.roehr@fu-berlin.de
+    is among the best tools in the presented quality benchmark.Availability
+    and implementation:https://github.com/seqan/flexbarContact:johannes.roehr@fu-berlin.de
     or knut.reinert@fu-berlin.de"
   status_changed: '2017-10-12 12:16:48'
   datestamp: '2017-10-12 12:16:48'
@@ -8550,21 +8550,21 @@
     and neuro-toxicological responses. Furthermore, four drugs (diazepam, cyclosporine
     A, chlorpromazine and amiodarone) were tested more in depth as representatives
     of different classes of neurotoxicants, inducing toxicity through different pathways
-    of toxicity.\r\n\r\nThe developed in vitro BBB model allowed detection of toxic
+    of toxicity.The developed in vitro BBB model allowed detection of toxic
     effects at the level of BBB and evaluation of drug transport through the barrier
     for predicting free brain concentrations of the studied drugs. The measurement
     of neuronal electrical activity was found to be a sensitive tool to predict the
     neuroactivity and neurotoxicity of drugs after acute exposure. The histotypic
     3D re-aggregating brain cell cultures, containing all brain cell types, were found
-    to be well suited for OMICs analyses after both acute and long term treatment.\r\n\r\nThe
+    to be well suited for OMICs analyses after both acute and long term treatment.The
     obtained data suggest that an in vitro ITS based on the information obtained from
     BBB studies and combined with metabolomics, proteomics and neuronal electrical
     activity measurements performed in stable in vitro neuronal cell culture systems,
-    has high potential to improve current in vitro drug-induced neurotoxicity evaluation.\r\n\r\nAbbreviations:\r\nBBB,
+    has high potential to improve current in vitro drug-induced neurotoxicity evaluation.Abbreviations:BBB,
     blood brain barrier; DMSO, dimethylsulfoxide; EC, endothelial cells; DIV, day
     in vitro; IPA, Ingenuity Pathway Analysis; ITS, integrated testing strategy; LY,
     Lucifer Yellow; MEA, micro-electrode array; RH, Ringer HEPES medium; SPSS, Statistical
-    Package for the Social Sciences\r\n"
+    Package for the Social Sciences"
   title: Evaluation of drug-induced neurotoxicity based on metabolomics, proteomics
     and electrical activity measurements in complementary CNS in vitro models
   type: article
@@ -8598,7 +8598,7 @@
   date_type: published
   metadata_visibility: show
   id_number: doi:10.1016/j.tiv.2015.05.016
-- event_title: "Proceedings of the 8th International Workshop in Algorithms in Bioinformatics\t(WABI'08)"
+- event_title: "Proceedings of the 8th International Workshop in Algorithms in Bioinformatics(WABI'08)"
   uri: http://publications.imp.fu-berlin.de/id/eprint/401
   lastmod: '2009-04-15 07:16:23'
   ispublished: pub
@@ -8640,18 +8640,18 @@
   type: conference_item
   title: Fast and Adaptive Variable Order Markov Chain Construction
   status_changed: '2009-03-11 11:27:27'
-  abstract: " Variable order Markov chains (VOMCs) are a flexible class of models\tthat
-    extend the well-known Markov chains. They have been applied\r\n\tto a variety
-    of problems in computational biology, e.g. protein family\r\n\tclassification.
-    A linear time and space construction algorithm has\r\n\tbeen published in 2000
-    by Apostolico and Bejerano. However, neither\r\n\ta report of the actual running
-    time nor an implementation of it have\r\n\tever been published since. Using their
-    theoretical results, we implement\r\n\tgeneral and problem oriented algorithms
-    considering recent advances\r\n\tin string matching. We introduce a new software
-    which is orders of\r\n\tmagnitudes faster than current tools for building VOMCs,
-    and is suitable\r\n\tfor large scale analysis. Along the way we show that the
-    lazy suffix\r\n\ttree algorithm by Giegerich and others can compete with state-of-the-art\r\n\tsuffix
-    array methods in terms of time and space under the type of\r\n\tconstraints we
+  abstract: " Variable order Markov chains (VOMCs) are a flexible class of modelsthat
+    extend the well-known Markov chains. They have been appliedto a variety
+    of problems in computational biology, e.g. protein familyclassification.
+    A linear time and space construction algorithm hasbeen published in 2000
+    by Apostolico and Bejerano. However, neithera report of the actual running
+    time nor an implementation of it haveever been published since. Using their
+    theoretical results, we implementgeneral and problem oriented algorithms
+    considering recent advancesin string matching. We introduce a new software
+    which is orders ofmagnitudes faster than current tools for building VOMCs,
+    and is suitablefor large scale analysis. Along the way we show that the
+    lazy suffixtree algorithm by Giegerich and others can compete with state-of-the-artsuffix
+    array methods in terms of time and space under the type ofconstraints we
     have analyzed in this work. "
   eprintid: 401
   refereed: 'TRUE'
@@ -8810,23 +8810,23 @@
   - group_algbioinf
   volume: 30
 - status_changed: '2009-04-14 14:56:57'
-  abstract: "Liquid chromatography coupled to mass spectrometry (LC-MS) has become\ta
-    major tool for the study of biological processes. High-throughput\r\n\tLC-MS experimentsare
-    frequently conducted in modern laboratories,\r\n\tgenerating an enormous amountof
-    data per day. A manual inspection\r\n\tis therefore no longer a feasible task.
-    Consequently, there is a\r\n\tneed for computational tools that can rapidly provide
-    informationabout\r\n\tmass, elution time, and abundance of the compounds in a
-    LC-MS sample.\r\n\tWepresent an algorithm for the detection and quantification
-    of peptides\r\n\tin LC-MS data. Our approach is flexible and independent of the
-    MS\r\n\ttechnology in use. It is basedon a combination of the sweep line\r\n\tparadigm
-    with a novel wavelet function tailoredto detect isotopic\r\n\tpatterns of peptides.
-    We propose a simple voting schema to usethe\r\n\tredundant information in consecutive
-    scans for an accurate determination\r\n\tofmonoisotopic masses and charge states.
-    By explicitly modeling the\r\n\tinstrument inaccuracy, we are also able to cope
-    with data sets of\r\n\tdifferent quality and resolution.We evaluate our technique
-    on data\r\n\tfrom different instruments and show that we canrapidly estimate mass,\r\n\tcentroid
-    of retention time and abundance of peptides in a sound algorithmic\r\n\tframework.
-    Finally, we compare the performance of our method to several\r\n\tother techniques
+  abstract: "Liquid chromatography coupled to mass spectrometry (LC-MS) has becomea
+    major tool for the study of biological processes. High-throughputLC-MS experimentsare
+    frequently conducted in modern laboratories,generating an enormous amountof
+    data per day. A manual inspectionis therefore no longer a feasible task.
+    Consequently, there is aneed for computational tools that can rapidly provide
+    informationaboutmass, elution time, and abundance of the compounds in a
+    LC-MS sample.Wepresent an algorithm for the detection and quantification
+    of peptidesin LC-MS data. Our approach is flexible and independent of the
+    MStechnology in use. It is basedon a combination of the sweep lineparadigm
+    with a novel wavelet function tailoredto detect isotopicpatterns of peptides.
+    We propose a simple voting schema to usetheredundant information in consecutive
+    scans for an accurate determinationofmonoisotopic masses and charge states.
+    By explicitly modeling theinstrument inaccuracy, we are also able to cope
+    with data sets ofdifferent quality and resolution.We evaluate our technique
+    on datafrom different instruments and show that we canrapidly estimate mass,centroid
+    of retention time and abundance of peptides in a sound algorithmicframework.
+    Finally, we compare the performance of our method to severalother techniques
     on three data sets of varying complexity."
   title: Computational Quantification of Peptides from LC-MS data
   type: article
@@ -8874,7 +8874,7 @@
   ispublished: pub
   uri: http://publications.imp.fu-berlin.de/id/eprint/406
   official_url: http://dx.doi.org/10.1089/cmb.2007.0117
-  keywords: "computational mass spectrometry, liquid chromatography - massspectrometry,\tquantification,
+  keywords: "computational mass spectrometry, liquid chromatography - massspectrometry,quantification,
     wavelets"
   date: 2008
   pagerange: 685-704
@@ -8931,7 +8931,7 @@
       honourific:
       lineage:
   datestamp: '2009-04-14 14:18:25'
-  title: "A Fast and Accurate Algorithm for the Quantification of Peptides\tfrom Mass
+  title: "A Fast and Accurate Algorithm for the Quantification of Peptidesfrom Mass
     Spectrometry data"
   status_changed: '2009-03-11 11:27:31'
   userid: 1
@@ -8940,7 +8940,7 @@
   lastmod: '2009-04-14 14:18:25'
   ispublished: pub
   uri: http://publications.imp.fu-berlin.de/id/eprint/407
-  event_title: "Proceedings of the Eleventh Annual International Conference on Research\tin
+  event_title: "Proceedings of the Eleventh Annual International Conference on Researchin
     Computational Molecular Biology (RECOMB 2007)"
 - uri: http://publications.imp.fu-berlin.de/id/eprint/408
   ispublished: pub
@@ -8951,35 +8951,35 @@
   type: article
   userid: 1
   status_changed: '2009-03-11 11:27:31'
-  abstract: "BACKGROUND: Mass Spectrometry coupled to Liquid Chromatography (LC-MS)\tis
-    commonly used to analyze the protein content of biological samples\r\n\tin large
-    scale studies. The data resulting from an LC-MS experiment\r\n\tis huge, highly
-    complex and noisy. Accordingly, it has sparked new\r\n\tdevelopments in Bioinformatics,
-    especially in the fields of algorithm\r\n\tdevelopment, statistics and software
-    engineering. In a quantitative\r\n\tlabel-free mass spectrometry experiment, crucial
-    steps are the detection\r\n\tof peptide features in the mass spectra and the alignment
-    of samples\r\n\tby correcting for shifts in retention time. At the moment, it
-    is\r\n\tdifficult to compare the plethora of algorithms for these tasks.\r\n\tSo
-    far, curated benchmark data exists only for peptide identification\r\n\talgorithms
-    but no data that represents a ground truth for the evaluation\r\n\tof feature
-    detection, alignment and filtering algorithms. RESULTS:\r\n\tWe present LC-MSsim,
-    a simulation software for LC-ESI-MS experiments.\r\n\tIt simulates ESI spectra
-    on the MS level. It reads a list of proteins\r\n\tfrom a FASTA file and digests
-    the protein mixture using a user-defined\r\n\tenzyme. The software creates an
-    LC-MS data set using a predictor\r\n\tfor the retention time of the peptides and
-    a model for peak shapes\r\n\tand elution profiles of the mass spectral peaks.
-    Our software also\r\n\toffers the possibility to add contaminants, to change the
-    background\r\n\tnoise level and includes a model for the detectability of peptides\r\n\tin
-    mass spectra. After the simulation, LC-MSsim writes the simulated\r\n\tdata to
-    public XML formats (mzXML or mzData). The software also stores\r\n\tthe positions
-    (monoisotopic m/z and retention time) and ion counts\r\n\tof the simulated ions
-    in separate files. CONCLUSIONS: LC-MSsim generates\r\n\tsimulated LC-MS data sets
-    and incorporates models for peak shapes\r\n\tand contaminations. Algorithm developers
-    can match the results of\r\n\tfeature detection and alignment algorithms against
-    the simulated\r\n\tion lists and meaningful error rates can be computed. We anticipate\r\n\tthat
-    LC-MSsim will be useful to the wider community to perform benchmark\r\n\tstudies
+  abstract: "BACKGROUND: Mass Spectrometry coupled to Liquid Chromatography (LC-MS)is
+    commonly used to analyze the protein content of biological samplesin large
+    scale studies. The data resulting from an LC-MS experimentis huge, highly
+    complex and noisy. Accordingly, it has sparked newdevelopments in Bioinformatics,
+    especially in the fields of algorithmdevelopment, statistics and software
+    engineering. In a quantitativelabel-free mass spectrometry experiment, crucial
+    steps are the detectionof peptide features in the mass spectra and the alignment
+    of samplesby correcting for shifts in retention time. At the moment, it
+    isdifficult to compare the plethora of algorithms for these tasks.So
+    far, curated benchmark data exists only for peptide identificationalgorithms
+    but no data that represents a ground truth for the evaluationof feature
+    detection, alignment and filtering algorithms. RESULTS:We present LC-MSsim,
+    a simulation software for LC-ESI-MS experiments.It simulates ESI spectra
+    on the MS level. It reads a list of proteinsfrom a FASTA file and digests
+    the protein mixture using a user-definedenzyme. The software creates an
+    LC-MS data set using a predictorfor the retention time of the peptides and
+    a model for peak shapesand elution profiles of the mass spectral peaks.
+    Our software alsooffers the possibility to add contaminants, to change the
+    backgroundnoise level and includes a model for the detectability of peptidesin
+    mass spectra. After the simulation, LC-MSsim writes the simulateddata to
+    public XML formats (mzXML or mzData). The software also storesthe positions
+    (monoisotopic m/z and retention time) and ion countsof the simulated ions
+    in separate files. CONCLUSIONS: LC-MSsim generatessimulated LC-MS data sets
+    and incorporates models for peak shapesand contaminations. Algorithm developers
+    can match the results offeature detection and alignment algorithms against
+    the simulatedion lists and meaningful error rates can be computed. We anticipatethat
+    LC-MSsim will be useful to the wider community to perform benchmarkstudies
     and comparisons between computational tools."
-  title: "LC-MSsim - a simulation software for liquid chromatography mass\tspectrometry
+  title: "LC-MSsim - a simulation software for liquid chromatography massspectrometry
     data"
   publication: BMC Bioinformatics
   datestamp: '2009-04-14 14:14:37'
@@ -9065,7 +9065,7 @@
   dir: disk0/00/00/04/03
   lastmod: '2017-03-03 14:40:15'
   ispublished: pub
-  note: "Extended abstract for talk given at Dagstuhl Seminar 05471 on Computational\tProteomics,
+  note: "Extended abstract for talk given at Dagstuhl Seminar 05471 on ComputationalProteomics,
     20.-25. November 2005"
   event_title: Computational Proteomics
   uri: http://publications.imp.fu-berlin.de/id/eprint/403
@@ -9109,7 +9109,7 @@
     can then be further evaluated by tools like Daisy to establish HGT regions. We
     successfully validated our approach on both simulated and real data, and show
     its benefits in an investigation of an outbreak involving Methicillin-resistant
-    Staphylococcus aureus data.\r\n\r\nAuthor summary\r\n\r\nEvolution is traditionally
+    Staphylococcus aureus data.Author summaryEvolution is traditionally
     viewed as a process where changes are only vertically inherited from parent to
     offspring across generations. Many principles such as phylogenetic trees and even
     the “tree of life” are based on that doctrine. The concept of horizontal gene
@@ -9425,21 +9425,21 @@
   type: article
   rev_number: 3
   title: OpenMS - An open-source software framework for mass spectrometry
-  abstract: "BACKGROUND: Mass spectrometry is an essential analytical technique\tfor
-    high-throughput analysis in proteomics and metabolomics. The\r\n\tdevelopment
-    of new separation techniques, precise mass analyzers\r\n\tand experimental protocols
-    is a very active field of research. This\r\n\tleads to more complex experimental
-    setups yielding ever increasing\r\n\tamounts of data. Consequently, analysis of
-    the data is currently\r\n\toften the bottleneck for experimental studies. Although
-    software\r\n\ttools for many data analysis tasks are available today, they are\r\n\toften
-    hard to combine with each other or not flexible enough to allow\r\n\tfor rapid
-    prototyping of a new analysis workflow. RESULTS: We present\r\n\tOpenMS, a software
-    framework for rapid application development in\r\n\tmass spectrometry. OpenMS
-    has been designed to be portable, easy-to-use\r\n\tand robust while offering a
-    rich functionality ranging from basic\r\n\tdata structures to sophisticated algorithms
-    for data analysis. This\r\n\thas already been demonstrated in several studies.
-    CONCLUSIONS: OpenMS\r\n\tis available under the Lesser GNU Public License (LGPL)
-    from the\r\n\tproject website at http://www.openms.de."
+  abstract: "BACKGROUND: Mass spectrometry is an essential analytical techniquefor
+    high-throughput analysis in proteomics and metabolomics. Thedevelopment
+    of new separation techniques, precise mass analyzersand experimental protocols
+    is a very active field of research. Thisleads to more complex experimental
+    setups yielding ever increasingamounts of data. Consequently, analysis of
+    the data is currentlyoften the bottleneck for experimental studies. Although
+    softwaretools for many data analysis tasks are available today, they areoften
+    hard to combine with each other or not flexible enough to allowfor rapid
+    prototyping of a new analysis workflow. RESULTS: We presentOpenMS, a software
+    framework for rapid application development inmass spectrometry. OpenMS
+    has been designed to be portable, easy-to-useand robust while offering a
+    rich functionality ranging from basicdata structures to sophisticated algorithms
+    for data analysis. Thishas already been demonstrated in several studies.
+    CONCLUSIONS: OpenMSis available under the Lesser GNU Public License (LGPL)
+    from theproject website at http://www.openms.de."
   status_changed: '2009-03-11 11:27:32'
   datestamp: '2009-04-14 14:16:52'
   publication: BMC Bioinformatics
@@ -9512,10 +9512,10 @@
   ispublished: pub
   uri: http://publications.imp.fu-berlin.de/id/eprint/1455
   official_url: http://bioinformatics.oxfordjournals.org/content/early/2014/07/29/bioinformatics.btu431.full
-  abstract: "MOTIVATION:\r\nThe landscape of structural variation (SV) including complex
+  abstract: "MOTIVATION:The landscape of structural variation (SV) including complex
     duplication and translocation patterns is far from resolved. SV detection tools
     usually exhibit low agreement, are often geared toward certain types or size ranges
-    of variation and struggle to correctly classify the type and exact size of SVs.\r\n\r\nRESULTS:\r\nWe
+    of variation and struggle to correctly classify the type and exact size of SVs.RESULTS:We
     present Gustaf (Generic mUlti-SpliT Alignment Finder), a sound generic multi-split
     SV detection tool that detects and classifies deletions, inversions, dispersed
     duplications and translocations of <span class='mathrm'>ge</span>30 bp. Our approach
@@ -9527,7 +9527,7 @@
     size and location of dispersed duplications and translocations, which otherwise
     might be wrongly classified, for example, as large deletions. Availability and
     implementation: Project information, paper benchmark and source code are available
-    via http://www.seqan.de/projects/gustaf/.\r\n\r\nCONTACT:kathrin.trappe@fu-berlin.de."
+    via http://www.seqan.de/projects/gustaf/.CONTACT:kathrin.trappe@fu-berlin.de."
   status_changed: '2014-12-10 15:11:43'
   title: 'Gustaf: Detecting and correctly classifying SVs in the NGS twilight zone'
   type: article
@@ -9592,7 +9592,7 @@
   date: 2001
   dir: disk0/00/00/04/10
   eprint_status: archive
-  event_title: "IEEE 2001 Symposium on Parallel and Large-Data Visualization and\tGraphics"
+  event_title: "IEEE 2001 Symposium on Parallel and Large-Data Visualization andGraphics"
   uri: http://publications.imp.fu-berlin.de/id/eprint/410
   lastmod: '2017-03-03 14:40:15'
   ispublished: pub
@@ -9850,15 +9850,15 @@
 - rev_number: 7
   type: article
   userid: 132
-  abstract: "Quality control is increasingly recognized as a crucial\r\naspect of
-    mass spectrometry based proteomics. Several\r\nrecent papers discuss relevant
-    parameters for quality\r\ncontrol and present applications to extract these from
-    the\r\ninstrumental raw data. What has been missing, however,\r\nis a standard
-    data exchange format for reporting these\r\nperformance metrics. We therefore
-    developed the qcML\r\nformat, an XML-based standard that follows the design\r\nprinciples
-    of the related mzML, mzIdentML, mzQuantML,\r\nand TraML standards from the HUPO-PSI
-    (Proteomics\r\nStandards Initiative). In addition to the XML format, we\r\nalso
-    provide tools for the calculation of a wide range of\r\nquality metrics as well
+  abstract: "Quality control is increasingly recognized as a crucialaspect of
+    mass spectrometry based proteomics. Severalrecent papers discuss relevant
+    parameters for qualitycontrol and present applications to extract these from
+    theinstrumental raw data. What has been missing, however,is a standard
+    data exchange format for reporting theseperformance metrics. We therefore
+    developed the qcMLformat, an XML-based standard that follows the designprinciples
+    of the related mzML, mzIdentML, mzQuantML,and TraML standards from the HUPO-PSI
+    (ProteomicsStandards Initiative). In addition to the XML format, wealso
+    provide tools for the calculation of a wide range ofquality metrics as well
     as a database format and interconversion tools, so that existing LIMS systems
     can easily add relational storage of the quality control data to their existing
     schema. We here describe the qcML specification, along with possible use cases
@@ -10152,15 +10152,15 @@
       honourific:
       given: P.
       lineage:
-  abstract: " We propose a general approach for frequency based string mining,\twhich
-    has many applications, e.g. in contrast data mining. Our contribution\n\tis a
-    novel algorithm based on a deferred data structure. Despite\n\tits simplicity,
-    our approach is up to 4 times faster and uses about\n\thalf the memory compared
-    to the best-known algorithm of Fischer et\n\tal. Applications in various string
-    domains, e.g. natural language,\n\tDNA or protein sequences, demonstrate the improvement
+  abstract: " We propose a general approach for frequency based string mining,which
+    has many applications, e.g. in contrast data mining. Our contributionis a
+    novel algorithm based on a deferred data structure. Despiteits simplicity,
+    our approach is up to 4 times faster and uses abouthalf the memory compared
+    to the best-known algorithm of Fischer etal. Applications in various string
+    domains, e.g. natural language,DNA or protein sequences, demonstrate the improvement
     of our algorithm."
   status_changed: '2009-03-11 11:27:34'
-  title: "Efficient String Mining under Constraints via the Deferred Frequency\tIndex"
+  title: "Efficient String Mining under Constraints via the Deferred FrequencyIndex"
   publisher: Springer Verlag
   type: conference_item
   rev_number: 3
@@ -10336,12 +10336,12 @@
     developments promise the personal $1,000 genome in a couple of years. The analysis
     of these unprecedented amounts of data demands for efficient data structures and
     algorithms. One such data structures is the substring index, that represents all
-    substrings or substrings up to a certain length contained in a given text.\r\nIn
+    substrings or substrings up to a certain length contained in a given text.In
     this thesis we propose 3 substring indices, which we extend to be applicable to
     millions of sequences. We devise internal and external memory construction algorithms
     and a uniform framework for accessing the generalized suffix tree. Additionally
     we propose different index-based applications, e.g. exact and approximate pattern
-    matching and different repeat search algorithms.\r\nSecond, we present the read
+    matching and different repeat search algorithms.Second, we present the read
     mapping tool RazerS, which aligns millions of single or paired-end reads of arbitrary
     lengths to their potential genomic origin using either Hamming or edit distance.
     Our tool can work either lossless or with a user-defined loss rate at higher speeds.
@@ -10349,7 +10349,7 @@
     reads than specified. This enables the user to adapt to the problem at hand and
     provides a seamless tradeoff between sensitivity and running time. We compare
     RazerS with other state-of-the-art read mappers and show that it has the highest
-    sensitivity and a comparable performance on various real-world datasets.\r\nAt
+    sensitivity and a comparable performance on various real-world datasets.At
     last, we propose a general approach for frequency based string mining, which has
     many applications, e.g. in contrast data mining. Our contribution is a novel and
     lightweight algorithm that is faster and uses less memory than the best available
@@ -10543,7 +10543,7 @@
     and new protocols provide longer reads than currently available. In almost all
     applications, read mapping is a first step. Hence, it is crucial to have algorithms
     and implementations that perform fast, with high sensitivity, and are able to
-    deal with long reads and a large absolute number of indels.\r\n\r\nResults: RazerS
+    deal with long reads and a large absolute number of indels.Results: RazerS
     is a read mapping program with adjustable sensitivity based on counting q-grams.
     In this work we propose the successor RazerS 3 which now supports shared-memory
     parallelism, an additional seed-based filter with adjustable sensitivity, a much
@@ -10553,7 +10553,7 @@
     compare RazerS 3 with other popular read mappers and show that its results are
     often superior to them in terms of sensitivity while exhibiting practical and
     often competetive run times. In addition, RazerS 3 works without a precomputed
-    index.\r\n\r\nAvailability and Implementation: Source code and binaries are freely
+    index.Availability and Implementation: Source code and binaries are freely
     available for download at http://www.seqan.de/projects/razers. RazerS 3 is implemented
     in C++ and OpenMP under a GPL license using the SeqAn library and supports Linux,
     Mac OS X, and Windows."
@@ -10717,17 +10717,17 @@
   title: 'VARSCOT: variant-aware detection and scoring enables sensitive and personalized
     off-target detection for CRISPR-Cas9'
   status_changed: '2020-04-02 11:57:40'
-  abstract: "Background\r\n\r\nNatural variations in a genome can drastically alter
+  abstract: "BackgroundNatural variations in a genome can drastically alter
     the CRISPR-Cas9 off-target landscape by creating or removing sites. Despite the
     resulting potential side-effects from such unaccounted for sites, current off-target
     detection pipelines are not equipped to include variant information. To address
-    this, we developed VARiant-aware detection and SCoring of Off-Targets (VARSCOT).\r\n\r\nResults\r\n\r\nVARSCOT
+    this, we developed VARiant-aware detection and SCoring of Off-Targets (VARSCOT).ResultsVARSCOT
     identifies only 0.6% of off-targets to be common between 4 individual genomes
     and the reference, with an average of 82% of off-targets unique to an individual.
     VARSCOT is the most sensitive detection method for off-targets, finding 40 to
     70% more experimentally verified off-targets compared to other popular software
     tools and its machine learning model allows for CRISPR-Cas9 concentration aware
-    off-target activity scoring.\r\n\r\nConclusions\r\n\r\nVARSCOT allows researchers
+    off-target activity scoring.ConclusionsVARSCOT allows researchers
     to take genomic variation into account when designing individual or population-wide
     targeting strategies. VARSCOT is available from https://github.com/BauerLab/VARSCOT."
   publication: BMC Biotechnology
@@ -10790,7 +10790,7 @@
   userid: 1
   type: article
   rev_number: 3
-  title: "Transformation and other factors of the peptide mass spectormetry\tpairwise
+  title: "Transformation and other factors of the peptide mass spectormetrypairwise
     peaklist comparison process"
   status_changed: '2009-03-11 11:27:35'
   publication: BMC Bioinformatics
@@ -10880,7 +10880,7 @@
       family: Reinert
   publication: BMC Bioinformatics
   datestamp: '2017-03-03 14:40:15'
-  title: "Calibration of mass spectrometric peptide mass fingerprint data without\tspecific
+  title: "Calibration of mass spectrometric peptide mass fingerprint data withoutspecific
     external or internal calibrants"
   status_changed: '2009-03-11 11:27:34'
   userid: 1
@@ -10970,12 +10970,12 @@
   rev_number: 9
   type: article
   title: Optimal precursor ion selection for LC-MALDI MS/MS
-  abstract: "Background\r\nLiquid chromatography mass spectrometry (LC-MS) maps in
+  abstract: "BackgroundLiquid chromatography mass spectrometry (LC-MS) maps in
     shotgun proteomics are often too complex to select every detected peptide signal
     for fragmentation by tandem mass spectrometry (MS/MS). Standard methods for precursor
     ion selection, commonly based on data dependent acquisition, select highly abundant
     peptide signals in each spectrum. However, these approaches produce redundant
-    information and are biased towards high-abundance proteins.\r\n\r\nResults\r\nWe
+    information and are biased towards high-abundance proteins.ResultsWe
     present two algorithms for inclusion list creation that formulate precursor ion
     selection as an optimization problem. Given an LC-MS map, the first approach maximizes
     the number of selected precursors given constraints such as a limited number of
@@ -10987,11 +10987,11 @@
     risk of erroneous assignments by including methods for retention time and proteotypicity
     predictions. We show that our method identifies a set of proteins requiring fewer
     precursors than standard approaches. Thus, it is well suited for precursor ion
-    selection in experiments with limited sample amount or analysis time.\r\n\r\nConclusions\r\nWe
+    selection in experiments with limited sample amount or analysis time.ConclusionsWe
     present three approaches to precursor ion selection with LC-MALDI MS/MS. Using
     a well-defined protein standard and a complex human cell lysate, we demonstrate
     that our methods outperform standard approaches. Our algorithms are implemented
-    as part of OpenMS and are available under http://www.openms.de.\r\n"
+    as part of OpenMS and are available under http://www.openms.de."
   status_changed: '2014-03-18 16:04:51'
   datestamp: '2014-03-18 15:56:36'
   publication: BMC Bioinformatics
@@ -11222,7 +11222,7 @@
   rev_number: 17
   type: conference_item
   title: 'From the Desktop to the Grid: conversion of KNIME Workflows to gUSE'
-  abstract: "The Konstanz Information Miner is a user-friendly\r\ngraphical workflow
+  abstract: "The Konstanz Information Miner is a user-friendlygraphical workflow
     designer with a broad user base in industry and academia. Its broad range of embedded
     tools and its powerful data mining and visualization tools render it ideal for
     scientific workflows. It is thus used more and more in a broad range of applications.
@@ -11230,14 +11230,14 @@
     if they want to tap into computing power. The grid and cloud User Support Environment
     is a free and open source project created for parallelized and distributed systems,
     but the creation of workflows with the included components has a steeper learning
-    curve.\r\nIn this work we suggest an easy to implement solution\r\ncombining the
-    ease-of-use of the Konstanz Information Miner\r\nwith the computational power
+    curve.In this work we suggest an easy to implement solutioncombining the
+    ease-of-use of the Konstanz Information Minerwith the computational power
     of distributed computing infrastructures. We present a solution permitting the
     conversion of workflows between the two platforms. This enables a convenient development,
     debugging, and maintenance of scientific workflows on the desktop. These workflows
-    can then be deployed on a cloud or grid, thus permitting large-scale computation.\r\nTo
-    achieve our goals, we relied on a Common Tool Description\r\nXML file format which
-    describes the execution of arbitrary\r\nprograms in a structured and easily readable
+    can then be deployed on a cloud or grid, thus permitting large-scale computation.To
+    achieve our goals, we relied on a Common Tool DescriptionXML file format which
+    describes the execution of arbitraryprograms in a structured and easily readable
     and parseable way. In order to integrate external programs into we employed the
     Generic KNIME Nodes extension."
   status_changed: '2014-08-19 14:26:35'
@@ -11312,7 +11312,7 @@
   rev_number: 5
   title: 'From the desktop to the grid: scalable bioinformatics via workflow conversion'
   status_changed: '2017-11-22 13:42:20'
-  abstract: "Background\r\n\r\nReproducibility is one of the tenets of the scientific
+  abstract: "BackgroundReproducibility is one of the tenets of the scientific
     method. Scientific experiments often comprise complex data flows, selection of
     adequate parameters, and analysis and visualization of intermediate and end results.
     Breaking down the complexity of such experiments into the joint collaboration
@@ -11320,11 +11320,11 @@
     and outputs, offers the immediate benefit of identifying bottlenecks, pinpoint
     sections which could benefit from parallelization, among others. Workflows rest
     upon the notion of splitting complex work into the joint effort of several manageable
-    tasks.\r\n\r\nThere are several engines that give users the ability to design
+    tasks.There are several engines that give users the ability to design
     and execute workflows. Each engine was created to address certain problems of
     a specific community, therefore each one has its advantages and shortcomings.
     Furthermore, not all features of all workflow engines are royalty-free —an aspect
-    that could potentially drive away members of the scientific community.\r\n\r\nResults\r\n\r\nWe
+    that could potentially drive away members of the scientific community.ResultsWe
     have developed a set of tools that enables the scientific community to benefit
     from workflow interoperability. We developed a platform-free structured representation
     of parameters, inputs, outputs of command-line tools in so-called Common Tool
@@ -11334,7 +11334,7 @@
     editor, and the Grid and User Support Environment, a web-based framework able
     to interact with several high-performance computing resources. We have thus created
     a free and highly accessible way to design workflows on a desktop computer and
-    execute them on high-performance computing resources.\r\n\r\nConclusions\r\n\r\nOur
+    execute them on high-performance computing resources.ConclusionsOur
     work will not only reduce time spent on designing scientific workflows, but also
     make executing workflows on remote high-performance computing resources more accessible
     to technically inexperienced users. We strongly believe that our efforts not only

--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -1,1468 +1,96 @@
 ---
-- date: 2017-08
-  place_of_pub: Saarbrücken/Wadern
-  subjects:
-  - G400
-  divisions:
-  - group_algbioinf
-  volume: 88
-  eprint_status: archive
-  dir: disk0/00/00/21/32
-  series: LIPICS
-  metadata_visibility: show
-  date_type: published
-  full_text_status: none
-  refereed: 'TRUE'
-  eprintid: 2132
-  title: 17th International Workshop on Algorithms in Bioinformatics (WABI 2017)
-  abstract: "This proceedings volume contains papers presented at the 17th Workshop
-    on Algorithms in Bioinformatics (WABI 2017), which was held in Boston, MA, USA
-    in conjunction with the 8th ACM Conference on Bioinformatics, Computational Biology,
-    and Health Informatics (ACM BCB) from August 21–23, 2017.The Workshop on Algorithms
-    in Bioinformatics is an annual conference established in 2001 to cover all aspects
-    of algorithmic work in bioinformatics, computational biology, and systems biology.
-    The workshop is intended as a forum for discrete algorithms and machine-learning
-    methods that address important problems in molecular biology, that are founded
-    on sound models, that are computationally efficient, and that have been implemented
-    and tested in simulations and on real datasets. The meeting’s focus is on recent
-    research results, including significant work-in-progress, as well as identifying
-    and explore directions of future research.WABI 2017 is grateful for the support
-    of ACM-BCB in allowing us to cohost the meetings, as well as to ACM-BCB’s sponsors:
-    the Association for Computing Machinery (ACM) and ACM’s SIGBIO.In 2017, a
-    total of 55 manuscripts were submitted to WABI from which 27 were selected for
-    presentation at the conference. This year, WABI is adopting a new proceedings
-    form, publishing the conference proceedings through the LIPIcs (Leibniz International
-    Proceedings in Informatics) proceedings series. Extended versions of selected
-    papers will be invited for publication in a thematic series in the journal Algorithms
-    for Molecular Biology (AMB), published by BioMed Central.The 27 papers were
-    selected based on a thorough peer review, involving at least three independent
-    reviewers per submitted paper, followed by discussions among the WABI Program
-    Committee members. The selected papers cover a wide range of topics, including
-    statistical inference, phylogenetic studies, sequence and genome analysis, comparative
-    genomics, and mass spectrometry data analysis.We thank all the authors of
-    submitted papers and the members of the WABI Program Committee and their reviewers
-    for their efforts that made this conference possible. We are also grateful to
-    the WABI Steering Committee for their help and advice. We also thank all the conference
-    participants and speakers who contribute to a great scientific program. Inparticular,
-    we are indebted to the keynote speaker of the conference, Tandy Warnow, for her
-    presentation. We also thank Christopher Pockrandt for setting up the WABI webpageand
-    Umit Acar for his help with coordinating the WABI and ACM-BCB pages. Finally,
-    we thank the ACM-BCB Organizing Committee, especially Nurit Haspel and Lenore
-    Cowen,for their hard work in making all of the local arrangements and working
-    closely with us to ensure a successful and exciting WABI and ACM-BCB."
-  editors:
-  - id:
-    name:
-      lineage:
-      family: Schwartz
-      given: Russell
-      honourific:
-  - name:
-      lineage:
-      family: Reinert
-      honourific:
-      given: Knut
-    id: knut.reinert@fu-berlin.de
-  status_changed: '2017-11-23 11:10:39'
-  userid: 132
-  type: book
-  publisher: Dagstuhl LIPIcs
-  rev_number: 7
-  related_url:
-  - url: http://nbn-resolving.de/urn:nbn:de:0030-drops-78120
-  datestamp: '2017-11-23 11:10:39'
-  pages: 394
-  lastmod: '2017-11-23 11:10:39'
-  ispublished: pub
-  isbn: 978-3-95977-050-7
-  uri: http://publications.imp.fu-berlin.de/id/eprint/2132
-  official_url: http://www.dagstuhl.de/dagpub/978-3-95977-050-7
-- datestamp: '2017-03-03 14:40:13'
-  publication: Science
-  title: The Genome Sequence of Drosophila melanogaster
-  status_changed: '2009-03-11 11:26:43'
-  userid: 1
-  rev_number: 3
-  type: article
-  keywords: ASSEMBLY
-  lastmod: '2017-03-03 14:40:13'
-  ispublished: pub
-  uri: http://publications.imp.fu-berlin.de/id/eprint/324
-  eprint_status: archive
-  dir: disk0/00/00/03/24
-  pagerange: 2185-2195
-  date: 2000
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  volume: 287
-  refereed: 'TRUE'
-  eprintid: 324
-  number: 5461
-  item_issues_count: 0
-  metadata_visibility: show
-  full_text_status: none
-- ispublished: pub
-  lastmod: '2013-04-10 11:52:42'
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1143
-  official_url: http://dx.plos.org/10.1371/journal.pone.0040656
-  abstract: "Background: Proteases play an essential part in a variety of biological
-    processes. Beside their importanceunder healthy conditions they are also known
-    to have a crucial role in complex diseases like cancer.It was shown in the
-    last years that not only the fragments produced by proteases but also their dynamics,especially
-    ex vivo, can serve as biomarkers. But so far, only a few approaches were taken
-    to explicitlymodel the dynamics of proteolysis in the context of mass spectrometry.Results:
-    We introduce a new concept model proteolytic processes, the degradation graph.
-    The degra-dation graph is an extension of the cleavage graph, a data structure
-    to reconstruct and visualize theproteolytic process. In contrast to previous
-    approaches we extended the model to incorporate endoproteolyticprocesses and
-    present a method to construct a degradation graph from mass spectrometrytime-series
-    data. Based on a degradation graph and the intensities extracted from the mass
-    spectra it ispossible to estimate reaction rates of the underlying processes.
-    We further suggest a score to rate differentdegradation graphs in their ability
-    to explain the observed data. This score is used in an iterativeheuristic
-    to improve the structure of the initially constructed degradation graph.Conclusion:
-    We show that the proposed method is able to recover all degraded and generatedpeptides,
-    the underlying reactions, and the reaction rates of proteolytic processes based
-    on mass spectrometrytime-series data. We use simulated and real data to demonstrate
-    that a given process can bereconstructed even in the presence of extensive
-    noise, isobaric signals and false identications. While themodel is currently
-    only validated on peptide data it is also applicable to proteins, as long as the
-    necessarytime series data can be produced."
-  status_changed: '2013-04-10 11:52:42'
-  title: Inferring Proteolytic Processes from Mass Spectrometry Time Series Data Using
-    Degradation Graphs
-  publisher: Public Library of Science
-  rev_number: 18
-  type: article
-  userid: 1
+- abstract: "Peptide sequencing from mass spectrometry data is a key step in proteome\
+    \ research. Especially de novo sequencing, the identification of a peptide from\
+    \ its spectrum alone, is still a challenge even for state-of-the-art algorithmic\
+    \ approaches. In this paper we present ANTILOPE, a new fast and flexible approach\
+    \ based on mathematical programming. It builds on the spectrum graph model and\
+    \ works with a variety of scoring schemes. ANTILOPE combines Lagrangian relaxation\
+    \ for solving an integer linear programming formulation with an adaptation of\
+    \ Yen\u2019s k shortest paths algorithm. It shows a significant improvement in\
+    \ running time compared to mixed integer optimization and performs at the same\
+    \ speed like other state-of-the-art tools. We also implemented a generic probabilistic\
+    \ scoring scheme that can be trained automatically for a dataset of annotated\
+    \ spectra and is independent of the mass spectrometer type. Evaluations on benchmark\
+    \ data show that ANTILOPE is competitive to the popular state-of-the-art programs\
+    \ PepNovo and NovoHMM both in terms of run time and accuracy. Furthermore, it\
+    \ offers increased flexibility in the number of considered ion types. ANTILOPE\
+    \ will be freely available as part of the open source proteomics library OpenMS."
+  bibtex: "@article{fu_mi_publications1047,\n abstract = {Peptide sequencing from\
+    \ mass spectrometry data is a key step in proteome research. Especially de novo\
+    \ sequencing, the identification of a peptide from its spectrum alone, is still\
+    \ a challenge even for state-of-the-art algorithmic approaches. In this paper\
+    \ we present ANTILOPE, a new fast and flexible approach based on mathematical\
+    \ programming. It builds on the spectrum graph model and works with a variety\
+    \ of scoring schemes. ANTILOPE combines Lagrangian relaxation for solving an integer\
+    \ linear programming formulation with an adaptation of Yen?s k shortest paths\
+    \ algorithm. It shows a significant improvement in running time compared to mixed\
+    \ integer optimization and performs at the same speed like other state-of-the-art\
+    \ tools. We also implemented a generic probabilistic scoring scheme that can be\
+    \ trained automatically for a dataset of annotated spectra and is independent\
+    \ of the mass spectrometer type. Evaluations on benchmark data show that ANTILOPE\
+    \ is competitive to the popular state-of-the-art programs PepNovo and NovoHMM\
+    \ both in terms of run time and accuracy. Furthermore, it offers increased flexibility\
+    \ in the number of considered ion types. ANTILOPE will be freely available as\
+    \ part of the open source proteomics library OpenMS.},\n address = {Los Alamitos,\
+    \ CA, USA},\n author = {S. Andreotti and G. W. Klau and K. Reinert},\n journal\
+    \ = {IEEE/ACM Transactions on Computational Biology and Bioinformatics (TCBB)\
+    \ },\n month = {March},\n note = {doi: 10.1109/TCBB.2011.59},\n number = {2},\n\
+    \ pages = {385--394},\n publisher = {IEEE Computer Society Press },\n title =\
+    \ {Antilope - A Lagrangian Relaxation Approach to the de novo Peptide Sequencing\
+    \ Problem},\n url = {http://publications.imp.fu-berlin.de/1047/},\n volume = {9},\n\
+    \ year = {2012}\n}\n\n"
   creators:
   - name:
-      family: Aiche
-      honourific:
+      family: Andreotti
       given: S.
-      lineage:
+      honourific: null
+      lineage: null
   - name:
-      honourific:
-      given: K.
+      family: Klau
+      given: G. W.
+      honourific: null
+      lineage: null
+  - name:
       family: Reinert
-      lineage:
-  - name:
-      lineage:
-      family: Schütte
-      honourific:
-      given: Ch.
-  - name:
-      lineage:
-      family: Hildebrand
-      given: D.
-      honourific:
-  - name:
-      given: H.
-      honourific:
-      family: Schlüter
-      lineage:
-  - name:
-      honourific:
-      given: T. O. F.
-      family: Conrad
-      lineage:
-  datestamp: '2012-06-11 17:28:03'
-  publication: PLoS ONE
-  related_url:
-  - type:
-    url: http://www.plosone.org/article/info%3Adoi%2F10.1371%2Fjournal.pone.0040656
-  - type: pub
-    url: http://plosone.org
-  item_issues_count: 0
+      given: K.
+      honourific: null
+      lineage: null
+  date: 2012-03
   date_type: published
-  full_text_status: none
-  metadata_visibility: show
-  number: 7
-  refereed: 'TRUE'
-  eprintid: 1143
-  date: '2012-07-17'
-  pagerange: e40656
-  volume: 7
-  divisions:
-  - group_comp-proteomics
-  - inst_math
-  - group_algbioinf
-  - inst_compsci
-  - group_biocomputing
-  subjects:
-  - G150
-  - C790
-  - G490
-  eprint_status: archive
-  issn: 1932-6203
-  dir: disk0/00/00/11/43
-- item_issues_count: 0
-  full_text_status: none
-  date_type: published
-  metadata_visibility: show
-  id_number: doi:10.1002/pmic.201400391
-  number: 8
-  refereed: 'TRUE'
-  eprintid: 1505
-  date: 2015-04
-  pagerange: 1443-1447
-  volume: 15
+  datestamp: '2011-03-29 13:34:32'
+  dir: disk0/00/00/10/47
   divisions:
   - group_algbioinf
-  subjects:
-  - G400
   eprint_status: archive
-  issn: 16159853
-  dir: disk0/00/00/15/05
-  lastmod: '2016-11-15 14:01:31'
+  eprintid: 1047
+  full_text_status: none
+  id_number: http://doi.ieeecomputersociety.org/10.1109/TCBB.2011.59
   ispublished: pub
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1505
-  official_url: http://dx.doi.org/10.1002/pmic.201400391
-  abstract: 'MS-based proteomics and metabolomics are rapidly evolving research fields
-    driven by the development of novel instruments, experimental approaches, and analysis
-    methods. Monolithic analysis tools perform well on single tasks but lack the flexibility
-    to cope with the constantly changing requirements and experimental setups. Workflow
-    systems, which combine small processing tools into complex analysis pipelines,
-    allow custom-tailored and flexible data-processing workflows that can be published
-    or shared with collaborators. In this article, we present the integration of established
-    tools for computational MS from the open-source software framework OpenMS into
-    the workflow engine Konstanz Information Miner (KNIME) for the analysis of large
-    datasets and production of high-quality visualizations. We provide example workflows
-    to demonstrate combined data processing and visualization for three diverse tasks
-    in computational MS: isobaric mass tag based quantitation in complex experimental
-    setups, label-free quantitation and identification of metabolites, and quality
-    control for proteomics experiments.'
-  status_changed: '2016-11-15 14:01:31'
-  title: Workflows for automated downstream data analysis and visualization in large-scale
-    computational mass spectrometry
-  publisher: Wiley VCH
+  item_issues_count: 0
+  key: fu_mi_publications1047
+  lastmod: '2012-05-16 13:55:44'
+  metadata_visibility: show
+  note: 'doi: 10.1109/TCBB.2011.59'
+  number: 2
+  official_url: http://doi.ieeecomputersociety.org/10.1109/TCBB.2011.59
+  pagerange: 385-394
+  place_of_pub: Los Alamitos, CA, USA
+  publication: 'IEEE/ACM Transactions on Computational Biology and Bioinformatics
+    (TCBB) '
+  publisher: 'IEEE Computer Society Press '
+  refereed: 'TRUE'
   rev_number: 13
-  type: article
-  userid: 132
-  creators:
-  - id:
-    name:
-      lineage:
-      honourific:
-      given: S.
-      family: Aiche
-  - id:
-    name:
-      lineage:
-      given: T.
-      honourific:
-      family: Sachsenberg
-  - id:
-    name:
-      lineage:
-      honourific:
-      given: E.
-      family: Kenar
-  - id:
-    name:
-      family: Walzer
-      given: M.
-      honourific:
-      lineage:
-  - id:
-    name:
-      family: Wiswedel
-      honourific:
-      given: B.
-      lineage:
-  - name:
-      family: Kristl
-      given: T.
-      honourific:
-      lineage:
-    id:
-  - id:
-    name:
-      lineage:
-      family: Boyles
-      given: M.
-      honourific:
-  - id:
-    name:
-      lineage:
-      honourific:
-      given: A.
-      family: Duschl
-  - name:
-      family: Huber
-      honourific:
-      given: C. G.
-      lineage:
-    id:
-  - id:
-    name:
-      lineage:
-      family: Berthold
-      honourific:
-      given: M. R.
-  - name:
-      lineage:
-      family: Reinert
-      honourific:
-      given: K.
-    id: knut.reinert@fu-berlin.de
-  - id:
-    name:
-      lineage:
-      honourific:
-      given: O.
-      family: Kohlbacher
-  datestamp: '2015-02-12 12:07:57'
-  publication: PROTEOMICS
-- date: '2013-09-30'
-  place_of_pub: Berlin, Germany
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  eprint_status: archive
-  dir: disk0/00/00/14/45
-  item_issues_count: 0
-  metadata_visibility: show
-  date_type: published
-  full_text_status: public
-  institution: Freie Universität Berlin
-  eprintid: 1445
-  title: Inferring Proteolytic Processes from Mass Spectrometry Time Series Data
-  status_changed: '2014-08-20 10:50:26'
-  userid: 30
-  type: thesis
-  rev_number: 12
-  creators:
-  - name:
-      lineage:
-      given: S.
-      honourific:
-      family: Aiche
-  thesis_type: phd
-  documents:
-  - language: en
-    files:
-    - uri: http://publications.imp.fu-berlin.de/id/file/18059
-      mime_type: application/pdf
-      filesize: 3615721
-      datasetid: document
-      mtime: '2017-03-03 14:41:37'
-      fileid: 18059
-      filename: thesis_aiche_no_cv.pdf
-      objectid: 617
-    relation:
-    - uri: "/id/document/1276"
-      type: http://eprints.org/relation/hasVersion
-    - type: http://eprints.org/relation/hasVolatileVersion
-      uri: "/id/document/1276"
-    - type: http://eprints.org/relation/haspreviewThumbnailVersion
-      uri: "/id/document/1276"
-    rev_number: 4
-    security: public
-    eprintid: 1445
-    pos: 1
-    mime_type: application/pdf
-    content: published
-    uri: http://publications.imp.fu-berlin.de/id/document/617
-    main: thesis_aiche_no_cv.pdf
-    docid: 617
-    format: application/pdf
-  datestamp: '2014-08-20 10:50:26'
-  department: Mathematics and Computer Science
-  ispublished: pub
-  lastmod: '2017-03-03 14:41:37'
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1445
-- metadata_visibility: show
-  full_text_status: none
-  item_issues_count: 0
-  refereed: 'TRUE'
-  eprintid: 326
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  pagerange: 4-16
-  date: 2002
-  dir: disk0/00/00/03/26
-  eprint_status: archive
-  uri: http://publications.imp.fu-berlin.de/id/eprint/326
-  event_title: "Proceedings of the 1st European Conference on Computational Biology(ECCB
-    2002)"
-  lastmod: '2017-03-03 14:40:13'
-  ispublished: pub
-  userid: 1
-  type: conference_item
-  rev_number: 3
-  title: "Multiple Sequence alignment with arbitrary gap costs: Computing anoptimal
-    solution using polyhedral combinatorics"
-  status_changed: '2009-03-11 11:26:44'
-  datestamp: '2017-03-03 14:40:13'
-  creators:
-  - name:
-      lineage:
-      family: Althaus
-      given: E.
-      honourific:
-  - name:
-      lineage:
-      given: A.
-      honourific:
-      family: Caprara
-  - name:
-      family: Lenhof
-      given: H.-P.
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      family: Reinert
-      honourific:
-      given: K.
-- ispublished: pub
-  lastmod: '2017-03-03 14:40:13'
-  uri: http://publications.imp.fu-berlin.de/id/eprint/325
-  creators:
-  - name:
-      family: Althaus
-      given: E.
-      honourific:
-      lineage:
-  - name:
-      family: Caprara
-      given: A.
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      given: H.-P.
-      honourific:
-      family: Lenhof
-  - name:
-      honourific:
-      given: K.
-      family: Reinert
-      lineage:
-  publication: Mathematical Programming
-  datestamp: '2017-03-03 14:40:13'
-  status_changed: '2009-03-11 11:26:44'
-  title: A Branch-and-Cut Algorithm for Multiple Sequence Alignment
-  type: article
-  rev_number: 3
-  userid: 1
-  number: 105
-  refereed: 'TRUE'
-  eprintid: 325
-  item_issues_count: 0
-  full_text_status: none
-  metadata_visibility: show
-  eprint_status: archive
-  dir: disk0/00/00/03/25
-  date: 2006
-  pagerange: 387-425
-  subjects:
-  - G400
-  divisions:
-  - group_algbioinf
-- volume: 9
+  status_changed: '2012-05-16 13:55:44'
   subjects:
   - G430
   - C
-  divisions:
-  - group_algbioinf
-  place_of_pub: Los Alamitos, CA, USA
-  pagerange: 385-394
-  date: 2012-03
-  dir: disk0/00/00/10/47
-  eprint_status: archive
-  date_type: published
-  full_text_status: none
-  id_number: http://doi.ieeecomputersociety.org/10.1109/TCBB.2011.59
-  metadata_visibility: show
-  item_issues_count: 0
-  number: 2
-  eprintid: 1047
-  refereed: 'TRUE'
-  type: article
-  publisher: 'IEEE Computer Society Press '
-  rev_number: 13
-  userid: 132
-  abstract: Peptide sequencing from mass spectrometry data is a key step in proteome
-    research. Especially de novo sequencing, the identification of a peptide from
-    its spectrum alone, is still a challenge even for state-of-the-art algorithmic
-    approaches. In this paper we present ANTILOPE, a new fast and flexible approach
-    based on mathematical programming. It builds on the spectrum graph model and works
-    with a variety of scoring schemes. ANTILOPE combines Lagrangian relaxation for
-    solving an integer linear programming formulation with an adaptation of Yen’s
-    k shortest paths algorithm. It shows a significant improvement in running time
-    compared to mixed integer optimization and performs at the same speed like other
-    state-of-the-art tools. We also implemented a generic probabilistic scoring scheme
-    that can be trained automatically for a dataset of annotated spectra and is independent
-    of the mass spectrometer type. Evaluations on benchmark data show that ANTILOPE
-    is competitive to the popular state-of-the-art programs PepNovo and NovoHMM both
-    in terms of run time and accuracy. Furthermore, it offers increased flexibility
-    in the number of considered ion types. ANTILOPE will be freely available as part
-    of the open source proteomics library OpenMS.
-  status_changed: '2012-05-16 13:55:44'
   title: Antilope - A Lagrangian Relaxation Approach to the de novo Peptide Sequencing
     Problem
-  publication: 'IEEE/ACM Transactions on Computational Biology and Bioinformatics
-    (TCBB) '
-  datestamp: '2011-03-29 13:34:32'
-  creators:
-  - name:
-      family: Andreotti
-      honourific:
-      given: S.
-      lineage:
-  - name:
-      lineage:
-      family: Klau
-      honourific:
-      given: G. W.
-  - name:
-      lineage:
-      family: Reinert
-      given: K.
-      honourific:
+  type: article
   uri: http://publications.imp.fu-berlin.de/id/eprint/1047
-  ispublished: pub
-  lastmod: '2012-05-16 13:55:44'
-  note: 'doi: 10.1109/TCBB.2011.59'
-  official_url: http://doi.ieeecomputersociety.org/10.1109/TCBB.2011.59
-- official_url: http://www.ncbi.nlm.nih.gov/pubmed/24000925
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1454
-  ispublished: pub
-  lastmod: '2014-09-24 09:33:53'
-  datestamp: '2014-09-24 08:36:24'
-  publication: Journal of Computational Biology
-  creators:
-  - name:
-      given: S.
-      honourific:
-      family: Andreotti
-      lineage:
-  - name:
-      family: Reinert
-      honourific:
-      given: K.
-      lineage:
-  - name:
-      family: Canzar
-      honourific:
-      given: S.
-      lineage:
-  userid: 30
-  rev_number: 12
-  type: article
-  title: 'The duplication-loss small phylogeny problem: from cherries to trees.'
-  abstract: Abstract The reconstruction of the history of evolutionary genome-wide
-    events among a set of related organisms is of great biological interest since
-    it can help to reveal the genomic basis of phenotypes. The sequencing of whole
-    genomes faciliates the study of gene families that vary in size through duplication
-    and loss events, like transfer RNA. However, a high sequence similarity often
-    does not allow one to distinguish between orthologs and paralogs. Previous methods
-    have addressed this difficulty by taking into account flanking regions of members
-    of a family independently. We go one step further by inferring the order of genes
-    of (a set of) families for ancestral genomes by considering the order of these
-    genes on sequenced genomes. We present a novel branch-and-cut algorithm to solve
-    the two species small phylogeny problem in the evolutionary model of duplications
-    and losses. On average, our implementation, DupLoCut, improves the running time
-    of a recently proposed method in the experiments on six Vibrionaceae lineages
-    by a factor of Ã¢&lt;88&gt;Â¼200. Besides the mere improvement in running time,
-    the efficiency of our approach allows us to extend our model from cherries of
-    a species tree, that is, subtrees with two leaves, to the median of three species
-    setting. Being able to determine the median of three species is of key importance
-    to one of the most common approaches to ancestral reconstruction, and our experiments
-    show that its repeated computation considerably reduces the number of duplications
-    and losses along the tree both on simulated instances comprising 128 leaves and
-    a set of Bacillus genomes. Furthermore, in our simulations we show that a reduction
-    in cost goes hand in hand with an improvement of the predicted ancestral genomes.
-    Finally, we prove that the small phylogeny problem in the duplication-loss model
-    is NP-complete already for two species.
-  status_changed: '2014-09-24 09:33:53'
-  eprintid: 1454
-  refereed: 'TRUE'
-  number: 9
-  metadata_visibility: show
-  full_text_status: none
-  item_issues_count: 0
-  dir: disk0/00/00/14/54
-  eprint_status: archive
-  divisions:
-  - group_algbioinf
-  subjects:
-  - C
-  - G
-  volume: 20
-  date: 2013-09
-  pagerange: 643-59
-- userid: 132
-  rev_number: 13
-  publisher: Elsevier
-  type: article
-  title: In-depth analysis of protein inference algorithms using multiple search engines
-    and well-defined metrics
-  abstract: 'In mass spectrometry-based shotgun proteomics, protein identifications
-    are usually the desired result. However, most of the analytical methods are based
-    on the identification of reliable peptides and not the direct identification of
-    intact proteins. Thus, assembling peptides identified from tandem mass spectra
-    into a list of proteins, referred to as protein inference, is a critical step
-    in proteomics research. Currently, different protein inference algorithms and
-    tools are available for the proteomics community. Here, we evaluated five software
-    tools for protein inference (PIA, ProteinProphet, Fido, ProteinLP, MSBayesPro)
-    using three popular database search engines: Mascot, X!Tandem, and MS-GF +. All
-    the algorithms were evaluated using a highly customizable KNIME workflow using
-    four different public datasets with varying complexities (different sample preparation,
-    species and analytical instruments). We defined a set of quality control metrics
-    to evaluate the performance of each combination of search engines, protein inference
-    algorithm, and parameters on each dataset. We show that the results for complex
-    samples vary not only regarding the actual numbers of reported protein groups
-    but also concerning the actual composition of groups. Furthermore, the robustness
-    of reported proteins when using databases of differing complexities is strongly
-    dependant on the applied inference algorithm. Finally, merging the identifications
-    of multiple search engines does not necessarily increase the number of reported
-    proteins, but does increase the number of peptides per protein and thus can generally
-    be recommended.'
-  status_changed: '2017-01-12 10:08:32'
-  datestamp: '2016-08-31 09:06:41'
-  publication: Journal of Proteomics
-  creators:
-  - name:
-      family: Audain
-      given: Enrique
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      family: Uszkoreit
-      honourific:
-      given: Julian
-  - name:
-      lineage:
-      family: Sachsenberg
-      honourific:
-      given: Timo
-  - name:
-      family: Pfeuffer
-      honourific:
-      given: Julianus
-      lineage:
-  - name:
-      family: Liang
-      honourific:
-      given: Xiao
-      lineage:
-  - name:
-      honourific:
-      given: Henning
-      family: Hermjakob
-      lineage:
-  - name:
-      given: Aniel
-      honourific:
-      family: Sanchez
-      lineage:
-  - name:
-      family: Eisenacher
-      honourific:
-      given: Martin
-      lineage:
-  - name:
-      lineage:
-      family: Reinert
-      given: Knut
-      honourific:
-  - name:
-      lineage:
-      family: Tabb
-      honourific:
-      given: David L.
-  - name:
-      lineage:
-      honourific:
-      given: Oliver
-      family: Kohlbacher
-  - name:
-      lineage:
-      family: Perez-Riverol
-      given: Yasset
-      honourific:
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1939
-  ispublished: pub
-  lastmod: '2017-01-12 10:08:32'
-  official_url: http://dx.doi.org/10.1016/j.jprot.2016.08.002
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  volume: 150
-  date: '2017-01-06'
-  pagerange: 170-182
-  dir: disk0/00/00/19/39
-  issn: 18743919
-  eprint_status: archive
-  metadata_visibility: show
-  id_number: doi:10.1016/j.jprot.2016.08.002
-  full_text_status: none
-  date_type: published
-  item_issues_count: 0
-  refereed: 'TRUE'
-  eprintid: 1939
-- rev_number: 3
-  publisher: Wiley-Eastern
-  type: book_section
-  userid: 1
-  status_changed: '2009-03-11 11:26:45'
-  title: Mass Spectrometry and Computational Proteomics
-  datestamp: '2017-03-03 14:40:13'
-  creators:
-  - name:
-      honourific:
-      given: V.
-      family: Bafna
-      lineage:
-  - name:
-      lineage:
-      family: Reinert
-      given: K.
-      honourific:
-  uri: http://publications.imp.fu-berlin.de/id/eprint/327
-  ispublished: pub
-  lastmod: '2017-03-03 14:40:13'
-  book_title: Encyclopedia of Genetics, Genomics, Proteomics and Bioinformatics
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  date: 2005
-  dir: disk0/00/00/03/27
-  eprint_status: archive
-  full_text_status: none
-  metadata_visibility: show
-  item_issues_count: 0
-  eprintid: 327
-  refereed: 'TRUE'
-- creators:
-  - name:
-      honourific:
-      given: J. A.
-      family: Bailey
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: Z.
-      family: Gu
-  - name:
-      lineage:
-      family: Clark
-      honourific:
-      given: R. A.
-  - name:
-      honourific:
-      given: K.
-      family: Reinert
-      lineage:
-  - name:
-      family: Samonte
-      honourific:
-      given: R. V.
-      lineage:
-  - name:
-      lineage:
-      family: Schwartz
-      given: S. S.
-      honourific:
-  - name:
-      lineage:
-      given: M. D.
-      honourific:
-      family: Adams
-  - name:
-      lineage:
-      given: E. W.
-      honourific:
-      family: Myers
-  - name:
-      lineage:
-      honourific:
-      given: P.
-      family: Li
-  - name:
-      given: E. E.
-      honourific:
-      family: Eichler
-      lineage:
-  datestamp: '2017-03-03 14:40:13'
-  publication: Science
-  title: Recent Segmental Duplications in the Human Genome
-  status_changed: '2009-03-11 11:26:45'
-  userid: 1
-  type: article
-  rev_number: 3
-  ispublished: pub
-  lastmod: '2017-03-03 14:40:13'
-  uri: http://publications.imp.fu-berlin.de/id/eprint/328
-  eprint_status: archive
-  dir: disk0/00/00/03/28
-  date: 2002
-  pagerange: 1003-1007
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  volume: 297
-  refereed: 'TRUE'
-  eprintid: 328
-  item_issues_count: 0
-  metadata_visibility: show
-  full_text_status: none
-- monograph_type: technical_report
-  datestamp: '2009-04-14 14:41:05'
-  creators:
-  - name:
-      honourific:
-      given: G.
-      family: Baudis
-      lineage:
-  - name:
-      family: Gröpl
-      given: C.
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      family: Hougardy
-      given: S.
-      honourific:
-  - name:
-      family: Nierhoff
-      honourific:
-      given: T.
-      lineage:
-  - name:
-      honourific:
-      given: H.-J.
-      family: Prömel
-      lineage:
-  userid: 1
-  rev_number: 3
-  type: monograph
-  title: Approximating Minimum Spanning Sets in Hypergraphs and Polymatroids
-  status_changed: '2009-03-11 11:26:46'
-  keywords: "Hypergraphs, set systems, and designs, Steiner trees, Approximationalgorithms,
-    Colouring, packing and covering, Combinatorial optimization,Graph algorithms"
-  uri: http://publications.imp.fu-berlin.de/id/eprint/329
-  note: "This paper was already accepted for ICALP 2000 but we did not presentit
-    since later we were informed that the main result had alreadybeen proven
-    in a different way."
-  lastmod: '2009-04-14 14:41:05'
-  ispublished: pub
-  dir: disk0/00/00/03/29
-  eprint_status: archive
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  date: 2000
-  institution: Humboldt-University Berlin
-  refereed: 'TRUE'
-  eprintid: 329
-  metadata_visibility: show
-  full_text_status: none
-  item_issues_count: 0
-- date: 2008
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  eprint_status: archive
-  dir: disk0/00/00/03/31
-  item_issues_count: 0
-  full_text_status: none
-  metadata_visibility: show
-  eprintid: 331
-  refereed: 'TRUE'
-  status_changed: '2009-03-11 11:26:47'
-  title: "An Exact Mathematical Programming Approach to Multiple RNA Sequence-StructureAlignment."
-  type: article
-  rev_number: 3
-  userid: 1
-  creators:
-  - name:
-      family: Bauer
-      given: M.
-      honourific:
-      lineage:
-  - name:
-      family: Klau
-      given: G. W.
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      family: Reinert
-      honourific:
-      given: K.
-  datestamp: '2009-08-20 09:47:13'
-  publication: Algorithmic Operations Research
-  ispublished: pub
-  lastmod: '2009-08-20 09:47:13'
-  note: to appear
-  uri: http://publications.imp.fu-berlin.de/id/eprint/331
-- type: conference_item
-  rev_number: 3
-  userid: 1
-  status_changed: '2009-03-11 11:26:49'
-  title: "Fast and Accurate Structural RNA Alignment by Progressive LagrangianRelaxation"
-  datestamp: '2017-03-03 14:40:13'
-  creators:
-  - name:
-      lineage:
-      given: M.
-      honourific:
-      family: Bauer
-  - name:
-      given: G. W.
-      honourific:
-      family: Klau
-      lineage:
-  - name:
-      given: K.
-      honourific:
-      family: Reinert
-      lineage:
-  uri: http://publications.imp.fu-berlin.de/id/eprint/334
-  event_title: "Proceedings of the 1st International Symposium on Computational LifeScience
-    (CompLife-05)"
-  lastmod: '2017-03-03 14:40:13'
-  ispublished: pub
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  pagerange: 217-228
-  date: 2005
-  dir: disk0/00/00/03/34
-  eprint_status: archive
-  full_text_status: none
-  metadata_visibility: show
-  item_issues_count: 0
-  refereed: 'TRUE'
-  eprintid: 334
-- dir: disk0/00/00/03/33
-  eprint_status: archive
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  pagerange: 303-314
-  date: 2005
-  eprintid: 333
-  refereed: 'TRUE'
-  metadata_visibility: show
-  full_text_status: none
-  item_issues_count: 0
-  datestamp: '2017-03-03 14:40:13'
-  creators:
-  - name:
-      given: M.
-      honourific:
-      family: Bauer
-      lineage:
-  - name:
-      family: Klau
-      honourific:
-      given: G. W.
-      lineage:
-  - name:
-      given: K.
-      honourific:
-      family: Reinert
-      lineage:
-  userid: 1
-  rev_number: 3
-  type: conference_item
-  title: Multiple Structural RNA Alignment with Lagrangian Relaxation
-  status_changed: '2009-03-11 11:26:48'
-  event_title: Proceedings of the 5th Workshop on Algorithms Bioinformatics (WABI-05)
-  uri: http://publications.imp.fu-berlin.de/id/eprint/333
-  lastmod: '2017-03-03 14:40:13'
-  ispublished: pub
-- refereed: 'TRUE'
-  eprintid: 330
-  item_issues_count: 0
-  series: LNCS 3341
-  full_text_status: none
-  metadata_visibility: show
-  eprint_status: archive
-  dir: disk0/00/00/03/30
-  date: 2004
-  pagerange: 113-125
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  lastmod: '2017-03-03 14:40:13'
-  ispublished: pub
-  event_title: "Proceedings of the 15th International Symposium, ISAAC 2004, HongKong"
-  uri: http://publications.imp.fu-berlin.de/id/eprint/330
-  creators:
-  - name:
-      lineage:
-      family: Bauer
-      honourific:
-      given: M.
-  - name:
-      lineage:
-      given: G. W.
-      honourific:
-      family: Klau
-  datestamp: '2017-03-03 14:40:13'
-  status_changed: '2009-03-11 11:26:47'
-  title: Structural Alignment of Two RNA Sequences with Lagrangian Relaxation
-  type: conference_item
-  publisher: Springer Verlag
-  rev_number: 3
-  userid: 1
-- creators:
-  - name:
-      family: Bauer
-      given: M.
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: G. W.
-      family: Klau
-  - name:
-      lineage:
-      given: K.
-      honourific:
-      family: Reinert
-  datestamp: '2017-03-03 14:40:13'
-  publication: BMC Bioinformatics
-  status_changed: '2009-03-11 11:26:48'
-  title: "Accurate multiple sequence-structure alignment of RNA sequences usingcombinatorial
-    optimization."
-  rev_number: 3
-  type: article
-  userid: 1
-  lastmod: '2017-03-03 14:40:13'
-  ispublished: pub
-  uri: http://publications.imp.fu-berlin.de/id/eprint/332
-  eprint_status: archive
-  dir: disk0/00/00/03/32
-  date: 2007-07
-  pagerange: 271
-  volume: 8
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  number: 1
-  eprintid: 332
-  refereed: 'TRUE'
-  item_issues_count: 0
-  full_text_status: none
-  metadata_visibility: show
-- eprint_status: archive
-  issn: 1999-4893
-  dir: disk0/00/00/04/50
-  date: 2009
-  pagerange: 692-709
-  volume: 2
-  subjects:
-  - G
-  divisions:
-  - group_algbioinf
-  number: 2
-  eprintid: 450
-  refereed: 'TRUE'
-  item_issues_count: 0
-  full_text_status: none
-  date_type: published
-  id_number: 10.3390/a2020692
-  metadata_visibility: show
-  creators:
-  - name:
-      given: R. A.
-      honourific:
-      family: Bauer
-      lineage:
-    id: ra.bauer@fu-berlin.de
-  - id:
-    name:
-      honourific:
-      given: K.
-      family: Rother
-      lineage:
-  - id:
-    name:
-      lineage:
-      family: Moor
-      honourific:
-      given: P.
-  - name:
-      lineage:
-      family: Reinert
-      given: K.
-      honourific:
-    id:
-  - name:
-      lineage:
-      family: Steinke
-      given: T.
-      honourific:
-    id:
-  - id:
-    name:
-      honourific:
-      given: J. M.
-      family: Bujnicki
-      lineage:
-  - id:
-    name:
-      lineage:
-      given: R.
-      honourific:
-      family: Preissner
-  datestamp: '2009-04-03 08:57:21'
-  publication: Algorithms and Molecular Sciences
-  status_changed: '2009-10-28 12:51:35'
-  abstract: "This work presents a generalized approach for the fast structural alignment
-    of thousands of macromolecular structures. The method uses string representations
-    of a macromolecular structure and a hash table that stores n-grams of a certain
-    size for searching. To this end, macromolecular structure-to-string translators
-    were implemented for protein and RNA structures. A query against the index is
-    performed in two hierarchical steps to unite speed and precision. In the ﬁrst
-    step the query structure is translated into n-grams, and all target structures
-    containing these n-grams are retrieved from the hash table. In the second step
-    all corresponding n-grams of the query and each target structure are subsequently
-    aligned, and after each alignment a score is calculated based on the matching
-    n-grams of query and target. The extendable framework enables the user to query
-    and structurally align thousands of protein and RNA structures on a commodity
-    machine and is available as open source from http://la jolla.sf.net. "
-  title: Fast Structural Alignment of Biomolecules Using a Hash Table, N-Grams and
-    String Descriptors
-  type: article
-  publisher: MDPI
-  rev_number: 12
-  userid: 29
-  official_url: http://www.mdpi.com/1999-4893/2/2/692
-  lastmod: '2010-09-01 13:28:41'
-  ispublished: pub
-  uri: http://publications.imp.fu-berlin.de/id/eprint/450
-- datestamp: '2011-04-29 12:38:12'
-  publication: Methods in molecular biology (Clifton, N.J.)
-  creators:
-  - name:
-      given: C.
-      honourific:
-      family: Bielow
-      lineage:
-  - name:
-      family: Gröpl
-      given: C.
-      honourific:
-      lineage:
-  - name:
-      family: Kohlbacher
-      given: O.
-      honourific:
-      lineage:
-  - name:
-      given: K.
-      honourific:
-      family: Reinert
-      lineage:
-  userid: 30
-  type: book_section
-  publisher: Humana Press
-  rev_number: 11
-  title: Bioinformatics for qualitative and quantitative proteomics.
-  status_changed: '2011-04-29 12:38:12'
-  abstract: Mass spectrometry is today a key analytical technique to elucidate the
-    amount and content of proteins expressed in a certain cellular context. The degree
-    of automation in proteomics has yet to reach that of genomic techniques, but even
-    current technologies make a manual inspection of the data infeasible. This article
-    addresses the key algorithmic problems bioinformaticians face when handling modern
-    proteomic samples and shows common solutions to them. We provide examples on how
-    algorithms can be combined to build relatively complex analysis pipelines, point
-    out certain pitfalls and aspects worth considering and give a list of current
-    state-of-the-art tools.
-  official_url: http://www.ncbi.nlm.nih.gov/pubmed/21370091
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1067
-  book_title: Bioinformatics for Omics Data Methods and Protocols
-  lastmod: '2011-04-29 12:38:12'
-  ispublished: pub
-  dir: disk0/00/00/10/67
-  eprint_status: archive
-  divisions:
-  - group_algbioinf
-  subjects:
-  - C
-  - G
-  volume: 719
-  pagerange: 331-49
-  date: 2011-01
-  eprintid: 1067
-  refereed: 'FALSE'
-  metadata_visibility: show
-  full_text_status: none
-  item_issues_count: 0
-- official_url: http://pubs.acs.org/doi/abs/10.1021/pr100177k
-  uri: http://publications.imp.fu-berlin.de/id/eprint/895
-  note: online publication complete, printed publication to be expected
-  ispublished: pub
-  lastmod: '2010-09-01 13:25:48'
-  publication: J. Proteome Res.
-  datestamp: '2010-04-14 11:06:56'
-  creators:
-  - name:
-      honourific:
-      given: C.
-      family: Bielow
-      lineage:
-    id: bielow@mi.fu-berlin.de
-  - id:
-    name:
-      honourific:
-      given: S.
-      family: Ruzek
-      lineage:
-  - id:
-    name:
-      family: Huber
-      honourific:
-      given: C.
-      lineage:
-  - id: knut.reinert@fu-berlin.de
-    name:
-      family: Reinert
-      given: K.
-      honourific:
-      lineage:
-  userid: 168
-  publisher: ACS Publications
-  rev_number: 10
-  type: article
-  title: Optimal Decharging and Clustering of Charge Ladders Generated in ESI−MS
-  abstract: In electrospray ionization mass spectrometry (ESI−MS), peptide and protein
-    ions are usually observed in multiple charge states. Moreover, adduction of the
-    multiply charged species with other ions frequently results in quite complex signal
-    patterns for a single analyte, which significantly complicates the derivation
-    of quantitative information from the mass spectra. Labeling strategies targeting
-    the MS1 level further aggravate this situation, as multiple biological states
-    such as healthy or diseased must be represented simultaneously. We developed an
-    integer linear programming (ILP) approach, which can cluster signals belonging
-    to the same peptide or protein. The algorithm is general in that it models all
-    possible shifts of signals along the m/z axis. These shifts can be induced by
-    different charge states of the compound, the presence of adducts (e.g., potassium
-    or sodium), and/or a fixed mass label (e.g., from ICAT or nicotinic acid labeling),
-    or any combination of the above. We show that our approach can be used to infer
-    more features in labeled data sets, correct wrong charge assignments even in high-resolution
-    MS, improve mass precision, and cluster charged species in different charge states
-    and several adduct types.
-  status_changed: '2010-04-14 11:06:56'
-  eprintid: 895
-  refereed: 'TRUE'
-  number: 5
-  id_number: 10.1021/pr100177k
-  metadata_visibility: show
-  date_type: published
-  full_text_status: none
-  item_issues_count: 0
-  dir: disk0/00/00/08/95
-  issn: 1535-3893
-  eprint_status: archive
-  subjects:
-  - G400
-  divisions:
-  - group_algbioinf
+  userid: 132
   volume: 9
-  pagerange: 2688-2695
-  date: '2010-03-04'
-- dir: disk0/00/00/14/44
-  eprint_status: archive
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  date: '2012-10-29'
-  place_of_pub: Berlin, Germany
-  institution: Freie Universität Berlin
-  eprintid: 1444
-  metadata_visibility: show
-  date_type: published
-  full_text_status: public
-  item_issues_count: 0
-  documents:
-  - formatdesc: Thesis (without CV)
-    content: published
-    mime_type: application/pdf
-    uri: http://publications.imp.fu-berlin.de/id/document/616
-    docid: 616
-    main: thesis_noCV.pdf
-    format: application/pdf
-    security: public
-    eprintid: 1444
-    pos: 1
-    rev_number: 4
-    language: en
-    files:
-    - fileid: 18031
-      objectid: 616
-      filename: thesis_noCV.pdf
-      datasetid: document
-      mtime: '2017-03-03 14:41:36'
-      mime_type: application/pdf
-      uri: http://publications.imp.fu-berlin.de/id/file/18031
-      filesize: 4488171
-    relation:
-    - uri: "/id/document/1275"
-      type: http://eprints.org/relation/hasVolatileVersion
-    - type: http://eprints.org/relation/haspreviewThumbnailVersion
-      uri: "/id/document/1275"
-    - type: http://eprints.org/relation/hasVersion
-      uri: "/id/document/1275"
-  thesis_type: phd
-  datestamp: '2014-08-20 09:50:37'
-  creators:
-  - name:
-      lineage:
-      given: C.
-      honourific:
-      family: Bielow
-  userid: 30
-  type: thesis
-  rev_number: 10
-  title: Quantification and Simulation of Liquid Chromatography-Mass Spectrometry
-    Data
-  abstract: "Computational mass spectrometry is a fast evolving field that has attracted
-    increased attention over the last couple of years.The performance of software
-    solutions determines the success of analysis to a great extent. New algorithms
-    are required to reflect new experimental procedures and deal with new instrument
-    generations.One essential component of algorithm development is the validation
-    (as well as comparison) of software on a broad range ofdata sets. This requires
-    a gold standard (or so-called ground truth), which is usually obtained by manual
-    annotation of a real data set.Comprehensive manually annotated public data
-    sets for mass spectrometry data are labor-intensive to produce and their quality
-    strongly depends on the skill of the human expert. Some parts of the data
-    may even be impossible to annotate due to high levels of noise or other ambiguities.Furthermore,
-    manually annotated data is usually not available for all steps in a typical computational
-    analysis pipeline.We thus developed the most comprehensive simulation software
-    to date, which allows to generate multiple levels of ground truthand features
-    a plethora of settings to reflect experimental conditions and instrument settings.The
-    simulator is used to generate several distinct types of data. The data are subsequently
-    employed to evaluate existing algorithms.Additionally, we employ simulation
-    to determine the influence of instrument attributes and sample complexity on the
-    ability ofalgorithms to recover information. The results give valuable hints
-    on how to optimize experimental setups.Furthermore, this thesis introduces
-    two quantitative approaches, namely a decharging algorithm based on integer linear
-    programming and a new workflow for identification of differentially expressed
-    proteins for a large in vitro study on toxic compounds.Decharging infers the
-    uncharged mass of a peptide (or protein) by clustering all its charge variants.
-    The latter occur frequently under certain experimental conditions.We employ
-    simulation to show that decharging is robust against missing values even for high
-    complexity data and that the algorithm outperformsother solutions in terms
-    of mass accuracy and run time on real data.The last part of this thesis deals
-    with a new state-of-the-art workflow for protein quantification based on isobaric
-    tags for relative and absolute quantitation (iTRAQ). We devisea new approach
-    to isotope correction, propose an experimental design, introduce new metrics of
-    iTRAQ data quality, andconfirm putative properties of iTRAQ data using a novel
-    approach.All tools developed as part of this thesis are implemented in
-    OpenMS, a C++ library for computational mass spectrometry."
-  status_changed: '2014-08-20 09:50:37'
-  official_url: http://www.diss.fu-berlin.de/diss/receive/FUDISS_thesis_000000040013
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1444
-  department: Mathematics and Computer Science
-  lastmod: '2017-03-03 14:41:36'
-  ispublished: pub
-- eprintid: 1066
-  refereed: 'TRUE'
-  number: 7
-  metadata_visibility: show
-  id_number: 10.1021/pr200155f
-  date_type: published
-  full_text_status: public
-  item_issues_count: 0
-  dir: disk0/00/00/10/66
-  eprint_status: archive
-  subjects:
-  - G
-  divisions:
-  - group_comp-proteomics
-  - group_algbioinf
-  - group_biocomputing
-  volume: 10
-  pagerange: 2922-2929
-  date: 2011-07
-  official_url: http://dx.doi.org/10.1021/pr200155f
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1066
-  lastmod: '2017-03-03 14:41:04'
-  ispublished: pub
-  documents:
-  - rev_number: 4
-    language: en
-    files:
-    - objectid: 470
-      filename: pr200155f.pdf
-      fileid: 12627
-      mtime: '2017-03-03 14:41:04'
-      datasetid: document
-      filesize: 926401
-      uri: http://publications.imp.fu-berlin.de/id/file/12627
-      mime_type: application/pdf
-    relation:
-    - uri: "/id/document/1186"
-      type: http://eprints.org/relation/hasVersion
-    - uri: "/id/document/1186"
-      type: http://eprints.org/relation/haspreviewThumbnailVersion
-    - uri: "/id/document/1186"
-      type: http://eprints.org/relation/hasVolatileVersion
-    format: application/pdf
-    content: published
-    mime_type: application/pdf
-    uri: http://publications.imp.fu-berlin.de/id/document/470
-    main: pr200155f.pdf
-    docid: 470
-    eprintid: 1066
-    pos: 1
-    security: public
-  datestamp: '2011-04-29 10:33:41'
-  publication: Journal of Proteome Research
-  creators:
-  - name:
-      lineage:
-      given: C.
-      honourific:
-      family: Bielow
-  - name:
-      lineage:
-      given: S.
-      honourific:
-      family: Aiche
-  - name:
-      lineage:
-      family: Andreotti
-      given: S.
-      honourific:
-  - name:
-      lineage:
-      family: Reinert
-      honourific:
-      given: K.
-  userid: 30
-  type: article
-  rev_number: 16
-  title: 'MSSimulator: Simulation of Mass Spectrometry Data'
-  status_changed: '2011-11-28 09:09:08'
-  abstract: Mass spectrometry coupled to liquid chromatography (LC-MS and LC-MS/MS)
+- abstract: Mass spectrometry coupled to liquid chromatography (LC-MS and LC-MS/MS)
     is commonly used to analyze the protein content of biological samples in large
     scale studies, enabling quantitation and identification of proteins and peptides
     using a wide range of experimental protocols, algorithms, and statistical models
@@ -1478,3326 +106,1523 @@
     elution profile shape, resolution and sampling rate. Several protocols for SILAC,
     iTRAQ or MS(E) are available, in addition to the usual label-free approach, making
     MSSimulator the most comprehensive simulator for LC-MS and LC-MS/MS data.
-- official_url: http://www.siam.org/proceedings/alenex/2010/alenex10.php
-  ispublished: pub
-  lastmod: '2010-09-01 13:33:56'
-  uri: http://publications.imp.fu-berlin.de/id/eprint/926
+  bibtex: "@article{fu_mi_publications1066,\n abstract = {Mass spectrometry coupled\
+    \ to liquid chromatography (LC-MS and LC-MS/MS) is commonly used to analyze the\
+    \ protein content of biological samples in large scale studies, enabling quantitation\
+    \ and identification of proteins and peptides using a wide range of experimental\
+    \ protocols, algorithms, and statistical models to analyze the data. Currently\
+    \ it is difficult to compare the plethora of algorithms for these tasks. So far,\
+    \ curated benchmark data exists for peptide identification algorithms but data\
+    \ that represents a ground truth for the evaluation of LC-MS data is limited.\
+    \ Hence there have been attempts to simulate such data in a controlled fashion\
+    \ to evaluate and compare algorithms. We present MSSimulator, a simulation software\
+    \ for LC-MS and LC-MS/MS experiments. Starting from a list of proteins from a\
+    \ FASTA file,the simulation will perform in-silico digestion, retention time prediction,\
+    \  ionization filtering, and raw signal simulation (including MS/MS), while providing\
+    \ many options to change the properties of the resultingdata like elution profile\
+    \ shape, resolution and sampling rate. Several protocols for SILAC, iTRAQ or MS(E)\
+    \ are available, in addition to the usual label-free approach, making MSSimulator\
+    \ the most comprehensive simulator for LC-MS and LC-MS/MS data.},\n author = {C.\
+    \ Bielow and S. Aiche and S. Andreotti and K. Reinert},\n journal = {Journal of\
+    \ Proteome Research},\n month = {July},\n number = {7},\n pages = {2922--2929},\n\
+    \ title = {MSSimulator: Simulation of Mass Spectrometry Data},\n url = {http://publications.imp.fu-berlin.de/1066/},\n\
+    \ volume = {10},\n year = {2011}\n}\n\n"
   creators:
-  - name:
-      lineage:
-      family: Birn
-      given: M.
-      honourific:
-    id: marcelbirn@gmx.de
-  - name:
-      lineage:
-      honourific:
-      given: M.
-      family: Holtgrewe
-    id: holtgrewe@ira.uka.de
-  - id: 'sanders@kit.edu '
-    name:
-      lineage:
-      honourific:
-      given: P.
-      family: Sanders
-  - id: 'singler@kit.edu '
-    name:
-      family: Singler
-      honourific:
-      given: J.
-      lineage:
-  datestamp: '2010-08-23 12:48:49'
-  publication: 2010 Proceedings of the Twelfth Workshop on Algorithm Engineering and
-    Experiments (ALENEX)
-  abstract: We present a simple randomized data structure for two-dimensional point
-    sets that allows fast nearest neighbor queries in many cases. An implementation
-    outperforms several previous implementations for commonly used benchmarks.
-  status_changed: '2010-08-23 12:48:49'
-  title: Simple and Fast Nearest Neighbor Search
-  publisher: ACM SIAM
-  type: article
-  rev_number: 8
-  userid: 167
-  refereed: 'TRUE'
-  eprintid: 926
-  item_issues_count: 0
-  full_text_status: none
-  date_type: published
-  metadata_visibility: show
-  eprint_status: archive
-  dir: disk0/00/00/09/26
-  date: 2010
-  pagerange: 43-54
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-- userid: 1
-  type: monograph
-  rev_number: 3
-  title: "Efficient ordering of state variables and transition relation partitionsin
-    symbolic model checking"
-  status_changed: '2009-03-11 11:26:49'
-  datestamp: '2009-04-14 14:44:15'
-  monograph_type: technical_report
-  creators:
-  - name:
-      lineage:
-      given: M.
-      honourific:
-      family: Block
-  - name:
-      family: Gröpl
-      honourific:
-      given: C.
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: H.
-      family: Preuss
-  - name:
-      given: H. J.
-      honourific:
-      family: Prömel
-      lineage:
-  - name:
-      family: Srivastav
-      honourific:
-      given: A.
-      lineage:
-  uri: http://publications.imp.fu-berlin.de/id/eprint/335
-  lastmod: '2009-04-14 14:44:15'
-  ispublished: pub
-  keywords: "Randomized algorithms and probabilistic analysis, VLSI-Design andlayout,
-    Binary Decision Diagrams, Hardware verification, Local searchand metaheuristics"
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  date: 1997
-  dir: disk0/00/00/03/35
-  eprint_status: archive
-  metadata_visibility: show
-  full_text_status: none
-  item_issues_count: 0
-  refereed: 'TRUE'
-  eprintid: 335
-  institution: Humboldt-Universität zu Berlin
-- eprintid: 336
-  refereed: 'TRUE'
-  metadata_visibility: show
-  full_text_status: none
-  item_issues_count: 0
-  dir: disk0/00/00/03/36
-  eprint_status: archive
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  volume: B54Ak
-  pagerange: 15 pages
-  date: 2007
-  place_of_pub: Taormina
-  keywords: "Three-Connected Planar Graph, Cnet, Planar Graph, Enumeration, Randomgraphs,
-    Random Generation, Dynamic Programming, Graph Theory"
-  uri: http://publications.imp.fu-berlin.de/id/eprint/336
-  lastmod: '2009-04-14 14:18:17'
-  ispublished: pub
-  publication: Séminaire Lotharingien de Combinatoire
-  datestamp: '2009-04-14 14:18:17'
-  creators:
-  - name:
-      family: Bodirsky
-      honourific:
-      given: M.
-      lineage:
-  - name:
-      given: C.
-      honourific:
-      family: Gröpl
-      lineage:
-  - name:
-      family: Johannsen
-      honourific:
-      given: D.
-      lineage:
-  - name:
-      family: Kang
-      given: M.
-      honourific:
-      lineage:
-  userid: 1
-  rev_number: 3
-  type: article
-  title: A direct decomposition of 3-connected planar graphs
-  status_changed: '2009-03-11 11:26:50'
-- creators:
-  - name:
-      lineage:
-      given: M.
-      honourific:
-      family: Bodirsky
-  - name:
-      lineage:
-      family: Gröpl
-      given: C.
-      honourific:
-  - name:
-      lineage:
-      family: Johannsen
-      honourific:
-      given: D.
-  - name:
-      lineage:
-      given: M.
-      honourific:
-      family: Kang
-  datestamp: '2009-04-14 14:32:56'
-  title: A direct decomposition of 3-connected planar graphs
-  status_changed: '2009-03-11 11:26:50'
-  userid: 1
-  type: conference_item
-  rev_number: 3
-  keywords: "Three-Connected Planar Graph, Cnet, Planar Graph, Enumeration, Randomgraphs,
-    Random Generation, Dynamic Programming, Graph Theory"
-  ispublished: pub
-  lastmod: '2009-04-14 14:32:56'
-  uri: http://publications.imp.fu-berlin.de/id/eprint/337
-  event_title: "Proceedings of the 17th Annual International Conference on FormalPower
-    Series and Algebraic Combinatorics (FPSAC05)"
-  eprint_status: archive
-  dir: disk0/00/00/03/37
-  date: 2005
-  place_of_pub: Taormina
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  eprintid: 337
-  refereed: 'TRUE'
-  item_issues_count: 0
-  metadata_visibility: show
-  full_text_status: none
-- title: Decomposing, Counting, and Generating Unlabeled Cubic Planar Graphs
-  status_changed: '2009-03-11 11:26:53'
-  abstract: "We present an expected polynomial time algorithm to generate an unlabeledconnected
-    cubic planar graph uniformly at random. We first considerrooted cubic planar
-    graphs, i.e., we count connected cubic planargraphs up to isomorphisms that
-    fix a certain directed edge. Basedon decompositions along the connectivity
-    structure, we derive recurrenceformulas for counting the exact number of
-    rooted cubic planar graphs.This leads to 3-connected planar graphs, which
-    have a unique embeddingon the sphere; but special care has to be taken for
-    rooted graphsthat have a sense-reversing automorphism. Therefore we introducethe
-    concept of colored networks, which stand in bijective correspondenceto rooted
-    graphs with given symmetries. Colored networks can againbe decomposed along
-    their connectivity structure. For rooted 3-connectedcubic planar graphs
-    embedded in the plane, we switch to the dualand count rooted triangulations.
-    All these numbers can be evaluatedin polynomial time by dynamic programming.
-    We can use them to generaterooted cubic planar graphs uniformly at random.
-    To generate connectedcubic planar graphs without a root uniformly at random,
-    we applyrejection sampling and obtain an expected polynomial time algorithm."
-  userid: 1
-  type: conference_item
-  rev_number: 3
-  creators:
-  - name:
-      lineage:
-      family: Bodirsky
-      honourific:
-      given: M.
-  - name:
-      lineage:
-      given: C.
-      honourific:
-      family: Gröpl
-  - name:
-      lineage:
-      honourific:
-      given: M.
-      family: Kang
-  datestamp: '2009-04-14 14:36:27'
-  lastmod: '2009-04-14 14:36:27'
-  ispublished: pub
-  event_title: "European Conference on Combinatorics, Graph Theory, and ApplicationsEUROCOMB'03
-    Prague"
-  uri: http://publications.imp.fu-berlin.de/id/eprint/342
-  keywords: "Cubic Planar Graph, Planar Graph, Cubic Graph, Enumeration, Randomgraphs,
-    Random Generation, Dynamic Programming, Graph Theory"
-  date: 2003
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  eprint_status: archive
-  dir: disk0/00/00/03/42
-  item_issues_count: 0
-  metadata_visibility: show
-  full_text_status: none
-  refereed: 'TRUE'
-  eprintid: 342
-- refereed: 'TRUE'
-  eprintid: 339
-  number: 3
-  metadata_visibility: show
-  full_text_status: none
-  item_issues_count: 0
-  dir: disk0/00/00/03/39
-  eprint_status: archive
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  volume: 379
-  date: 2007
-  pagerange: 377-386
-  keywords: "Labeled planar graph, Enumeration, Decomposition, Sampling algorithm,Dynamic
-    programming, Graph theory"
-  official_url: http://www.sciencedirect.com/science/article/B6V1G-4N4PY45-5/2 /4c06fbabe635c3a288cbf0427e0b395d
-  uri: http://publications.imp.fu-berlin.de/id/eprint/339
-  lastmod: '2009-04-14 14:19:26'
-  ispublished: pub
-  datestamp: '2009-04-14 14:19:26'
-  publication: Theoretical Computer Science
-  creators:
-  - name:
-      honourific:
-      given: M.
-      family: Bodirsky
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: C.
-      family: Gröpl
-  - name:
-      lineage:
-      given: M.
-      honourific:
-      family: Kang
-  userid: 1
-  type: article
-  rev_number: 3
-  title: Generating labeled planar graphs uniformly at random
-  status_changed: '2009-03-11 11:26:52'
-  abstract: "We present a deterministic polynomial time algorithm to sample a labeledplanar
-    graph uniformly at random. Our approach uses recursive formulaefor the exact
-    number of labeled planar graphs with n vertices andm edges, based on a decomposition
-    into 1-, 2-, and 3-connected components.We can then use known sampling algorithms
-    and counting formulae for3-connected planar graphs."
-- datestamp: '2009-04-14 14:37:56'
-  creators:
-  - name:
-      family: Bodirsky
-      given: M.
-      honourific:
-      lineage:
-  - name:
-      family: Gröpl
-      given: C.
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: M.
-      family: Kang
-  userid: 1
-  rev_number: 3
-  publisher: Springer Verlag
-  type: conference_item
-  title: Generating labeled planar graphs uniformly at random
-  abstract: "We present an expected polynomial time algorithm to generate a labeledplanar
-    graph uniformly at random. To generate the planar graphs,we derive recurrence
-    formulas that count all such graphs with n verticesand m edges, based on
-    a decomposition into 1-, 2-, and 3-connectedcomponents. For 3-connected
-    graphs we apply a recent random generationalgorithm by Schaeffer and a counting
-    formula by Mullin and Schellenberg."
-  status_changed: '2009-03-11 11:26:53'
-  keywords: "Planar Graph, Enumeration, Random graphs, Random Generation, DynamicProgramming,
-    Graph Theory"
-  uri: http://publications.imp.fu-berlin.de/id/eprint/341
-  event_title: Proceedings of ICALP 2003
-  note: "Appeared 2008 in Theoretical Computer Science. { The download isthe journal
-    submission &lt;br&gt; From time to time we receive requestsfor source code,
-    so here it is: See the files BGK03b.README and GBK03b.tar.bz2}"
-  lastmod: '2009-04-14 14:37:56'
-  ispublished: pub
-  dir: disk0/00/00/03/41
-  eprint_status: archive
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  date: 2003
-  pagerange: 1095-1107
-  eprintid: 341
-  refereed: 'TRUE'
-  number: 2719
-  metadata_visibility: show
-  full_text_status: none
-  series: Lecture Notes in Computer Science
-  item_issues_count: 0
-- ispublished: pub
-  lastmod: '2009-04-14 14:13:28'
-  uri: http://publications.imp.fu-berlin.de/id/eprint/338
-  title: Generating unlabeled connected cubic planar graphs uniformly at random
-  status_changed: '2009-03-11 11:26:51'
-  abstract: "We present an expected polynomial time algorithm to generate an unlabeledconnected
-    cubic planar graph uniformly at random. We first considerrooted connected
-    cubic planar graphs, i.e., we count connected cubicplanar graphs up to isomorphisms
-    that fix a certain directed edge.Based on decompositions along the connectivity
-    structure, we deriverecurrence formulas for the exact number of rooted cubic
-    planar graphs.This leads to rooted 3-connected cubic planar graphs, which
-    havea unique embedding on the sphere. Special care has to be taken forrooted
-    graphs that have a sense-reversing automorphism. Thereforewe introduce the
-    concept of colored networks, which stand in bijectivecorrespondence to rooted
-    3-connected cubic planar graphs with givensymmetries. Colored networks can
-    again be decomposed along the connectivitystructure. For rooted 3-connected
-    cubic planar graphs embedded inthe plane, we switch to the dual and count
-    rooted triangulations.Since all these numbers can be evaluated in polynomial
-    time usingdynamic programming, rooted connected cubic planar graphs can
-    begenerated uniformly at random in polynomial time by inverting thedecomposition
-    along the connectivity structure. To generate connectedcubic planar graphs
-    without a root uniformly at random, we applyrejection sampling and obtain
-    an expected polynomial time algorithm"
-  userid: 1
-  rev_number: 3
-  type: article
-  creators:
-  - name:
-      honourific:
-      given: M.
-      family: Bodirsky
-      lineage:
-  - name:
-      lineage:
-      family: Gröpl
-      honourific:
-      given: C.
-  - name:
-      lineage:
-      family: Kang
-      given: M.
-      honourific:
-  publication: Random Structures and Algorithms
-  datestamp: '2009-04-14 14:13:28'
-  item_issues_count: 0
-  metadata_visibility: show
-  full_text_status: none
-  refereed: 'TRUE'
-  eprintid: 338
-  number: 2
-  date: 2008
-  pagerange: 157-180
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  volume: 32
-  eprint_status: archive
-  dir: disk0/00/00/03/38
-- refereed: 'TRUE'
-  eprintid: 340
-  item_issues_count: 0
-  full_text_status: none
-  metadata_visibility: show
-  eprint_status: archive
-  dir: disk0/00/00/03/40
-  date: 2005
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  keywords: "Planar Graph, Enumeration, Random graphs, Random Generation, GraphTheory"
-  ispublished: pub
-  lastmod: '2010-09-01 13:43:09'
-  uri: http://publications.imp.fu-berlin.de/id/eprint/340
-  event_title: "Proceedings of the 16th Annual International Symposium on Algorithmsand
-    Computation (ISAAC05)"
-  creators:
-  - name:
-      lineage:
-      family: Bodirsky
-      given: M.
-      honourific:
-  - name:
-      lineage:
-      given: C.
-      honourific:
-      family: Gröpl
-  - name:
-      family: Kang
-      honourific:
-      given: M.
-      lineage:
-  datestamp: '2010-09-01 13:43:09'
-  status_changed: '2009-03-11 11:26:52'
-  title: Sampling Unlabeled Biconnected Planar Graphs
-  type: conference_item
-  rev_number: 3
-  userid: 1
-- datestamp: '2017-03-03 14:40:13'
-  creators:
-  - name:
-      family: Bradford
-      honourific:
-      given: P. G.
-      lineage:
-  - name:
-      lineage:
-      given: K.
-      honourific:
-      family: Reinert
-  type: conference_item
-  rev_number: 3
-  userid: 1
-  status_changed: '2009-03-11 11:26:54'
-  title: Lower Bounds for Row Minima Searching
-  event_title: "Proceedings of the 23rd International Colloquium on Automata, Languages,and
-    Programming 1996 (ICALP-96), LNCS 1099"
-  uri: http://publications.imp.fu-berlin.de/id/eprint/343
-  ispublished: pub
-  lastmod: '2017-03-03 14:40:13'
-  dir: disk0/00/00/03/43
-  eprint_status: archive
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  pagerange: 454-465
-  date: 1996
-  refereed: 'TRUE'
-  eprintid: 343
-  full_text_status: none
-  metadata_visibility: show
-  item_issues_count: 0
-- datestamp: '2019-08-29 10:32:18'
-  publication: Frontiers in Microbiology
-  creators:
-  - name:
-      lineage:
-      honourific:
-      given: Anne
-      family: Busch
-  - name:
-      lineage:
-      honourific:
-      given: Prasad
-      family: Thomas
-  - name:
-      given: Eric
-      honourific:
-      family: Zuchantke
-      lineage:
-  - name:
-      given: Holger
-      honourific:
-      family: Brendebach
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: Kerstin
-      family: Neubert
-  - name:
-      lineage:
-      family: Gruetzke
-      given: Josephine
-      honourific:
-  - name:
-      given: Sascha
-      honourific:
-      family: Al Dahouk
-      lineage:
-  - name:
-      lineage:
-      given: Martin
-      honourific:
-      family: Peters
-  - name:
-      honourific:
-      given: Helmut
-      family: Hotzel
-      lineage:
-  - name:
-      lineage:
-      family: Neubauer
-      given: Heinrich
-      honourific:
-  - name:
-      honourific:
-      given: Herbert
-      family: Tomaso
-      lineage:
-  type: article
-  rev_number: 5
-  userid: 132
-  abstract: Francisella (F.) tularensis is a highly virulent, Gram-negative bacterial
-    pathogen and the causative agent of the zoonotic disease tularemia. Here, we generated,
-    analyzed and characterized a high quality circular genome sequence of the F. tularensis
-    subsp. holarctica strain 12T0050 that caused fatal tularemia in a hare. Besides
-    the genomic structure, we focused on the analysis of oriC, unique to the Francisella
-    genus and regulating replication in and outside hosts and the first report on
-    genomic DNA methylation of a Francisella strain. The high quality genome was used
-    to establish and evaluate a diagnostic whole genome sequencing pipeline. A genotyping
-    strategy for F. tularensis was developed using various bioinformatics tools for
-    genotyping. Additionally, whole genome sequences of F. tularensis subsp. holarctica
-    isolates isolated in the years 2008–2015 in Germany were generated. A phylogenetic
-    analysis allowed to determine the genetic relatedness of these isolates and confirmed
-    the highly conserved nature of F. tularensis subsp. holarctica.
-  status_changed: '2019-08-29 10:32:18'
-  title: 'Revisiting Francisella tularensis subsp. holarctica, Causative Agent of
-    Tularemia in Germany With Bioinformatics: New Insights in Genome Structure, DNA
-    Methylation and Comparative Phylogenetic Analysis'
-  official_url: http://doi.org/10.3389/fmicb.2018.00344
-  uri: http://publications.imp.fu-berlin.de/id/eprint/2374
-  ispublished: pub
-  lastmod: '2019-08-29 10:32:18'
-  issn: 1664-302X
-  dir: disk0/00/00/23/74
-  eprint_status: archive
-  volume: 9
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  date: '2018-03-13'
-  eprintid: 2374
-  refereed: 'TRUE'
-  date_type: published
-  full_text_status: none
-  id_number: doi:10.3389/fmicb.2018.00344
-  metadata_visibility: show
-- refereed: 'TRUE'
-  eprintid: 1132
-  number: 4
-  metadata_visibility: show
-  full_text_status: none
-  date_type: published
-  item_issues_count: 0
-  dir: disk0/00/00/11/32
-  issn: 1545-4963
-  eprint_status: archive
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  volume: 8
-  pagerange: 976-986
-  date: 2011-07
-  official_url: http://www.computer.org/csdl/trans/tb/2011/04/ttb2011040976.html
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1132
-  ispublished: pub
-  lastmod: '2012-05-16 14:17:03'
-  related_url:
-  - type: pub
-    url: http://www.computer.org/portal/web/tcbb
-  publication: 'IEEE/ACM Transactions on Computational Biology and Bioinformatics '
-  datestamp: '2012-04-10 14:19:34'
-  creators:
-  - id:
-    name:
-      honourific:
-      given: S.
-      family: Böcker
-      lineage:
-  - id: birte.kehr@fu-berlin.de
-    name:
-      lineage:
-      honourific:
-      given: B.
-      family: Kehr
-  - name:
-      lineage:
-      family: Rasche
-      given: F.
-      honourific:
-    id:
-  userid: 132
-  rev_number: 12
-  publisher: IEEE computer society, TCBB
-  type: article
-  title: Determination of Glycan Structure from Tandem Mass Spectra
-  abstract: Glycans are molecules made from simple sugars that form complex tree structures.
-    Glycans constitute one of the most important protein modifications and identification
-    of glycans remains a pressing problem in biology. Unfortunately, the structure
-    of glycans is hard to predict from the genome sequence of an organism. In this
-    paper, we consider the problem of deriving the topology of a glycan solely from
-    tandem mass spectrometry (MS) data. We study, how to generate glycan tree candidates
-    that sufficiently match the sample mass spectrum, avoiding the combinatorial explosion
-    of glycan structures. Unfortunately, the resulting problem is known to be computationally
-    hard. We present an efficient exact algorithm for this problem based on fixed-parameter
-    algorithmics that can process a spectrum in a matter of seconds. We also report
-    some preliminary results of our method on experimental data, combining it with
-    a preliminary candidate evaluation scheme. We show that our approach is fast in
-    applications, and that we can reach very well de novo identification results.
-    Finally, we show how to count the number of glycan topologies for a fixed size
-    or a fixed mass. We generalize this result to count the number of (labeled) trees
-    with bounded out degree, improving on results obtained using Pólya's enumeration
-    theorem.
-  status_changed: '2012-05-16 14:17:03'
-- item_issues_count: 0
-  date_type: published
-  full_text_status: none
-  id_number: doi:10.1186/s13059-015-0865-0
-  metadata_visibility: show
-  number: 1
-  eprintid: 1830
-  refereed: 'TRUE'
-  date: '2016-01-30'
-  volume: 17
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  eprint_status: archive
-  issn: 1474-760X
-  dir: disk0/00/00/18/30
-  lastmod: '2016-11-15 13:54:32'
-  ispublished: pub
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1830
-  official_url: http://dx.doi.org/10.1186/s13059-015-0865-0
-  abstract: We present CIDANE, a novel framework for genome-based transcript reconstruction
-    and quantification from RNA-seq reads. CIDANE assembles transcripts efficiently
-    with significantly higher sensitivity and precision than existing tools. Its algorithmic
-    core not only reconstructs transcripts ab initio, but also allows the use of the
-    growing annotation of known splice sites, transcription start and end sites, or
-    full-length transcripts, which are available for most model organisms. CIDANE
-    supports the integrated analysis of RNA-seq and additional gene-boundary data
-    and recovers splice junctions that are invisible to other methods. CIDANE is available
-    at http://​ccb.​jhu.​edu/​software/​cidane/​.
-  status_changed: '2016-11-15 13:54:32'
-  title: 'CIDANE: comprehensive isoform discovery and abundance estimation'
-  publisher: BioMed Central, Springer Science+Business Media
-  rev_number: 10
-  type: article
-  userid: 132
-  creators:
-  - name:
-      family: Canzar
-      honourific:
-      given: S.
-      lineage:
-    id:
-  - id:
-    name:
-      lineage:
-      family: Andreotti
-      given: S.
-      honourific:
-  - id:
-    name:
-      lineage:
-      given: D.
-      honourific:
-      family: Weese
-  - id: knut.reinert@fu-berlin.de
-    name:
-      lineage:
-      given: K.
-      honourific:
-      family: Reinert
-  - id:
-    name:
-      lineage:
-      given: G. W.
-      honourific:
-      family: Klau
-  publication: Genome Biology
-  datestamp: '2016-02-25 12:27:42'
-- id_number: doi:10.7717/peerj.3138
-  metadata_visibility: show
-  date_type: published
-  full_text_status: none
-  eprintid: 2119
-  refereed: 'TRUE'
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  volume: 5
-  pagerange: e3138
-  date: '2017-03-28'
-  dir: disk0/00/00/21/19
-  issn: 2167-8359
-  eprint_status: archive
-  uri: http://publications.imp.fu-berlin.de/id/eprint/2119
-  ispublished: pub
-  lastmod: '2017-10-12 13:01:44'
-  official_url: http://doi.org/10.7717/peerj.3138
-  userid: 132
-  rev_number: 5
-  type: article
-  title: 'SLIMM: species level identification of microorganisms from metagenomes'
-  abstract: Identification and quantification of microorganisms is a significant step
-    in studying the alpha and beta diversities within and between microbial communities
-    respectively. Both identification and quantification of a given microbial community
-    can be carried out using whole genome shotgun sequences with less bias than when
-    using 16S-rDNA sequences. However, shared regions of DNA among reference genomes
-    and taxonomic units pose a significant challenge in assigning reads correctly
-    to their true origins. The existing microbial community profiling tools commonly
-    deal with this problem by either preparing signature-based unique references or
-    assigning an ambiguous read to its least common ancestor in a taxonomic tree.
-    The former method is limited to making use of the reads which can be mapped to
-    the curated regions, while the latter suffer from the lack of uniquely mapped
-    reads at lower (more specific) taxonomic ranks. Moreover, even if the tools exhibited
-    good performance in calling the organisms present in a sample, there is still
-    room for improvement in determining the correct relative abundance of the organisms.
-    We present a new method Species Level Identification of Microorganisms from Metagenomes
-    (SLIMM) which addresses the above issues by using coverage information of reference
-    genomes to remove unlikely genomes from the analysis and subsequently gain more
-    uniquely mapped reads to assign at lower ranks of a taxonomic tree. SLIMM is based
-    on a few, seemingly easy steps which when combined create a tool that outperforms
-    state-of-the-art tools in run-time and memory usage while being on par or better
-    in computing quantitative and qualitative information at species-level.
-  status_changed: '2017-10-12 13:01:44'
-  datestamp: '2017-10-12 13:01:44'
-  publication: PeerJ
-  creators:
-  - name:
-      lineage:
-      family: Dadi
-      given: Temesgen Hailemariam
-      honourific:
-  - name:
-      lineage:
-      family: Renard
-      given: Bernhard Y.
-      honourific:
-  - name:
-      lineage:
-      honourific:
-      given: Lothar H.
-      family: Wieler
-  - name:
-      lineage:
-      given: Torsten
-      honourific:
-      family: Semmler
-  - name:
-      lineage:
-      honourific:
-      given: Knut
-      family: Reinert
-- datestamp: '2018-11-08 11:49:07'
-  publication: Bioinformatics
-  creators:
-  - name:
-      lineage:
-      family: Dadi
-      honourific:
-      given: Temesgen Hailemariam
-  - name:
-      lineage:
-      given: Enrico
-      honourific:
-      family: Siragusa
-  - name:
-      lineage:
-      family: Piro
-      honourific:
-      given: Vitor C
-  - name:
-      family: Andrusch
-      given: Andreas
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      family: Seiler
-      honourific:
-      given: Enrico
-  - name:
-      honourific:
-      given: Bernhard Y
-      family: Renard
-      lineage:
-  - name:
-      honourific:
-      given: Knut
-      family: Reinert
-      lineage:
-  userid: 132
-  rev_number: 5
-  type: article
-  title: 'DREAM-Yara: an exact read mapper for very large databases with short update
-    time'
-  abstract: "MotivationMapping-based approaches have become limited in their
-    application to very large sets of references since computing an FM-index for very
-    large databases (e.g. >10 GB) has become a bottleneck. This affects many analyses
-    that need such index as an essential step for approximate matching of the NGS
-    reads to reference databases. For instance, in typical metagenomics analysis,
-    the size of the reference sequences has become prohibitive to compute a single
-    full-text index on standard machines. Even on large memory machines, computing
-    such index takes about 1 day of computing time. As a result, updates of indices
-    are rarely performed. Hence, it is desirable to create an alternative way of indexing
-    while preserving fast search times.ResultsTo solve the index construction
-    and update problem we propose the DREAM (Dynamic seaRchablE pArallel coMpressed
-    index) framework and provide an implementation. The main contributions are the
-    introduction of an approximate search distributor via a novel use of Bloom filters.
-    We combine several Bloom filters to form an interleaved Bloom filter and use this
-    new data structure to quickly exclude reads for parts of the databases where they
-    cannot match. This allows us to keep the databases in several indices which can
-    be easily rebuilt if parts are updated while maintaining a fast search time. The
-    second main contribution is an implementation of DREAM-Yara a distributed version
-    of a fully sensitive read mapper under the DREAM framework.Availability
-    and implementation: https://gitlab.com/pirovc/dream_yara/"
-  status_changed: '2018-11-08 11:49:07'
-  official_url: http://doi.org/10.1093/bioinformatics/bty567
-  uri: http://publications.imp.fu-berlin.de/id/eprint/2282
-  lastmod: '2018-11-08 11:49:07'
-  ispublished: pub
-  dir: disk0/00/00/22/82
-  issn: 1367-4803
-  eprint_status: archive
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  volume: 34
-  date: '2018-09-08'
-  pagerange: i766-i772
-  eprintid: 2282
-  refereed: 'TRUE'
-  number: 17
-  id_number: doi:10.1093/bioinformatics/bty567
-  metadata_visibility: show
-  full_text_status: none
-  date_type: published
-- ispublished: pub
-  lastmod: '2017-03-03 14:40:19'
-  uri: http://publications.imp.fu-berlin.de/id/eprint/455
-  official_url: http://www.biomedcentral.com/1471-2105/9/11
-  abstract: BACKGROUND:The use of novel algorithmic techniques is pivotal to many
-    important problems in life science. For example the sequencing of the human genome
-    [1] would not have been possible without advanced assembly algorithms. However,
-    owing to the high speed of technological progress and the urgent need for bioinformatics
-    tools, there is a widening gap between state-of-the-art algorithmic techniques
-    and the actual algorithmic components of tools that are in widespread use.RESULTS:To
-    remedy this trend we propose the use of SeqAn, a library of efficient data types
-    and algorithms for sequence analysis in computational biology. SeqAn comprises
-    implementations of existing, practical state-of-the-art algorithmic components
-    to provide a sound basis for algorithm testing and development. In this paper
-    we describe the design and content of SeqAn and demonstrate its use by giving
-    two examples. In the first example we show an application of SeqAn as an experimental
-    platform by comparing different exact string matching algorithms. The second example
-    is a simple version of the well-known MUMmer tool rewritten in SeqAn. Results
-    indicate that our implementation is very efficient and versatile to use.CONCLUSION:We
-    anticipate that SeqAn greatly simplifies the rapid development of new bioinformatics
-    tools by providing a collection of readily usable, well-designed algorithmic components
-    which are fundamental for the field of sequence analysis. This leverages not only
-    the implementation of new algorithms, but also enables a sound analysis and comparison
-    of existing algorithms.
-  status_changed: '2009-04-15 07:21:49'
-  title: SeqAn -- An efficient, generic C++ library for sequence analysis
-  rev_number: 11
-  type: article
-  userid: 30
-  creators:
-  - name:
-      family: Döring
-      honourific:
-      given: A.
-      lineage:
-  - name:
-      lineage:
-      given: D.
-      honourific:
-      family: Weese
-  - name:
-      given: T.
-      honourific:
-      family: Rausch
-      lineage:
-  - name:
-      honourific:
-      given: K.
-      family: Reinert
-      lineage:
-  datestamp: '2009-04-15 07:21:49'
-  publication: BMC Bioinformatics
-  documents:
-  - security: public
-    pos: 1
-    eprintid: 455
-    uri: http://publications.imp.fu-berlin.de/id/document/237
-    docid: 237
-    main: BMC_Bioinformatics_2008_DöringAn_efficient_generic_C++_library.pdf
-    mime_type: application/pdf
-    format: application/pdf
-    relation:
-    - type: http://eprints.org/relation/haspreviewThumbnailVersion
-      uri: "/id/document/1021"
-    - uri: "/id/document/1021"
-      type: http://eprints.org/relation/hasVolatileVersion
-    - uri: "/id/document/1021"
-      type: http://eprints.org/relation/hasVersion
-    files:
-    - mime_type: application/pdf
-      uri: http://publications.imp.fu-berlin.de/id/file/5656
-      filesize: 565980
-      fileid: 5656
-      objectid: 237
-      filename: BMC_Bioinformatics_2008_DöringAn_efficient_generic_C++_library.pdf
-      datasetid: document
-      mtime: '2017-03-03 14:40:19'
-    language: en
-    rev_number: 3
-  item_issues_count: 0
-  full_text_status: public
-  date_type: published
-  metadata_visibility: show
-  number: 1
-  refereed: 'TRUE'
-  eprintid: 455
-  pagerange: 11
-  date: 2008
-  volume: 9
-  divisions:
-  - group_algbioinf
-  eprint_status: archive
-  dir: disk0/00/00/04/55
-- uri: http://publications.imp.fu-berlin.de/id/eprint/792
-  ispublished: pub
-  lastmod: '2010-09-01 13:04:47'
-  official_url: http://bioinformatics.oxfordjournals.org/cgi/content/full/26/1/123
-  rev_number: 18
-  publisher: Oxford University Press
-  type: article
-  userid: 30
-  status_changed: '2010-08-23 12:05:14'
-  abstract: 'Motivation: Deep sequencing has become the method of choice for determining
-    the small RNA content of a cell. Mapping the sequenced reads onto their reference
-    genome serves as the basis for all further analyses, namely for identification
-    and quantification. A method frequently used is Mega BLAST followed by several
-    filtering steps, even though it is slow and inefficient for this task. Also, none
-    of the currently available short read aligners has established itself for the
-    particular task of small RNA mapping.  Results: We present MicroRazerS, a tool
-    optimized for mapping small RNAs onto a reference genome. It is an order of magnitude
-    faster than Mega BLAST and comparable in speed to other short read mapping tools.
-    In addition, it is more sensitive and easy to handle and adjust.  Availability:
-    MicroRazerS is part of the SeqAn C++ library and can be downloaded from http://www.seqan.de/projects/MicroRazerS.html.  Contact:
-    emde@inf.fu-berlin.de, grunert@molgen.mpg.de'
-  title: 'MicroRazerS: Rapid alignment of small RNA reads'
-  publication: Bioinformatics
-  datestamp: '2009-11-10 13:22:54'
-  related_url:
-  - url: http://bioinformatics.oxfordjournals.org/cgi/content/abstract/btp601v1
-  - url: http://bioinformatics.oxfordjournals.org/cgi/content/short/26/1/123
-  creators:
-  - name:
-      lineage:
-      honourific:
-      given: A.-K.
-      family: Emde
-  - name:
-      family: Grunert
-      given: M.
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      given: D.
-      honourific:
-      family: Weese
-  - name:
-      family: Reinert
-      honourific:
-      given: K.
-      lineage:
-  - name:
-      given: S. R.
-      honourific:
-      family: Sperling
-      lineage:
-  date_type: published
-  full_text_status: none
-  id_number: 'doi:10.1093/bioinformatics/btp601 '
-  metadata_visibility: show
-  item_issues_count: 0
-  number: 1
-  eprintid: 792
-  refereed: 'TRUE'
-  volume: 26
-  divisions:
-  - group_algbioinf
-  subjects:
-  - C
-  - G
-  date: '2010-01-01'
-  pagerange: 123-124
-  issn: 1367-4803
-  dir: disk0/00/00/07/92
-  eprint_status: archive
-- official_url: http://bioinformatics.oxfordjournals.org/content/28/5/619
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1160
-  lastmod: '2017-03-03 14:41:14'
-  ispublished: pub
-  documents:
-  - format: application/pdf
-    docid: 516
-    uri: http://publications.imp.fu-berlin.de/id/document/516
-    main: 2012_Emde_Detecting_genomic_indel_variants_with_exact_breakpoints_in_single-_and_paired-end_sequencing_data_using_SplazerS-1.pdf
-    mime_type: application/pdf
-    formatdesc: Original Paper
-    pos: 2
-    eprintid: 1160
-    security: public
-    rev_number: 4
-    relation:
-    - uri: "/id/document/1227"
-      type: http://eprints.org/relation/hasVersion
-    - uri: "/id/document/1227"
-      type: http://eprints.org/relation/haspreviewThumbnailVersion
-    - uri: "/id/document/1227"
-      type: http://eprints.org/relation/hasVolatileVersion
-    language: en
-    files:
-    - objectid: 516
-      filename: 2012_Emde_Detecting_genomic_indel_variants_with_exact_breakpoints_in_single-_and_paired-end_sequencing_data_using_SplazerS-1.pdf
-      fileid: 14191
-      mtime: '2017-03-03 14:41:14'
-      datasetid: document
-      filesize: 575317
-      uri: http://publications.imp.fu-berlin.de/id/file/14191
-      mime_type: application/pdf
-  datestamp: '2012-09-12 08:40:15'
-  publication: Bioinformatics
-  creators:
-  - name:
-      lineage:
-      given: A.-K.
-      honourific:
-      family: Emde
-  - name:
-      lineage:
-      family: Schulz
-      honourific:
-      given: M. H.
-  - name:
-      family: Weese
-      given: D.
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      family: Sun
-      given: R.
-      honourific:
-  - name:
-      family: Vingron
-      given: M.
-      honourific:
-      lineage:
-  - name:
-      given: V. M.
-      honourific:
-      family: Kalscheuer
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: S. A.
-      family: Haas
-  - name:
-      given: K.
-      honourific:
-      family: Reinert
-      lineage:
-  userid: 30
-  type: article
-  publisher: Oxford University Press
-  rev_number: 18
-  title: Detecting genomic indel variants with exact breakpoints in single- and paired-end
-    sequencing data using SplazerS
-  abstract: "Motivation: The reliable detection of genomic variation in resequencing
-    data is still a major challenge, especially for variants larger than a few base
-    pairs. Sequencing reads crossing boundaries of structural variation carry the
-    potential for their identification, but are difficult to map.Results:
-    Here we present a method for ‘split’ read mapping, where prefix and suffix match
-    of a read may be interrupted by a longer gap in the read-to-reference alignment.
-    We use this method to accurately detect medium-sized insertions and long deletions
-    with precise breakpoints in genomic resequencing data. Compared with alternative
-    split mapping methods, SplazerS significantly improves sensitivity for detecting
-    large indel events, especially in variant-rich regions. Our method is robust in
-    the presence of sequencing errors as well as alignment errors due to genomic mutations/divergence,
-    and can be used on reads of variable lengths. Our analysis shows that SplazerS
-    is a versatile tool applicable to unanchored or single-end as well as anchored
-    paired-end reads. In addition, application of SplazerS to targeted resequencing
-    data led to the interesting discovery of a complete, possibly functional gene
-    retrocopy variant.Availability: SplazerS is available from http://www.seqan.de/projects/
-    splazers."
-  status_changed: '2012-09-12 08:40:15'
-  eprintid: 1160
-  refereed: 'TRUE'
-  number: 5
-  metadata_visibility: show
-  id_number: 10.1093/bioinformatics/bts019
-  date_type: published
-  full_text_status: public
-  item_issues_count: 0
-  dir: disk0/00/00/11/60
-  eprint_status: archive
-  divisions:
-  - group_algbioinf
-  subjects:
-  - C
-  - G
-  volume: 28
-  date: '2012-01-11'
-  pagerange: 619-627
-- dir: disk0/00/00/03/45
-  eprint_status: archive
-  volume: 4532
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  date: 2007
-  pagerange: 119-129
-  pres_type: paper
-  refereed: 'TRUE'
-  eprintid: 345
-  full_text_status: none
-  metadata_visibility: show
-  event_type: workshop
-  item_issues_count: 0
-  series: Lecture Notes in Computer Science
-  datestamp: '2009-03-11 16:59:59'
-  creators:
-  - name:
-      lineage:
-      family: Fasulo
-      given: D.
-      honourific:
-  - name:
-      honourific:
-      given: A.-K.
-      family: Emde
-      lineage:
-  - name:
-      lineage:
-      family: Wang
-      honourific:
-      given: L.-Y.
-  - name:
-      lineage:
-      honourific:
-      given: N. J.
-      family: Edwards
-  rev_number: 6
-  publisher: Springer Verlag
-  type: conference_item
-  userid: 1
-  abstract: "Mass spectrometry (MS) is becoming a popular approach for quantifyingthe
-    protein composition of complex samples. A great challenge forcomparative
-    proteomic profiling is to match corresponding peptidefeatures from different
-    experiments to ensure that the same proteinintensities are correctly identified.
-    Multi-dimensional data acquisitionfrom liquid-chromatography mass spectrometry
-    (LC-MS) makes the alignmentproblem harder. We propose a general paradigm
-    for aligning peptidefeatures using a bounded error model. Our method is
-    tolerant of imperfectmeasurements, missing peaks, and extraneous peaks.
-    It can handlean arbitrary number of dimensions of separation, and is very
-    fastin practice even for large data sets. Finally, its parameters areintuitive
-    and we describe a heuristic for estimating them automatically.We demonstrate
-    results on single- and multi-dimensional data."
-  status_changed: '2009-03-11 11:26:55'
-  title: Alignment of Mass Spectrometry Data by Clique Finding and Optimization
-  official_url: http://www.springerlink.com/content/h716314047k25505
-  uri: http://publications.imp.fu-berlin.de/id/eprint/345
-  event_title: Systems Biology and Computational Proteomics
-  lastmod: '2010-09-01 13:22:04'
-  ispublished: pub
-- full_text_status: none
-  metadata_visibility: show
-  item_issues_count: 0
-  number: 18
-  eprintid: 346
-  refereed: 'TRUE'
-  volume: 19
-  divisions:
-  - group_algbioinf
-  date: 2003-12
-  pagerange: 2442-2447
-  dir: disk0/00/00/03/46
-  eprint_status: archive
-  uri: http://publications.imp.fu-berlin.de/id/eprint/346
-  ispublished: pub
-  lastmod: '2009-04-14 14:35:22'
-  official_url: http://dx.doi.org/10.1093/bioinformatics/btg343
-  keywords: algorithm, proteomics, statistics
-  rev_number: 3
-  type: article
-  userid: 1
-  abstract: "Motivation: The Dictionary of Interfaces in Proteins (DIP) is a databasecollecting
-    the 3D structure of interacting parts of proteins thatare called patches.
-    It serves as a repository, in which patches similarto given query patches
-    can be found. The computation of the similarityof two patches is time consuming
-    and traversing the entire DIP requiressome hours. In this work we address
-    the question of how the patchessimilar to a given query can be identified
-    by scanning only a smallpart of DIP. The answer to this question requires
-    the investigationof the distribution of the similarity of patches. Results:
-    The scorevalues describing the similarity of two patches can roughly be
-    dividedinto three ranges that correspond to different levels of spatialsimilarity.
-    Interestingly, the two iso-score lines separating thethree classes can be
-    determined by two different approaches. Applyinga concept of the theory
-    of random graphs reveals significant structuralproperties of the data in
-    DIP. These can be used to accelerate scanningthe DIP for patches similar
-    to a given query. Searches for very similarpatches could be accelerated
-    by a factor of more than 25. Patcheswith a medium similarity could be found
-    10 times faster than by brute-forcesearch. 10.1093/bioinformatics/btg343"
-  status_changed: '2009-03-11 11:26:55'
-  title: "Accelerating screening of 3D protein data with a graph theoreticalapproach"
-  publication: Bioinformatics
-  datestamp: '2009-04-14 14:35:22'
-  creators:
-  - name:
-      honourific:
-      given: C.
-      family: Frömmel
-      lineage:
-  - name:
-      lineage:
-      family: Gille
-      given: Ch.
-      honourific:
-  - name:
-      family: Goede
-      honourific:
-      given: A.
-      lineage:
-  - name:
-      family: Gröpl
-      given: C.
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      family: Hougardy
-      honourific:
-      given: S.
-  - name:
-      lineage:
-      honourific:
-      given: T.
-      family: Nierhoff
-  - name:
-      lineage:
-      family: Preissner
-      given: R.
-      honourific:
-  - name:
-      honourific:
-      given: M.
-      family: Thimm
-      lineage:
-- divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  date: 2010
-  place_of_pub: Boca Raton, USA
-  dir: disk0/00/00/08/25
-  eprint_status: archive
-  metadata_visibility: show
-  date_type: published
-  full_text_status: none
-  series: 'Chapman & Hall/CRC Mathematical & Computational Biology '
-  item_issues_count: 0
-  refereed: 'FALSE'
-  eprintid: 825
-  number: 1
-  userid: 132
-  rev_number: 11
-  publisher: CRC Press
-  type: book
-  title: Biological Sequence Analysis using the SeqAn C++ Library
-  status_changed: '2010-03-04 12:10:11'
-  abstract: "Before the SeqAn project, there was clearly a lack of available implementations
-    in sequence analysis, even for standard tasks. Implementations of needed algorithmic
-    components were either unavailable or hard to access in third-party monolithic
-    software products. Addressing these concerns, the developers of SeqAn created
-    a comprehensive, easy-to-use, open source C++ library of efficient algorithms
-    and data structures for the analysis of biological sequences. Written by the founders
-    of this project, Biological Sequence Analysis Using the SeqAn C++ Library covers
-    the SeqAn library, its documentation, and the supporting infrastructure.The
-    first part of the book describes the general library design. It introduces biological
-    sequence analysis problems, discusses the benefit of using software libraries,
-    summarizes the design principles and goals of SeqAn, details the main programming
-    techniques used in SeqAn, and demonstrates the application of these techniques
-    in various examples. Focusing on the components provided by SeqAn, the second
-    part explores basic functionality, sequence data structures, alignments, pattern
-    and motif searching, string indices, and graphs. The last part illustrates applications
-    of SeqAn to genome alignment, consensus sequence in assembly projects, suffix
-    array construction, and more.This handy book describes a user-friendly
-    library of efficient data types and algorithms for sequence analysis in computational
-    biology. SeqAn enables not only the implementation of new algorithms, but also
-    the sound analysis and comparison of existing algorithms."
-  datestamp: '2010-03-04 12:10:11'
-  creators:
-  - id: andreas.doering@mdc-berlin.de
-    name:
-      lineage:
-      honourific:
-      given: A.
-      family: Gogol-Döring
-  - name:
-      family: Reinert
-      honourific:
-      given: K.
-      lineage:
-    id: knut.reinert@fu-berlin.de
-  isbn: 9781420076233
-  uri: http://publications.imp.fu-berlin.de/id/eprint/825
-  pages: 311
-  lastmod: '2010-09-01 13:26:25'
-  ispublished: pub
-  official_url: http://crcpress.com/product/isbn/9781420076233
-- full_text_status: none
-  date_type: published
-  metadata_visibility: show
-  id_number: doi:10.1093/infdis/jix567
-  number: 9
-  eprintid: 2283
-  refereed: 'TRUE'
-  volume: 217
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  pagerange: 1442-1452
-  date: '2018-05-01'
-  issn: 0022-1899
-  dir: disk0/00/00/22/83
-  eprint_status: archive
-  uri: http://publications.imp.fu-berlin.de/id/eprint/2283
-  lastmod: '2018-11-08 11:52:57'
-  ispublished: pub
-  official_url: http://doi.org/10.1093/infdis/jix567
-  type: article
-  rev_number: 5
-  userid: 132
-  status_changed: '2018-11-08 11:52:57'
-  abstract: Spontaneous outbreaks of Clostridium difficile infection (CDI) occur in
-    neonatal piglets, but the predisposing factors are largely not known. To study
-    the conditions for C. difficile colonization and CDI development, 48 neonatal
-    piglets were moved into isolators, fed bovine milk–based formula, and infected
-    with C. difficile 078. Analyses included clinical scoring; measurement of the
-    fecal C. difficile burden, toxin B level, and calprotectin level; and postmortem
-    histopathological analysis of colon specimens. Controls were noninfected suckling
-    piglets. Fecal specimens from suckling piglets, formula-fed piglets, and formula-fed,
-    C. difficile–infected piglets were used for metagenomics analysis. High background
-    levels of C. difficile and toxin were detected in formula-fed piglets prior to
-    infection, while suckling piglets carried about 3-fold less C. difficile, and
-    toxin was not detected. Toxin level in C. difficile–challenged animals correlated
-    positively with C. difficile and calprotectin levels. Postmortem signs of CDI
-    were absent in suckling piglets, whereas mesocolonic edema and gas-filled distal
-    small intestines and ceca, cellular damage, and reduced expression of claudins
-    were associated with animals from the challenge trials. Microbiota in formula-fed
-    piglets was enriched with Escherichia, Shigella, Streptococcus, Enterococcus,
-    and Ruminococcus species. Formula-fed piglets were predisposed to C. difficile
-    colonization earlier as compared to suckling piglets. Infection with a hypervirulent
-    C. difficile ribotype did not aggravate the symptoms of infection. Sow-offspring
-    association and consumption of porcine milk during early life may be crucial for
-    the control of C. difficile expansion in piglets.
-  title: Formula Feeding Predisposes Neonatal Piglets to Clostridium difficile Gut
-    Infection
-  publication: The Journal of Infectious Diseases
-  datestamp: '2018-11-08 11:52:57'
-  creators:
-  - name:
-      family: Grześkowiak
-      given: Łukasz
-      honourific:
-      lineage:
-  - name:
-      given: Beatriz
-      honourific:
-      family: Martínez-Vallespín
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: Temesgen H
-      family: Dadi
-  - name:
-      lineage:
-      given: Judith
-      honourific:
-      family: Radloff
-  - name:
-      lineage:
-      family: Amasheh
-      honourific:
-      given: Salah
-  - name:
-      lineage:
-      honourific:
-      given: Femke-Anouska
-      family: Heinsen
-  - name:
-      honourific:
-      given: Andre
-      family: Franke
-      lineage:
-  - name:
-      given: Knut
-      honourific:
-      family: Reinert
-      lineage:
-  - name:
-      lineage:
-      given: Wilfried
-      honourific:
-      family: Vahjen
-  - name:
-      honourific:
-      given: Jürgen
-      family: Zentek
-      lineage:
-  - name:
-      given: Robert
-      honourific:
-      family: Pieper
-      lineage:
-- official_url: http://www.dagstuhl.de/05471/
-  note: "Extended abstract for talk given at Dagstuhl Seminar 05471 on ComputationalProteomics,
-    20.-25. November 2005"
-  lastmod: '2009-04-14 14:26:41'
-  ispublished: pub
-  uri: http://publications.imp.fu-berlin.de/id/eprint/347
-  event_title: Computational Proteomics
-  creators:
-  - name:
-      family: Gröpl
-      honourific:
-      given: C.
-      lineage:
-  datestamp: '2009-04-14 14:26:41'
-  title: An Algorithm for Feature Finding in LC/MS Raw Data
-  status_changed: '2009-03-11 11:26:56'
-  userid: 1
-  rev_number: 3
-  publisher: Dagstuhl Online Publication Server (DROPS)
-  type: conference_item
-  refereed: 'TRUE'
-  eprintid: 347
-  item_issues_count: 0
-  metadata_visibility: show
-  full_text_status: none
-  eprint_status: archive
-  dir: disk0/00/00/03/47
-  date: 2005
-  subjects:
-  - G400
-  divisions:
-  - group_algbioinf
-- divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  date: 2003
-  dir: disk0/00/00/03/48
-  eprint_status: archive
-  full_text_status: none
-  metadata_visibility: show
-  item_issues_count: 0
-  eprintid: 348
-  refereed: 'TRUE'
-  type: other
-  rev_number: 3
-  userid: 1
-  status_changed: '2009-03-11 11:26:56'
-  title: Algorithmen in der Bioinformatik
-  datestamp: '2009-04-14 14:36:34'
-  creators:
-  - name:
-      lineage:
-      family: Gröpl
-      given: C.
-      honourific:
-  uri: http://publications.imp.fu-berlin.de/id/eprint/348
-  ispublished: pub
-  lastmod: '2009-04-14 14:36:34'
-  note: "Skript zu meiner Vorlesung im Wintersemester 2002/03 am Institutfür Informatik
-    der Humboldt-Universität zu Berlin"
-- official_url: http://dochost.rz.hu-berlin.de/dissertationen/informatik/groepl-clemens
-  keywords: "Binary decision diagram, Boolean function, probabilistic analysis,Shannon
-    effect"
-  ispublished: unpub
-  lastmod: '2009-04-14 14:41:14'
-  uri: http://publications.imp.fu-berlin.de/id/eprint/349
-  creators:
-  - name:
-      lineage:
-      given: C.
-      honourific:
-      family: Gröpl
-  datestamp: '2009-04-14 14:41:14'
-  thesis_type: phd
-  status_changed: '2009-03-11 11:26:57'
-  abstract: "(deutsche Zusammenfassung siehe unten)&lt;p&gt; Binary Decision Diagrams(BDDs)
-    are a data structure for Boolean functions which are alsoknown as branching
-    programs. In ordered binary decision diagrams(OBDDs), the tests have to
-    obey a fixed variable ordering. In freebinary decision diagrams (FBDDs),
-    each variable can be tested atmost once. The efficiency of new variants
-    of the BDD concept is usuallydemonstrated with spectacular (worst-case)
-    examples. We pursue anotherapproach and compare the representation sizes
-    of almost all Booleanfunctions. Whereas I. Wegener proved that for `most'
-    values of nthe expected OBDD size of a random Boolean function of n variablesis
-    equal to the worst-case size up to terms of lower order, we showthat this
-    is not the case for n within intervals of constant lengtharound the values
-    n = 2h + h. Furthermore, ranges of n exist forwhich minimal FBDDs are almost
-    always at least a constant factorsmaller than minimal OBDDs. Our main theorems
-    have doubly exponentiallysmall probability bounds (in n). We also investigate
-    the evolutionof random OBDDs and their worst-case size, revealing an oscillatingbehaviour
-    that explains why certain results cannot be improved ingeneral. &lt;p&gt;
-    &lt;b&gt;Zusammenfassung:&lt;/b&gt;&lt;p&gt; Binary Decision Diagrams(BDDs)
-    sind eine Datenstruktur für Boolesche Funktionen, dieauch unter dem Namen
-    branching program bekannt ist. In ordered binarydecision diagrams (OBDDs)
-    müssen die Tests einer festen Variablenordnunggenügen. In free binary decision
-    diagrams (FBDDs) darf jede Variablehöchstens einmal getestet werden. Die
-    Effizienz neuer Variantendes BDD-Konzepts wird gewöhnlich anhand spektakulärer
-    (worst-case)Beispiele aufgezeigt. Wir verfolgen einen anderen Ansatz und
-    vergleichendie Darstellungsgrößen für fast alle Booleschen Funktionen.Während
-    I. Wegener bewiesen hat, daß für die `meisten'n die erwartete OBDD-Größe
-    einer zufälligen BooleschenFunktion von n Variablen gleich der worst-case
-    Größe bisauf Terme kleinerer Ordnung ist, zeigen wir daß dies nicht derFall
-    ist für n innerhalb von Intervallen konstanter Längeum die Werte n = 2h
-    + h. Ferner gibt es Bereiche von n, in denenminimale FBDDs fast immer um
-    mindestens einen konstanten Faktor kleinersind als minimale OBDDs. Unsere
-    Hauptsätze ha ben doppelt exponentielleWahrschein- lichkeitsschranken (in
-    n). Außerdem untersuchen wirdie Entwicklung zufälliger OBDDs und ihrer worst-case
-    Größeund decken dabei ein oszillierendes Verhalten auf, das erklärt,warum
-    gewisse Aussagen im allgemeinen nicht verstärkt werdenkönnen. &lt;p&gt;Schlagwörter:&lt;p&gt;
-    Binäres Entscheidungsdiagramm,Boolesche Funktion,probabilistische Analyse,
-    Shannon Effekt."
-  title: Binary Decision Diagrams for Random Boolean Functions
-  rev_number: 3
-  type: thesis
-  userid: 1
-  eprintid: 349
-  refereed: 'TRUE'
-  institution: Humboldt-Universität zu Berlin
-  item_issues_count: 0
-  full_text_status: none
-  metadata_visibility: show
-  eprint_status: archive
-  dir: disk0/00/00/03/49
-  date: 1999
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-- keywords: Approximation algorithms, Colouring, packing and covering
-  uri: http://publications.imp.fu-berlin.de/id/eprint/350
-  lastmod: '2009-04-14 14:43:52'
-  ispublished: unpub
-  thesis_type: masters
-  datestamp: '2009-04-14 14:43:52'
-  creators:
-  - name:
-      honourific:
-      given: C.
-      family: Gröpl
-      lineage:
-  userid: 1
-  rev_number: 3
-  type: thesis
-  title: "Über Approximationsalgorithmen zur Färbung k-färbbarerGraphen, die vektorchromatische
-    Zahl und andere Varianten der vartheta-Funktion"
-  status_changed: '2009-03-11 11:26:57'
-  refereed: 'TRUE'
-  eprintid: 350
-  institution: Rheinische Friedrich-Wilhelms-Universität Bonn
-  metadata_visibility: show
-  full_text_status: none
-  item_issues_count: 0
-  dir: disk0/00/00/03/50
-  eprint_status: archive
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  date: 1996-01
-  place_of_pub: Forschungsinstitut für Diskrete Mathematik
-- keywords: mass spectrometry, proteomics, open source software
-  ispublished: pub
-  lastmod: '2010-09-01 13:38:57'
-  note: http://mbi.osu.edu/2004/workshops2004.html
-  uri: http://publications.imp.fu-berlin.de/id/eprint/351
-  creators:
-  - name:
-      lineage:
-      honourific:
-      given: C.
-      family: Gröpl
-  - name:
-      lineage:
-      honourific:
-      given: A.
-      family: Hildebrandt
-  - name:
-      honourific:
-      given: E.
-      family: Lange
-      lineage:
-  - name:
-      lineage:
-      given: S.
-      honourific:
-      family: Lövenich
-  - name:
-      lineage:
-      family: Sturm
-      honourific:
-      given: M.
-  datestamp: '2009-03-11 16:53:50'
-  status_changed: '2009-03-11 11:26:58'
-  title: OpenMS - Software for Mass Spectrometry
-  rev_number: 4
-  type: other
-  userid: 1
-  eprintid: 351
-  refereed: 'TRUE'
-  item_issues_count: 0
-  full_text_status: none
-  metadata_visibility: show
-  eprint_status: archive
-  dir: disk0/00/00/03/51
-  date: 2005
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-- uri: http://publications.imp.fu-berlin.de/id/eprint/352
-  note: http://www.hupo2005.com/
-  ispublished: pub
-  lastmod: '2010-09-01 13:40:54'
-  keywords: mass spectrometry, proteomics, open source software
-  userid: 1
-  rev_number: 3
-  type: other
-  title: OpenMS - a generic open source framework for HPLC/MS-based proteomics
-  status_changed: '2009-03-11 11:26:59'
-  datestamp: '2010-09-01 13:40:54'
-  creators:
-  - name:
-      given: C.
-      honourific:
-      family: Gröpl
-      lineage:
-  - name:
-      honourific:
-      given: A.
-      family: Hildebrandt
-      lineage:
-  - name:
-      honourific:
-      given: E.
-      family: Lange
-      lineage:
-  - name:
-      lineage:
-      given: M.
-      honourific:
-      family: Sturm
-  metadata_visibility: show
-  full_text_status: none
-  item_issues_count: 0
-  refereed: 'TRUE'
-  eprintid: 352
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  date: 2005
-  dir: disk0/00/00/03/52
-  eprint_status: archive
-- creators:
-  - name:
-      family: Gröpl
-      honourific:
-      given: C.
-      lineage:
-  - name:
-      honourific:
-      given: S.
-      family: Hougardy
-      lineage:
-  - name:
-      lineage:
-      given: T.
-      honourific:
-      family: Nierhoff
-  - name:
-      given: H.-J.
-      honourific:
-      family: Prömel
-      lineage:
-  datestamp: '2009-04-14 14:39:16'
-  status_changed: '2009-03-11 11:26:59'
-  editors:
-  - name:
-      honourific:
-      given: X.
-      family: Cheng
-      lineage:
-  - name:
-      honourific:
-      given: D. Z.
-      family: Du
-      lineage:
-  title: Approximation Algorithms for the Steiner Tree Problem in Graphs
-  publisher: Kluwer Academic Publishers
-  rev_number: 3
-  type: book_section
-  userid: 1
-  keywords: "Approximation algorithms, Combinatorial optimization, Graph algorithms,Steiner
-    trees"
-  ispublished: pub
-  lastmod: '2009-04-14 14:39:16'
-  note: Survey article with new proofs
-  book_title: Steiner Trees in Industry
-  uri: http://publications.imp.fu-berlin.de/id/eprint/353
-  eprint_status: archive
-  dir: disk0/00/00/03/53
-  date: 2001
-  pagerange: 235-279
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  refereed: 'TRUE'
-  eprintid: 353
-  item_issues_count: 0
-  full_text_status: none
-  metadata_visibility: show
-- series: LNCS
-  item_issues_count: 0
-  metadata_visibility: show
-  full_text_status: none
-  refereed: 'TRUE'
-  eprintid: 355
-  date: 2001
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  eprint_status: archive
-  dir: disk0/00/00/03/55
-  ispublished: pub
-  lastmod: '2009-04-14 14:40:07'
-  uri: http://publications.imp.fu-berlin.de/id/eprint/355
-  event_title: "Proceedings of the 27th International Workshop on Graph-TheoreticConcepts
-    in Computer Science (2001)"
-  keywords: "Steiner trees, Approximation algorithms, Combinatorial optimization,Graph
-    algorithms, Hypergraphs, set systems, and designs"
-  title: "Lower bounds for approximation algorithms for the Steiner treeproblem"
-  status_changed: '2009-03-11 11:27:00'
-  abstract: "The Steiner tree problem asks for a shortest subgraph connecting agiven
-    set of terminals in a graph. It is known to be APX-complete,which means
-    that no polynomial time approximation scheme can existfor this problem,
-    unless P=NP. Currently, the best approximationalgorithm for the Steiner
-    tree problem has a performance ratio of<span class='mathrm'>1.55</span>,
-    whereas the corresponding lower bound is smaller than <span class='mathrm'>1.01</span>.In
-    this paper, we provide for several Steiner tree approximationalgorithms
-    lower bounds on their performance ratio that are muchlarger. For two algorithms
-    that solve the Steiner tree problem onquasi-bipartite instances, we even
-    prove lower bounds that matchthe upper bounds. Quasi-bipartite instances
-    are of special interest,as currently all known lower bound reductions for
-    the Steiner treeproblem in graphs produce such instances."
-  userid: 1
-  publisher: Springer Verlag
-  type: conference_item
-  rev_number: 3
-  creators:
-  - name:
-      honourific:
-      given: C.
-      family: Gröpl
-      lineage:
-  - name:
-      lineage:
-      family: Hougardy
-      given: S.
-      honourific:
-  - name:
-      family: Nierhoff
-      given: T.
-      honourific:
-      lineage:
-  - name:
-      given: H.-J.
-      honourific:
-      family: Prömel
-      lineage:
-  datestamp: '2009-04-14 14:40:07'
-- keywords: Steiner trees, Graph algorithms, Approximation algorithms
-  uri: http://publications.imp.fu-berlin.de/id/eprint/354
-  lastmod: '2009-04-14 14:39:09'
-  ispublished: pub
-  publication: Information Processing Letters
-  datestamp: '2009-04-14 14:39:09'
-  creators:
-  - name:
-      lineage:
-      given: C.
-      honourific:
-      family: Gröpl
-  - name:
-      lineage:
-      given: S.
-      honourific:
-      family: Hougardy
-  - name:
-      family: Nierhoff
-      honourific:
-      given: T.
-      lineage:
-  - name:
-      honourific:
-      given: H.-J.
-      family: Prömel
-      lineage:
-  userid: 1
-  type: article
-  rev_number: 3
-  title: Steiner trees in uniformly quasi-bipartite graphs
-  status_changed: '2009-03-11 11:27:00'
-  abstract: "The area of approximation algorithms for the Steiner tree problemin
-    graphs has seen continuous progress over the last years. Currentlythe best
-    approximation algorithm has a performance ratio of 1.550.This is still far
-    away from 1.0074, the largest known lower boundon the achievable performance
-    ratio. As all instances resulting fromknown lower bound reductions are uniformly
-    quasi-bipartite, it isinteresting whether this special case can be approximated
-    betterthan the general case. We present an approximation algorithm withperformance
-    ratio 73/60 &lt; 1.217 for the uniformly quasi-bipartitecase. This improves
-    on the previously known ratio of 1.279 of Robinsand Zelikovsky. We use a
-    new method of analysis that combines ideasfrom the greedy algorithm for
-    set cover with a matroid-style exchangeargument to model the connectivity
-    constraint. As a consequence,we are able to provide a tight instance."
-  refereed: 'TRUE'
-  eprintid: 354
-  metadata_visibility: show
-  full_text_status: none
-  item_issues_count: 0
-  dir: disk0/00/00/03/54
-  eprint_status: archive
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  volume: 83
-  date: 2002
-  pagerange: 195-200
-- eprintid: 356
-  refereed: 'TRUE'
-  metadata_visibility: show
-  full_text_status: none
-  item_issues_count: 0
-  dir: disk0/00/00/03/56
-  eprint_status: archive
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  date: 2002
-  uri: http://publications.imp.fu-berlin.de/id/eprint/356
-  ispublished: pub
-  lastmod: '2009-04-14 14:37:28'
-  datestamp: '2009-04-14 14:37:28'
-  creators:
-  - name:
-      lineage:
-      family: Gröpl
-      given: C.
-      honourific:
-  - name:
-      honourific:
-      given: S.
-      family: Hougardy
-      lineage:
-  - name:
-      lineage:
-      family: Nierhoff
-      honourific:
-      given: T.
-  - name:
-      honourific:
-      given: H.-J.
-      family: Prömel
-      lineage:
-  - name:
-      lineage:
-      family: Thimm
-      honourific:
-      given: M.
-  userid: 1
-  type: other
-  rev_number: 3
-  title: Approximationsalgorithmen für das Steinerbaumproblem in Graphen
-  status_changed: '2009-03-11 11:27:01'
-- dir: disk0/00/00/03/58
-  eprint_status: archive
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  pagerange: 151-163
-  date: 2005
-  refereed: 'TRUE'
-  eprintid: 358
-  full_text_status: none
-  metadata_visibility: show
-  item_issues_count: 0
-  datestamp: '2009-04-14 14:27:04'
-  creators:
-  - name:
-      family: Gröpl
-      honourific:
-      given: C.
-      lineage:
-  - name:
-      lineage:
-      given: E.
-      honourific:
-      family: Lange
-  - name:
-      lineage:
-      given: K.
-      honourific:
-      family: Reinert
-  - name:
-      lineage:
-      family: Sturm
-      honourific:
-      given: M.
-  - name:
-      lineage:
-      family: Huber
-      honourific:
-      given: Ch.
-  - name:
-      family: Mayr
-      honourific:
-      given: B. M.
-      lineage:
-  - name:
-      lineage:
-      given: C. L.
-      honourific:
-      family: Klein
-  type: conference_item
-  rev_number: 3
-  userid: 1
-  status_changed: '2009-03-11 11:27:02'
-  abstract: "HPLC-ESI-MS is rapidly becoming an established standard method forshotgun
-    proteomics. Currently, its major drawbacks are twofold: quantificationis
-    mostly limited to relative quantification and the large amountof data produced
-    by every individual experiment can make manual analysisquite difficult.
-    Here we present a new, combined experimental andalgorithmic approach to
-    absolutely quantify proteins from sampleswith unprecedented precision. We
-    apply the method to the analysisof myoglobin in human blood serum, which
-    is an important diagnosticmarker for myocardial infarction. Our approach
-    was able to determinethe absolute amount of myoglobin in a serum sample
-    through a seriesof standard addition experiments with a relative error of
-    2.5 percent.Compared to a manual analysis of the same dataset we could improvethe
-    precision and conduct it in a fraction of the time needed forthe manual
-    analysis. We anticipate that our automatic quantitationmethod will facilitate
-    further absolute or relative quantitationof even more complex peptide samples.
-    The algorithm was developedusing our publically available software framework
-    OpenMS (www.openms.de)."
-  title: "Algorithms for the automated absolute quantification of diagnosticmarkers
-    in complex proteomics samples"
-  event_title: "Proceedings of the 1st International Symposium on Computational LifeScience
-    (CompLife05)"
-  uri: http://publications.imp.fu-berlin.de/id/eprint/358
-  lastmod: '2009-04-14 14:27:04'
-  ispublished: pub
-- keywords: Binary Decision Diagrams
-  ispublished: pub
-  lastmod: '2009-04-14 14:40:13'
-  uri: http://publications.imp.fu-berlin.de/id/eprint/361
-  creators:
-  - name:
-      lineage:
-      family: Gröpl
-      honourific:
-      given: C.
-  - name:
-      given: H.-J.
-      honourific:
-      family: Prömel
-      lineage:
-  - name:
-      lineage:
-      family: Srivastav
-      given: A.
-      honourific:
-  publication: Information Processing Letters
-  datestamp: '2009-04-14 14:40:13'
-  title: On the Evolution of the Worst-Case OBDD Size
-  abstract: "We prove matching lower and upper bounds on the worst-case OBDD sizeof
-    a Boolean function, revealing an interesting ocillating behaviour."
-  status_changed: '2009-03-11 11:27:04'
-  userid: 1
-  rev_number: 3
-  type: article
-  eprintid: 361
-  refereed: 'TRUE'
-  item_issues_count: 0
-  metadata_visibility: show
-  full_text_status: none
-  eprint_status: archive
-  dir: disk0/00/00/03/61
-  pagerange: 1-7
-  date: 2001
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  volume: 77
-- userid: 1
-  rev_number: 3
-  type: article
-  title: Ordered binary decision diagrams and the Shannon effect
-  abstract: "We investigate the size and structure of ordered binary decision diagrams(OBDDs)
-    for random Boolean functions. It was known that for mostvalues of n, the
-    expected OBDD size of a random Boolean functionwith n variables is equal
-    to the worst-case size up to terms of lowerorder. Such a phenomenon is generally
-    called strong Shannon effect.Here we show that the strong Shannon effect
-    is not valid for alln. Instead it undergoes a certain periodic `phase transition':
-    Ifn lies within intervals of constant width around the values n = 2h+
-    h, then the strong Shannon effect does not hold, whereas it doeshold outside
-    these intervals. Our analysis provides doubly exponentialprobability bounds
-    and generalises to ordered Kronecker functionaldecision diagrams (OKFDDs). "
-  status_changed: '2009-03-11 11:27:03'
-  datestamp: '2009-04-14 14:35:30'
-  publication: Discrete Applied Mathematics
-  creators:
-  - name:
-      lineage:
-      family: Gröpl
-      given: C.
-      honourific:
-  - name:
-      given: H.-J.
-      honourific:
-      family: Prömel
-      lineage:
-  - name:
-      honourific:
-      given: A.
-      family: Srivastav
-      lineage:
-  uri: http://publications.imp.fu-berlin.de/id/eprint/360
-  ispublished: pub
-  lastmod: '2009-04-14 14:35:30'
-  keywords: "VLSI-Design and layout, Binary Decision Diagrams, Graph theory (other),Hardware
-    verification, Probability theory, Random graphs, Randomizedalgorithms and
-    probabilistic analysis, Theoretical computer science(other)"
-  subjects:
-  - G400
-  divisions:
-  - group_algbioinf
-  volume: 142
-  pagerange: 67-85
-  date: 2004
-  dir: disk0/00/00/03/60
-  eprint_status: archive
-  metadata_visibility: show
-  full_text_status: none
-  item_issues_count: 0
-  eprintid: 360
-  refereed: 'TRUE'
-- creators:
-  - name:
-      honourific:
-      given: C.
-      family: Gröpl
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: H.-J.
-      family: Prömel
-  - name:
-      lineage:
-      family: Srivastav
-      honourific:
-      given: A.
-  datestamp: '2009-04-14 14:42:04'
-  editors:
-  - name:
-      lineage:
-      honourific:
-      given: D.
-      family: Korb
-  - name:
-      lineage:
-      family: Meinel
-      given: Ch.
-      honourific:
-  - name:
-      family: Morvan
-      honourific:
-      given: M.
-      lineage:
-  status_changed: '2009-03-11 11:27:03'
-  title: "Size and Structure of Random Ordered Binary Decision Diagrams (ExtendedAbstract)"
-  publisher: Springer Verlag
-  type: conference_item
-  rev_number: 3
-  userid: 1
-  keywords: VLSI-Design and layout, Hardware verification, Random graphs
-  lastmod: '2009-04-14 14:42:04'
-  ispublished: pub
-  event_title: STACS 98
-  uri: http://publications.imp.fu-berlin.de/id/eprint/359
-  eprint_status: archive
-  dir: disk0/00/00/03/59
-  place_of_pub: Berlin, Heidelberg, New York
-  date: 1998
-  pagerange: 238-248
-  subjects:
-  - G400
-  divisions:
-  - group_algbioinf
-  number: 1373
-  refereed: 'TRUE'
-  eprintid: 359
-  item_issues_count: 0
-  series: Lecture Notes in Computer Science
-  full_text_status: none
-  metadata_visibility: show
-- dir: disk0/00/00/03/63
-  eprint_status: archive
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  volume: 1367
-  pagerange: 161-177
-  date: 1998
-  eprintid: 363
-  refereed: 'TRUE'
-  metadata_visibility: show
-  full_text_status: none
-  series: Lecture Notes in Computer Science
-  item_issues_count: 0
-  datestamp: '2009-04-14 14:42:14'
-  creators:
-  - name:
-      given: C.
-      honourific:
-      family: Gröpl
-      lineage:
-  - name:
-      family: Skutella
-      given: M.
-      honourific:
-      lineage:
-  userid: 1
-  type: book_section
-  publisher: Springer
-  rev_number: 3
-  title: Parallel Repetition of MIP(2,1) Systems
-  status_changed: '2009-03-11 11:27:05'
-  editors:
-  - name:
-      honourific:
-      given: E. W.
-      family: Mayr
-      lineage:
-  - name:
-      honourific:
-      given: H.-J.
-      family: Prömel
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: A.
-      family: Steger
-  keywords: "Theoretical computer science (other), Approximation algorithms, PCPand
-    non-approximability"
-  uri: http://publications.imp.fu-berlin.de/id/eprint/363
-  note: The book grow out of a Dagstuhl Seminar, April 21-25, 1997
-  book_title: Lectures on Proof Verification and Approximation Algorithms
-  lastmod: '2009-04-14 14:42:14'
-  ispublished: pub
-- type: conference_item
-  rev_number: 3
-  userid: 1
-  status_changed: '2009-03-11 11:27:06'
-  title: Segment Match refinment and applications
-  datestamp: '2017-03-03 14:40:14'
-  creators:
-  - name:
-      family: Halpern
-      given: A. L.
-      honourific:
-      lineage:
-  - name:
-      honourific:
-      given: D. H.
-      family: Huson
-      lineage:
-  - name:
-      given: K.
-      honourific:
-      family: Reinert
-      lineage:
-  event_title: Proceedings of the 2nd Workshop on Algorithms Bioinformatics (WABI-02)
-  uri: http://publications.imp.fu-berlin.de/id/eprint/364
-  lastmod: '2017-03-03 14:40:14'
-  ispublished: pub
-  subjects:
-  - G400
-  divisions:
-  - group_algbioinf
-  pagerange: 126-139
-  date: 2002
-  dir: disk0/00/00/03/64
-  eprint_status: archive
-  full_text_status: none
-  metadata_visibility: show
-  item_issues_count: 0
-  eprintid: 364
-  refereed: 'TRUE'
-- volume: 30
-  divisions:
-  - group_algbioinf
-  date: 2014-09
-  pagerange: i349-i355
-  dir: disk0/00/00/14/53
-  eprint_status: archive
-  full_text_status: none
-  metadata_visibility: show
-  item_issues_count: 0
-  number: 17
-  refereed: 'TRUE'
-  eprintid: 1453
-  rev_number: 13
-  publisher: Oxford University Press
-  type: article
-  userid: 29
-  status_changed: '2016-11-15 14:03:47'
-  abstract: "MOTIVATION:Next-generation sequencing technologies produce unprecedented
-    amounts of data, leading to completely new research fields. One of these is metagenomics,
-    the study of large-size DNA samples containing a multitude of diverse organisms.
-    A key problem in metagenomics is to functionally and taxonomically classify the
-    sequenced DNA, to which end the well-known BLAST program is usually used. But
-    BLAST has dramatic resource requirements at metagenomic scales of data, imposing
-    a high financial or technical burden on the researcher. Multiple attempts have
-    been made to overcome these limitations and  present a viable alternative to BLAST.RESULTS:In
-    this work we present Lambda, our own alternative for BLAST in the context of sequence
-    classification. In our tests, Lambda often outperforms the best tools at reproducing
-    BLAST's results and is the fastest compared with the current state of the art
-    at comparable levels of sensitivity.AVAILABILITY AND IMPLEMENTATION:Lambda
-    was implemented in the SeqAn open-source C++ library for sequence analysis and
-    is publicly available for download at http://www.seqan.de/projects/lambda.CONTACT:hannes.hauswedell@fu-berlin.deSUPPLEMENTARY
-    INFORMATION:Supplementary data are available at Bioinformatics online."
-  title: 'Lambda: the local aligner for massive biological data'
-  datestamp: '2014-09-23 18:00:01'
-  publication: Bioinformatics (Oxford, England)
-  creators:
-  - name:
-      lineage:
-      given: H.
-      honourific:
-      family: Hauswedell
-  - name:
-      given: J.
-      honourific:
-      family: Singer
-      lineage:
-  - name:
-      family: Reinert
-      honourific:
-      given: K.
-      lineage:
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1453
-  lastmod: '2016-11-15 14:03:47'
-  ispublished: pub
-  official_url: http://bioinformatics.oxfordjournals.org/content/30/17/i349.full
-- lastmod: '2011-06-27 13:44:14'
-  ispublished: pub
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1072
-  official_url: http://dx.doi.org/10.1186/1471-2105-12-210
-  status_changed: '2011-06-27 13:44:14'
-  abstract: "BackgroundSecond generation sequencing technologies yield DNA sequence
-    data at ultra high-throughput. Common to most biological applications is a mapping
-    of the reads to an almost identical or highly similar reference genome. The assessment
-    of the quality of read mapping results is not straightforward and has not been
-    formalized so far. Hence, it has not been easy to compare different read mapping
-    approaches in a unified way and to determine which program is the best for what
-    task.ResultsWe present a new benchmark method, called Rabema (Read
-    Alignment BEnchMArk), for read mappers. It consists of a strict definition of
-    the read mapping problem and of tools to evaluate the result of arbitrary read
-    mappers supporting the SAM output format.ConclusionsWe show the usefulness
-    of the benchmark program by performing a comparison of popular read mappers. The
-    tools supporting the benchmark are licensed under the GPL and available from http://www.seqan.de/projects/rabema.html."
-  title: A Novel And Well-Defined Benchmarking Method For Second Generation Read Mapping
-  type: article
-  publisher: BioMed Central
-  rev_number: 12
-  userid: 167
-  creators:
-  - id: holtgrewe@mi.fu-berlin.de
-    name:
-      lineage:
-      honourific:
-      given: M.
-      family: Holtgrewe
-  - name:
-      lineage:
-      family: Emde
-      given: A.-K.
-      honourific:
-    id:
-  - name:
-      family: Weese
-      honourific:
-      given: D.
-      lineage:
-    id:
-  - name:
-      honourific:
-      given: K.
-      family: Reinert
-      lineage:
-    id:
-  publication: BMC Bioinformatics
-  datestamp: '2011-06-09 13:52:15'
-  item_issues_count: 0
-  date_type: published
-  full_text_status: none
-  metadata_visibility: show
-  id_number: 10.1186/1471-2105-12-210
-  number: 120
-  refereed: 'TRUE'
-  eprintid: 1072
-  date: '2011-05-26'
-  volume: 12
-  subjects:
-  - C700
-  - G400
-  divisions:
-  - group_algbioinf
-  eprint_status: archive
-  issn: 1471-2105
-  dir: disk0/00/00/10/72
-- lastmod: '2016-02-25 11:13:53'
-  ispublished: pub
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1506
-  official_url: http://dx.doi.org/10.1093/bioinformatics/btv051
-  title: Methods for the Detection and Assembly of Novel Sequence in High-Throughput
-    Sequencing Data
-  status_changed: '2016-02-25 11:13:53'
-  abstract: "Motivation: Large insertions of novel sequence are an important type
-    of structural variants. Previous studies used traditional de novo assemblers for
-    assembling non-mapping high-throughput sequencing (HTS) or capillary reads and
-    then tried to anchor them in the reference using paired read information.Results:
-    We present approaches for detecting insertion breakpoints and targeted assembly
-    of large insertions from HTS paired data: BASIL and ANISE. On near identity repeats
-    that are hard for assemblers, ANISE employs a repeat resolution step. This results
-    in far better reconstructions than obtained by the compared methods. On simulated
-    data, we found our insert assembler to be competitive with the de novo assemblers
-    ABYSS and SGA while yielding already anchored inserted sequence as opposed to
-    unanchored contigs as from ABYSS/SGA. On real-world data, we detected novel sequence
-    in a human individual and thoroughly validated the assembled sequence. ANISE was
-    found to be superior to the competing tool MindTheGap on both simulated and real-world
-    data.Availability and implementation: ANISE and BASIL are available for
-    download at http://www.seqan.de/projects/herbarium under a permissive open source
-    license. Contact: manuel.holtgrewe@fu-berlin.de or knut.reinert@fu-berlin.de"
-  userid: 132
-  type: article
-  rev_number: 14
-  creators:
-  - name:
-      lineage:
-      family: Holtgrewe
-      given: M.
-      honourific:
-  - name:
-      given: L.
-      honourific:
-      family: Kuchenbecker
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: K.
-      family: Reinert
-  datestamp: '2015-02-16 13:41:21'
-  publication: Bioinformatics
-  item_issues_count: 0
-  metadata_visibility: show
-  id_number: doi:10.1093/bioinformatics/btv051
-  date_type: published
-  full_text_status: none
-  refereed: 'TRUE'
-  eprintid: 1506
-  number: 12
-  date: 2015
-  pagerange: 1904-1912
-  subjects:
-  - G400
-  divisions:
-  - group_algbioinf
-  volume: 31
-  eprint_status: archive
-  dir: disk0/00/00/15/06
-  issn: 1367-4803
-- uri: http://publications.imp.fu-berlin.de/id/eprint/930
-  lastmod: '2010-09-01 13:33:27'
-  ispublished: pub
-  official_url: http://ieeexplore.ieee.org/xpl/freeabs_all.jsp?arnumber=5470485
-  userid: 167
-  type: article
-  rev_number: 7
-  title: Engineering a scalable high quality graph partitioner
-  abstract: We describe an approach to parallel graph partitioning that scales to
-    hundreds of processors and produces a high solution quality. For example, for
-    many instances from Walshaw's benchmark collection we improve the best known partitioning.
-    We use the well known framework of multi-level graph partitioning. All components
-    are implemented by scalable parallel algorithms. Quality improvements compared
-    to previous systems are due to better prioritization of edges to be contracted,
-    better approximation algorithms for identifying matchings, better local search
-    heuristics, and perhaps most notably, a parallelization of the FM local search
-    algorithm that works more locally than previous approaches.
-  status_changed: '2010-08-23 12:49:46'
-  publication: 2010 IEEE International Symposium on Parallel & Distributed Processing
-    (IPDPS)
-  datestamp: '2010-08-23 12:49:46'
-  creators:
-  - name:
-      family: Holtgrewe
-      honourific:
-      given: M.
-      lineage:
-    id: holtgrewe@ira.uka.de
-  - id: sanders@kit.edu
-    name:
-      honourific:
-      given: P.
-      family: Sanders
-      lineage:
-  - id: c_schulz@ira.uka.de
-    name:
-      family: Schulz
-      given: C.
-      honourific:
-      lineage:
-  id_number: '10.1109/IPDPS.2010.5470485 '
-  metadata_visibility: show
-  date_type: published
-  full_text_status: none
-  item_issues_count: 0
-  refereed: 'TRUE'
-  eprintid: 930
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  date: 2010-04
-  pagerange: 1-12
-  dir: disk0/00/00/09/30
-  issn: '1530-2075 '
-  eprint_status: archive
-- uri: http://publications.imp.fu-berlin.de/id/eprint/962
-  lastmod: '2017-03-03 14:40:55'
-  ispublished: pub
-  datestamp: '2011-10-08 13:21:08'
-  publication: Technical Report FU Berlin
-  documents:
-  - relation:
-    - uri: "/id/document/1165"
-      type: http://eprints.org/relation/hasVersion
-    - type: http://eprints.org/relation/haspreviewThumbnailVersion
-      uri: "/id/document/1165"
-    - type: http://eprints.org/relation/hasVolatileVersion
-      uri: "/id/document/1165"
-    language: en
-    files:
-    - uri: http://publications.imp.fu-berlin.de/id/file/11200
-      mime_type: application/pdf
-      filesize: 338345
-      fileid: 11200
-      objectid: 509
-      filename: mason201009.pdf
-      datasetid: document
-      mtime: '2017-03-03 14:40:55'
-    rev_number: 4
-    pos: 2
-    eprintid: 962
-    security: public
-    format: application/pdf
-    main: mason201009.pdf
-    uri: http://publications.imp.fu-berlin.de/id/document/509
-    docid: 509
-    mime_type: application/pdf
-    content: submitted
-  creators:
-  - id: manuel.holtgrewe@fu-berlin.de
-    name:
-      lineage:
-      family: Holtgrewe
-      honourific:
-      given: M.
-  type: article
-  rev_number: 19
-  userid: 167
-  status_changed: '2011-10-08 14:32:15'
-  abstract: We present a read simulator software for Illumina, 454 and Sanger reads.
-    Its features include position specific error rates and base quality values. For
-    Illumina reads, we give a comprehensive analysis with empirical data for the error
-    and quality model. For the other technologies, we use models from the literature.
-    It has been written with performance in mind and can sample reads from large genomes.
-    The C++ source code is extensible, and freely available under the GPL/LGPL.
-  title: Mason – A Read Simulator for Second Generation Sequencing Data
-  refereed: 'FALSE'
-  eprintid: 962
-  full_text_status: public
-  metadata_visibility: show
-  item_issues_count: 0
-  dir: disk0/00/00/09/62
-  eprint_status: archive
-  subjects:
-  - G400
-  divisions:
-  - group_algbioinf
-  date: 2010-10
-- creators:
-  - id: jialu.hu@fu-berlin.de
-    name:
-      given: J.
-      honourific:
-      family: Hu
-      lineage:
-  - name:
-      honourific:
-      given: B.
-      family: Kehr
-      lineage:
-    id:
-  - name:
-      lineage:
-      honourific:
-      given: K.
-      family: Reinert
-    id: knut.reinert@fu-berlin.de
-  publication: Bioinformatics
-  datestamp: '2014-03-18 15:26:45'
-  title: 'NetCoffee: a fast and accurate global alignment approach to identify functionally
-    conserved proteins in multiple networks'
-  abstract: "Motivation: Owing to recent advancements in high-throughput technologies,
-    protein–protein interaction networks of more and more species become available
-    in public databases. The question of how to identify functionally conserved proteins
-    across species attracts a lot of attention in computational biology. Network alignments
-    provide a systematic way to solve this problem. However, most existing alignment
-    tools encounter limitations in tackling this problem. Therefore, the demand for
-    faster and more efficient alignment tools is growing.Results: We present
-    a fast and accurate algorithm, NetCoffee, which allows to find a global alignment
-    of multiple protein–protein interaction networks. NetCoffee searches for a global
-    alignment by maximizing a target function using simulated annealing on a set of
-    weighted bipartite graphs that are constructed using a triplet approach similar
-    to T-Coffee. To assess its performance, NetCoffee was applied to four real datasets.
-    Our results suggest that NetCoffee remedies several limitations of previous algorithms,
-    outperforms all existing alignment tools in terms of speed and nevertheless identifies
-    biologically meaningful alignments.Availability: The source code and data
-    are freely available for download under the GNU GPL v3 license at https://code.google.com/p/netcoffee/. "
-  status_changed: '2014-08-19 14:46:18'
-  userid: 132
-  publisher: Oxford University Press
-  type: article
-  rev_number: 9
-  official_url: http://bioinformatics.oxfordjournals.org/cgi/doi/10.1093/bioinformatics/btt715
-  ispublished: pub
-  lastmod: '2014-08-19 14:46:18'
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1399
-  eprint_status: archive
-  dir: disk0/00/00/13/99
-  issn: 1367-4803
-  pagerange: 540-548
-  date: '2014-02-15'
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  volume: 30
-  eprintid: 1399
-  refereed: 'TRUE'
-  number: 4
-  item_issues_count: 0
-  metadata_visibility: show
-  id_number: 'doi: 10.1093/bioinformatics/btt715'
-  date_type: published
-  full_text_status: none
-- official_url: http://bioinformatics.oxfordjournals.org/cgi/doi/10.1093/bioinformatics/btu652
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1457
-  ispublished: pub
-  lastmod: '2016-11-15 14:02:23'
-  datestamp: '2014-10-12 19:16:09'
-  publication: Bioinformatics
-  creators:
-  - name:
-      lineage:
-      family: Hu
-      honourific:
-      given: J.
-  - name:
-      lineage:
-      family: Reinert
-      given: K.
-      honourific:
-  userid: 29
-  publisher: Oxford University Press
-  rev_number: 16
-  type: article
-  title: 'LocalAli: An Evolutionary-based Local Alignment Approach to Identify Functionally
-    Conserved Modules in Multiple Networks.'
-  abstract: "MOTIVATION:Sequences and protein interaction data are of significance
-    to understand the underlying molecular mechanism of organisms. Local network alignment
-    is one of key systematic ways for predicting protein functions, identifying functional
-    modules, and understanding the phylogeny from these data. Most of currently existing
-    tools, however, encounter their limitations which are mainly concerned with scoring
-    scheme, speed and scalability. Therefore, there are growing demands for sophisticated
-    network evolution models and efficient local alignment algorithms.RESULTS:We
-    developed a fast and scalable local network alignment tool so-called LocalAli
-    for the identification of functionally conserved modules in multiple networks.
-    In this algorithm, we firstly proposed a new framework to reconstruct the evolution
-    history of conserved modules based on a maximum-parsimony evolutionary model.
-    By relying on this model, LocalAli facilitates interpretation of resulting local
-    alignments in terms of conserved modules which have been evolved from a common
-    ancestral module through a series of evolutionary events. A meta-heuristic method
-    simulated annealing was used to search for the optimal or near-optimal inner nodes
-    (i.e. ancestral modules) of the evolutionary tree. To evaluate the performance
-    and the statistical significance, LocalAli were tested on a total of 26 real datasets
-    and 1040 randomly generated datasets. The results suggest that LocalAli outperforms
-    all existing algorithms in terms of coverage, consistency and scalability, meanwhile
-    retains a high precision in the identification of functionally coherent subnetworks.AVAILABILITY:The
-    source code and test datasets are freely available for download under the GNU
-    GPL v3 license at https://code.google.com/p/localali/.CONTACT:jialu.hu@fu-berlin.de
-    or knut.reinert@fu-berlin.de."
-  status_changed: '2016-11-15 14:02:22'
-  refereed: 'TRUE'
-  eprintid: 1457
-  number: 1
-  metadata_visibility: show
-  id_number: 'doi: 10.1093/bioinformatics/btu652'
-  date_type: published
-  full_text_status: none
-  item_issues_count: 0
-  dir: disk0/00/00/14/57
-  issn: 1367-4803
-  eprint_status: archive
-  divisions:
-  - group_algbioinf
-  subjects:
-  - C100
-  - G400
-  volume: 30
-  pagerange: 363-372
-  date: 2015
-- dir: disk0/00/00/03/65
-  eprint_status: archive
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  date: 2001
-  pagerange: 294-306
-  refereed: 'TRUE'
-  eprintid: 365
-  metadata_visibility: show
-  full_text_status: none
-  item_issues_count: 0
-  datestamp: '2017-03-03 14:40:14'
-  creators:
-  - name:
-      lineage:
-      honourific:
-      given: D. H.
-      family: Huson
-  - name:
-      honourific:
-      given: A. L.
-      family: Halpern
-      lineage:
-  - name:
-      honourific:
-      given: Z.
-      family: Lai
-      lineage:
-  - name:
-      lineage:
-      given: E. W.
-      honourific:
-      family: Myers
-  - name:
-      given: K.
-      honourific:
-      family: Reinert
-      lineage:
-  - name:
-      family: Sutton
-      honourific:
-      given: G. G.
-      lineage:
-  userid: 1
-  type: conference_item
-  rev_number: 3
-  title: Comparing Assemblies using Fragments and Mate-pairs
-  status_changed: '2009-03-11 11:27:06'
-  uri: http://publications.imp.fu-berlin.de/id/eprint/365
-  event_title: Proceedings of the 1st Workshop on Algorithms Bioinformatics (WABI-01)
-  lastmod: '2017-03-03 14:40:14'
-  ispublished: pub
-- datestamp: '2017-03-03 14:40:14'
-  creators:
-  - name:
-      lineage:
-      family: Huson
-      given: D. H.
-      honourific:
-  - name:
-      lineage:
-      given: K.
-      honourific:
-      family: Reinert
-  - name:
-      lineage:
-      family: Kravitz
-      given: S. A.
-      honourific:
-  - name:
-      lineage:
-      family: Remington
-      honourific:
-      given: "K.A."
-  - name:
-      lineage:
-      family: Delcher
-      given: A. L.
-      honourific:
-  - name:
-      given: I. M.
-      honourific:
-      family: Dew
-      lineage:
-  - name:
-      family: Flanigan
-      honourific:
-      given: M. J.
-      lineage:
-  - name:
-      honourific:
-      given: A. L.
-      family: Halpern
-      lineage:
-  - name:
-      lineage:
-      given: Z.
-      honourific:
-      family: Lai
-  - name:
-      honourific:
-      given: C. M.
-      family: Mobarry
-      lineage:
-  - name:
-      lineage:
-      given: G. G.
-      honourific:
-      family: Sutton
-  - name:
-      lineage:
-      family: Myers
-      given: E. W.
-      honourific:
-  userid: 1
-  type: conference_item
-  rev_number: 3
-  title: Design of a compartmentalized Shotgun Assembler for the Human Genome
-  status_changed: '2009-03-11 11:27:07'
-  uri: http://publications.imp.fu-berlin.de/id/eprint/366
-  event_title: "Proceedings of the Ninth International Conference on IntelligentSystems
-    for Molecular Biology (ISMB-01)"
-  ispublished: pub
-  lastmod: '2017-03-03 14:40:14'
-  dir: disk0/00/00/03/66
-  eprint_status: archive
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  date: 2001
-  pagerange: 132-139
-  eprintid: 366
-  refereed: 'TRUE'
-  metadata_visibility: show
-  full_text_status: none
-  item_issues_count: 0
-- divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  volume: 49
-  date: 2002
-  pagerange: 603-615
-  dir: disk0/00/00/03/67
-  eprint_status: archive
-  metadata_visibility: show
-  full_text_status: none
-  item_issues_count: 0
-  refereed: 'TRUE'
-  eprintid: 367
-  number: 5
-  userid: 1
-  type: article
-  rev_number: 3
-  title: The Greedy Path-Merging Algorithm for Sequence Assembly
-  status_changed: '2009-03-11 11:27:08'
-  datestamp: '2017-03-03 14:40:14'
-  publication: Journal of the ACM
-  creators:
-  - name:
-      lineage:
-      given: D. H.
-      honourific:
-      family: Huson
-  - name:
-      given: K.
-      honourific:
-      family: Reinert
-      lineage:
-  - name:
-      family: Myers
-      given: E. W.
-      honourific:
-      lineage:
-  uri: http://publications.imp.fu-berlin.de/id/eprint/367
-  ispublished: pub
-  lastmod: '2017-03-03 14:40:14'
-- type: conference_item
-  rev_number: 3
-  userid: 1
-  status_changed: '2009-03-11 11:27:08'
-  title: The Greedy Path-Merging Algorithm for Sequence Assembly
-  datestamp: '2017-03-03 14:40:14'
-  creators:
-  - name:
-      family: Huson
-      given: D. H.
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      family: Reinert
-      honourific:
-      given: K.
-  - name:
-      given: E. W.
-      honourific:
-      family: Myers
-      lineage:
-  uri: http://publications.imp.fu-berlin.de/id/eprint/368
-  event_title: "Proceedings of the Fifth Annual International Conference on ComputationalMolecular
-    Biology (RECOMB-01)"
-  ispublished: pub
-  lastmod: '2017-03-03 14:40:14'
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  date: 2001
-  pagerange: 157-163
-  dir: disk0/00/00/03/68
-  eprint_status: archive
-  full_text_status: none
-  metadata_visibility: show
-  item_issues_count: 0
-  refereed: 'TRUE'
-  eprintid: 368
-- uri: http://publications.imp.fu-berlin.de/id/eprint/935
-  ispublished: pub
-  lastmod: '2010-11-18 13:44:27'
-  official_url: http://dx.doi.org/10.1371/journal.ppat.1000985
-  type: article
-  rev_number: 11
-  userid: 132
-  abstract: Adeno-associated virus type 2 (AAV) is known to establish latency by preferential
-    integration in human chromosome 19q13.42. The AAV non-structural protein Rep appears
-    to target a site called AAVS1 by simultaneously binding to Rep-binding sites (RBS)
-    present on the AAV genome and within AAVS1. In the absence of Rep, as is the case
-    with AAV vectors, chromosomal integration is rare and random. For a genome-wide
-    survey of wildtype AAV integration a linker-selection-mediated (LSM)-PCR strategy
-    was designed to retrieve AAV-chromosomal junctions. DNA sequence determination
-    revealed wildtype AAV integration sites scattered over the entire human genome.
-    The bioinformatic analysis of these integration sites compared to those of rep-deficient
-    AAV vectors revealed a highly significant overrepresentation of integration events
-    near to consensus RBS. Integration hotspots included AAVS1 with 10% of total events.
-    Novel hotspots near consensus RBS were identified on chromosome 5p13.3 denoted
-    AAVS2 and on chromsome 3p24.3 denoted AAVS3. AAVS2 displayed seven independent
-    junctions clustered within only 14 bp of a consensus RBS which proved to bind
-    Rep in vitro similar to the RBS in AAVS3. Expression of Rep in the presence of
-    rep-deficient AAV vectors shifted targeting preferences from random integration
-    back to the neighbourhood of consensus RBS at hotspots and numerous additional
-    sites in the human genome. In summary, targeted AAV integration is not as specific
-    for AAVS1 as previously assumed. Rather, Rep targets AAV to integrate into open
-    chromatin regions in the reach of various, consensus RBS homologues in the human
-    genome.
-  status_changed: '2010-11-18 13:44:27'
-  title: Integration Preferences of Wildtype AAV-2 for Consensus Rep-Binding Sites
-    at Numerous Loci in the Human Genome
-  datestamp: '2010-08-26 11:10:39'
-  publication: PLoS Pathogens
-  creators:
-  - name:
-      lineage:
-      family: Hüser
-      given: D.
-      honourific:
-    id:
-  - name:
-      given: A.
-      honourific:
-      family: Gogol-Döring
-      lineage:
-    id:
-  - name:
-      family: Lutter
-      given: T.
-      honourific:
-      lineage:
-    id:
-  - name:
-      lineage:
-      family: Weger
-      given: S.
-      honourific:
-    id:
-  - id:
-    name:
-      given: K.
-      honourific:
-      family: Winter
-      lineage:
-  - id:
-    name:
-      lineage:
-      family: Hammer
-      given: E.-M.
-      honourific:
-  - name:
-      given: T.
-      honourific:
-      family: Cathomen
-      lineage:
-    id:
-  - name:
-      given: K.
-      honourific:
-      family: Reinert
-      lineage:
-    id: knut.reinert@fu-berlin.de
-  - name:
-      given: R.
-      honourific:
-      family: Heilbronn
-      lineage:
-    id:
-  date_type: published
-  full_text_status: none
-  id_number: doi:10.1371/journal.ppat.1000985
-  metadata_visibility: show
-  item_issues_count: 0
-  number: 7
-  refereed: 'TRUE'
-  eprintid: 935
-  volume: 6
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  pagerange: e1000985
-  date: '2010-07-08'
-  issn: 1553-7374
-  dir: disk0/00/00/09/35
-  eprint_status: archive
-- userid: 1
-  rev_number: 3
-  type: article
-  title: Whole-genome shotgun assembly and comparison of human genome assemblies
-  status_changed: '2009-03-11 11:27:09'
-  datestamp: '2017-03-03 14:40:14'
-  publication: Proceedings of the national academy of science (PNAS)
-  creators:
-  - name:
-      family: Istrail
-      given: S.
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      given: G. G.
-      honourific:
-      family: Sutton
-  - name:
-      honourific:
-      given: L.
-      family: Florea
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: C. M.
-      family: Mobarry
-  - name:
-      lineage:
-      honourific:
-      given: R.
-      family: Lippert
-  - name:
-      family: Walenz
-      given: B.
-      honourific:
-      lineage:
-  - name:
-      family: Shatkay
-      honourific:
-      given: H.
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: Ian
-      family: Dew
-  - name:
-      family: Miller
-      given: J. R.
-      honourific:
-      lineage:
-  - name:
-      family: Flanigan
-      honourific:
-      given: M. J.
-      lineage:
-  - name:
-      lineage:
-      family: Edwards
-      honourific:
-      given: N. J.
-  - name:
-      lineage:
-      honourific:
-      given: R.
-      family: Bolanos
-  - name:
-      lineage:
-      family: Fasulo
-      honourific:
-      given: D.
-  - name:
-      honourific:
-      given: B. V.
-      family: Halldorsson
-      lineage:
-  - name:
-      family: Hannenhalli
-      honourific:
-      given: S.
-      lineage:
-  - name:
-      family: Turner
-      honourific:
-      given: R. J.
-      lineage:
-  - name:
-      lineage:
-      given: S.
-      honourific:
-      family: Yooseph
-  - name:
-      lineage:
-      honourific:
-      given: Fu
-      family: Lu
-  - name:
-      given: D. R.
-      honourific:
-      family: Nusskern
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: B. C.
-      family: Shue
-  - name:
-      lineage:
-      honourific:
-      given: X. H.
-      family: Zheng
-  - name:
-      given: F.
-      honourific:
-      family: Zhong
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: A. L.
-      family: Delcher
-  - name:
-      lineage:
-      honourific:
-      given: D. H.
-      family: Huson
-  - name:
-      lineage:
-      family: Kravitz
-      honourific:
-      given: S. A.
-  - name:
-      lineage:
-      honourific:
-      given: L.
-      family: Mouchard
-  - name:
-      lineage:
-      family: Reinert
-      given: K.
-      honourific:
-  - name:
-      honourific:
-      given: K. A.
-      family: Remington
-      lineage:
-  - name:
-      lineage:
-      family: Clark
-      given: A. G.
-      honourific:
-  - name:
-      lineage:
-      honourific:
-      given: M. S.
-      family: Waterman
-  - name:
-      family: Eichler
-      given: E. E.
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      family: Adams
-      honourific:
-      given: M. D.
-  - name:
-      lineage:
-      family: Hunkapillar
-      given: M. W.
-      honourific:
-  - name:
-      given: E. W.
-      honourific:
-      family: Myers
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: J. C.
-      family: Venter
-  uri: http://publications.imp.fu-berlin.de/id/eprint/369
-  ispublished: pub
-  lastmod: '2017-03-03 14:40:14'
-  subjects:
-  - G400
-  divisions:
-  - group_algbioinf
-  volume: 101
-  date: 2004
-  pagerange: 1916-1921
-  dir: disk0/00/00/03/69
-  eprint_status: archive
-  metadata_visibility: show
-  full_text_status: none
-  item_issues_count: 0
-  refereed: 'TRUE'
-  eprintid: 369
-  number: 7
-- number: 7
-  refereed: 'TRUE'
-  eprintid: 1396
-  date_type: published
-  full_text_status: none
-  id_number: 'doi: 10.1021/pr300187f'
-  metadata_visibility: show
-  item_issues_count: 0
-  issn: 1535-3893
-  dir: disk0/00/00/13/96
-  eprint_status: archive
-  volume: 11
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  pagerange: 3914-3920
-  date: '2012-07-06'
-  official_url: http://pubs.acs.org/doi/abs/10.1021/pr300187f
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1396
-  lastmod: '2014-03-18 14:13:29'
-  ispublished: pub
-  datestamp: '2014-03-18 14:13:29'
-  publication: J. Proteome Res.
-  creators:
-  - name:
-      honourific:
-      given: J.
-      family: Junker
-      lineage:
-    id:
   - name:
       family: Bielow
       given: C.
-      honourific:
-      lineage:
-    id:
-  - id:
-    name:
-      lineage:
-      family: Bertsch
-      given: A.
-      honourific:
+      honourific: null
+      lineage: null
   - name:
-      honourific:
-      given: M.
-      family: Sturm
-      lineage:
-    id:
+      family: Aiche
+      given: S.
+      honourific: null
+      lineage: null
+  - name:
+      family: Andreotti
+      given: S.
+      honourific: null
+      lineage: null
   - name:
       family: Reinert
-      honourific:
       given: K.
-      lineage:
-    id: knut.reinert@fu-berlin.de
-  - id:
-    name:
-      lineage:
+      honourific: null
+      lineage: null
+  date: 2011-07
+  date_type: published
+  datestamp: '2011-04-29 10:33:41'
+  dir: disk0/00/00/10/66
+  divisions:
+  - group_comp-proteomics
+  - group_algbioinf
+  - group_biocomputing
+  documents:
+  - content: published
+    docid: 470
+    eprintid: 1066
+    files:
+    - datasetid: document
+      fileid: 12627
+      filename: pr200155f.pdf
+      filesize: 926401
+      mime_type: application/pdf
+      mtime: '2017-03-03 14:41:04'
+      objectid: 470
+      uri: http://publications.imp.fu-berlin.de/id/file/12627
+    format: application/pdf
+    language: en
+    main: pr200155f.pdf
+    mime_type: application/pdf
+    pos: 1
+    relation:
+    - type: http://eprints.org/relation/hasVersion
+      uri: /id/document/1186
+    - type: http://eprints.org/relation/haspreviewThumbnailVersion
+      uri: /id/document/1186
+    - type: http://eprints.org/relation/hasVolatileVersion
+      uri: /id/document/1186
+    rev_number: 4
+    security: public
+    uri: http://publications.imp.fu-berlin.de/id/document/470
+  eprint_status: archive
+  eprintid: 1066
+  full_text_status: public
+  id_number: 10.1021/pr200155f
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications1066
+  lastmod: '2017-03-03 14:41:04'
+  metadata_visibility: show
+  number: 7
+  official_url: http://dx.doi.org/10.1021/pr200155f
+  pagerange: 2922-2929
+  publication: Journal of Proteome Research
+  refereed: 'TRUE'
+  rev_number: 16
+  status_changed: '2011-11-28 09:09:08'
+  subjects:
+  - G
+  title: 'MSSimulator: Simulation of Mass Spectrometry Data'
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1066
+  userid: 30
+  volume: 10
+- abstract: Mass spectrometry is today a key analytical technique to elucidate the
+    amount and content of proteins expressed in a certain cellular context. The degree
+    of automation in proteomics has yet to reach that of genomic techniques, but even
+    current technologies make a manual inspection of the data infeasible. This article
+    addresses the key algorithmic problems bioinformaticians face when handling modern
+    proteomic samples and shows common solutions to them. We provide examples on how
+    algorithms can be combined to build relatively complex analysis pipelines, point
+    out certain pitfalls and aspects worth considering and give a list of current
+    state-of-the-art tools.
+  bibtex: "@incollection{fu_mi_publications1067,\n abstract = {Mass spectrometry is\
+    \ today a key analytical technique to elucidate the amount and content of proteins\
+    \ expressed in a certain cellular context. The degree of automation in proteomics\
+    \ has yet to reach that of genomic techniques, but even current technologies make\
+    \ a manual inspection of the data infeasible. This article addresses the key algorithmic\
+    \ problems bioinformaticians face when handling modern proteomic samples and shows\
+    \ common solutions to them. We provide examples on how algorithms can be combined\
+    \ to build relatively complex analysis pipelines, point out certain pitfalls and\
+    \ aspects worth considering and give a list of current state-of-the-art tools.},\n\
+    \ author = {C. Bielow and C. Gr{\\\"o}pl and O. Kohlbacher and K. Reinert},\n\
+    \ booktitle = {Bioinformatics for Omics Data Methods and Protocols},\n journal\
+    \ = {Methods in molecular biology (Clifton, N.J.)},\n month = {January},\n pages\
+    \ = {331--49},\n publisher = {Humana Press},\n title = {Bioinformatics for qualitative\
+    \ and quantitative proteomics.},\n url = {http://publications.imp.fu-berlin.de/1067/},\n\
+    \ volume = {719},\n year = {2011}\n}\n\n"
+  book_title: Bioinformatics for Omics Data Methods and Protocols
+  creators:
+  - name:
+      family: Bielow
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
       family: Kohlbacher
       given: O.
-      honourific:
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: 2011-01
+  datestamp: '2011-04-29 12:38:12'
+  dir: disk0/00/00/10/67
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 1067
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications1067
+  lastmod: '2011-04-29 12:38:12'
+  metadata_visibility: show
+  official_url: http://www.ncbi.nlm.nih.gov/pubmed/21370091
+  pagerange: 331-49
+  publication: Methods in molecular biology (Clifton, N.J.)
+  publisher: Humana Press
+  refereed: 'FALSE'
+  rev_number: 11
+  status_changed: '2011-04-29 12:38:12'
+  subjects:
+  - C
+  - G
+  title: Bioinformatics for qualitative and quantitative proteomics.
+  type: book_section
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1067
+  userid: 30
+  volume: 719
+- abstract: "Background\r\nSecond generation sequencing technologies yield DNA sequence\
+    \ data at ultra high-throughput. Common to most biological applications is a mapping\
+    \ of the reads to an almost identical or highly similar reference genome. The\
+    \ assessment of the quality of read mapping results is not straightforward and\
+    \ has not been formalized so far. Hence, it has not been easy to compare different\
+    \ read mapping approaches in a unified way and to determine which program is the\
+    \ best for what task.\r\n\r\nResults\r\nWe present a new benchmark method, called\
+    \ Rabema (Read Alignment BEnchMArk), for read mappers. It consists of a strict\
+    \ definition of the read mapping problem and of tools to evaluate the result of\
+    \ arbitrary read mappers supporting the SAM output format.\r\n\r\nConclusions\r\
+    \nWe show the usefulness of the benchmark program by performing a comparison of\
+    \ popular read mappers. The tools supporting the benchmark are licensed under\
+    \ the GPL and available from http://www.seqan.de/projects/rabema.html."
+  bibtex: "@article{fu_mi_publications1072,\n abstract = {Background\nSecond generation\
+    \ sequencing technologies yield DNA sequence data at ultra high-throughput. Common\
+    \ to most biological applications is a mapping of the reads to an almost identical\
+    \ or highly similar reference genome. The assessment of the quality of read mapping\
+    \ results is not straightforward and has not been formalized so far. Hence, it\
+    \ has not been easy to compare different read mapping approaches in a unified\
+    \ way and to determine which program is the best for what task.\n\nResults\nWe\
+    \ present a new benchmark method, called Rabema (Read Alignment BEnchMArk), for\
+    \ read mappers. It consists of a strict definition of the read mapping problem\
+    \ and of tools to evaluate the result of arbitrary read mappers supporting the\
+    \ SAM output format.\n\nConclusions\nWe show the usefulness of the benchmark program\
+    \ by performing a comparison of popular read mappers. The tools supporting the\
+    \ benchmark are licensed under the GPL and available from http://www.seqan.de/projects/rabema.html.},\n\
+    \ author = {M. Holtgrewe and A.-K. Emde and D. Weese and K. Reinert},\n journal\
+    \ = {BMC Bioinformatics},\n month = {May},\n number = {120},\n publisher = {BioMed\
+    \ Central},\n title = {A Novel And Well-Defined Benchmarking Method For Second\
+    \ Generation Read Mapping},\n url = {http://publications.imp.fu-berlin.de/1072/},\n\
+    \ volume = {12},\n year = {2011}\n}\n\n"
+  creators:
+  - id: holtgrewe@mi.fu-berlin.de
+    name:
+      family: Holtgrewe
+      given: M.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Emde
+      given: A.-K.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Weese
+      given: D.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: '2011-05-26'
+  date_type: published
+  datestamp: '2011-06-09 13:52:15'
+  dir: disk0/00/00/10/72
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 1072
+  full_text_status: none
+  id_number: 10.1186/1471-2105-12-210
+  ispublished: pub
+  issn: 1471-2105
+  item_issues_count: 0
+  key: fu_mi_publications1072
+  lastmod: '2011-06-27 13:44:14'
+  metadata_visibility: show
+  number: 120
+  official_url: http://dx.doi.org/10.1186/1471-2105-12-210
+  publication: BMC Bioinformatics
+  publisher: BioMed Central
+  refereed: 'TRUE'
+  rev_number: 12
+  status_changed: '2011-06-27 13:44:14'
+  subjects:
+  - C700
+  - G400
+  title: A Novel And Well-Defined Benchmarking Method For Second Generation Read Mapping
   type: article
-  publisher: ACS Publications
-  rev_number: 10
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1072
+  userid: 167
+  volume: 12
+- abstract: "Background\r\nLarge-scale comparison of genomic sequences requires reliable\
+    \ tools for the search of local alignments. Practical local aligners are in general\
+    \ fast, but heuristic, and hence sometimes miss significant matches.\r\n\r\nResults\r\
+    \nWe present here the local pairwise aligner STELLAR that has full sensitivity\
+    \ for \u03B5-alignments, i.e. guarantees to report all local alignments of a given\
+    \ minimal length and maximal error rate. The aligner is composed of two steps,\
+    \ filtering and verification. We apply the SWIFT algorithm for lossless filtering,\
+    \ and have developed a new verification strategy that we prove to be exact. Our\
+    \ results on simulated and real genomic data confirm and quantify the conjecture\
+    \ that heuristic tools like BLAST or BLAT miss a large percentage of significant\
+    \ local alignments.\r\n\r\nConclusions\r\nSTELLAR is very practical and fast on\
+    \ very long sequences which makes it a suitable new tool for finding local alignments\
+    \ between genomic sequences under the edit distance model. Binaries are freely\
+    \ available for Linux, Windows, and Mac OS X at http://www.seqan.de/projects/stellar.\
+    \ The source code is freely distributed with the SeqAn C++ library version 1.3\
+    \ and later at http://www.seqan.de."
+  bibtex: "@article{fu_mi_publications1092,\n abstract = {Background\nLarge-scale\
+    \ comparison of genomic sequences requires reliable tools for the search of local\
+    \ alignments. Practical local aligners are in general fast, but heuristic, and\
+    \ hence sometimes miss significant matches.\n\nResults\nWe present here the local\
+    \ pairwise aligner STELLAR that has full sensitivity for {\\ensuremath{\\epsilon}}-alignments,\
+    \ i.e. guarantees to report all local alignments of a given minimal length and\
+    \ maximal error rate. The aligner is composed of two steps, filtering and verification.\
+    \ We apply the SWIFT algorithm for lossless filtering, and have developed a new\
+    \ verification strategy that we prove to be exact. Our results on simulated and\
+    \ real genomic data confirm and quantify the conjecture that heuristic tools like\
+    \ BLAST or BLAT miss a large percentage of significant local alignments.\n\nConclusions\n\
+    STELLAR is very practical and fast on very long sequences which makes it a suitable\
+    \ new tool for finding local alignments between genomic sequences under the edit\
+    \ distance model. Binaries are freely available for Linux, Windows, and Mac OS\
+    \ X at http://www.seqan.de/projects/stellar. The source code is freely distributed\
+    \ with the SeqAn C++ library version 1.3 and later at http://www.seqan.de.},\n\
+    \ author = {B. Kehr and D. Weese and K. Reinert},\n journal = {BMC Bioinformatics},\n\
+    \ month = {October},\n number = {S9},\n pages = {S15},\n publisher = {BioMed Central},\n\
+    \ title = {STELLAR: fast and exact local alignments},\n url = {http://publications.imp.fu-berlin.de/1092/},\n\
+    \ volume = {12},\n year = {2011}\n}\n\n"
+  creators:
+  - name:
+      family: Kehr
+      given: B.
+      honourific: null
+      lineage: null
+  - name:
+      family: Weese
+      given: D.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: '2011-10-03'
+  date_type: published
+  datestamp: '2011-10-08 13:20:36'
+  dir: disk0/00/00/10/92
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 1092
+  full_text_status: none
+  ispublished: pub
+  issn: 1471-2105
+  item_issues_count: 0
+  key: fu_mi_publications1092
+  lastmod: '2011-10-08 13:20:36'
+  metadata_visibility: show
+  number: S9
+  official_url: http://www.biomedcentral.com/1471-2105/12/S9/S15
+  pagerange: S15
+  publication: BMC Bioinformatics
+  publisher: BioMed Central
+  refereed: 'TRUE'
+  rev_number: 11
+  status_changed: '2011-10-08 13:20:36'
+  subjects:
+  - C400
+  - G400
+  title: 'STELLAR: fast and exact local alignments'
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1092
+  userid: 30
+  volume: 12
+- abstract: "Glycans are molecules made from simple sugars that form complex tree\
+    \ structures. Glycans constitute one of the most important protein modifications\
+    \ and identification of glycans remains a pressing problem in biology. Unfortunately,\
+    \ the structure of glycans is hard to predict from the genome sequence of an organism.\
+    \ In this paper, we consider the problem of deriving the topology of a glycan\
+    \ solely from tandem mass spectrometry (MS) data. We study, how to generate glycan\
+    \ tree candidates that sufficiently match the sample mass spectrum, avoiding the\
+    \ combinatorial explosion of glycan structures. Unfortunately, the resulting problem\
+    \ is known to be computationally hard. We present an efficient exact algorithm\
+    \ for this problem based on fixed-parameter algorithmics that can process a spectrum\
+    \ in a matter of seconds. We also report some preliminary results of our method\
+    \ on experimental data, combining it with a preliminary candidate evaluation scheme.\
+    \ We show that our approach is fast in applications, and that we can reach very\
+    \ well de novo identification results. Finally, we show how to count the number\
+    \ of glycan topologies for a fixed size or a fixed mass. We generalize this result\
+    \ to count the number of (labeled) trees with bounded out degree, improving on\
+    \ results obtained using P\xF3lya's enumeration theorem."
+  bibtex: "@article{fu_mi_publications1132,\n abstract = {Glycans are molecules made\
+    \ from simple sugars that form complex tree structures. Glycans constitute one\
+    \ of the most important protein modifications and identification of glycans remains\
+    \ a pressing problem in biology. Unfortunately, the structure of glycans is hard\
+    \ to predict from the genome sequence of an organism. In this paper, we consider\
+    \ the problem of deriving the topology of a glycan solely from tandem mass spectrometry\
+    \ (MS) data. We study, how to generate glycan tree candidates that sufficiently\
+    \ match the sample mass spectrum, avoiding the combinatorial explosion of glycan\
+    \ structures. Unfortunately, the resulting problem is known to be computationally\
+    \ hard. We present an efficient exact algorithm for this problem based on fixed-parameter\
+    \ algorithmics that can process a spectrum in a matter of seconds. We also report\
+    \ some preliminary results of our method on experimental data, combining it with\
+    \ a preliminary candidate evaluation scheme. We show that our approach is fast\
+    \ in applications, and that we can reach very well de novo identification results.\
+    \ Finally, we show how to count the number of glycan topologies for a fixed size\
+    \ or a fixed mass. We generalize this result to count the number of (labeled)\
+    \ trees with bounded out degree, improving on results obtained using P{\\'o}lya's\
+    \ enumeration theorem.},\n author = {S. B{\\\"o}cker and B. Kehr and F. Rasche},\n\
+    \ journal = {IEEE/ACM Transactions on Computational Biology and Bioinformatics\
+    \ },\n month = {July},\n number = {4},\n pages = {976--986},\n publisher = {IEEE\
+    \ computer society, TCBB},\n title = {Determination of Glycan Structure from Tandem\
+    \ Mass Spectra},\n url = {http://publications.imp.fu-berlin.de/1132/},\n volume\
+    \ = {8},\n year = {2011}\n}\n\n"
+  creators:
+  - id: null
+    name:
+      family: "B\xF6cker"
+      given: S.
+      honourific: null
+      lineage: null
+  - id: birte.kehr@fu-berlin.de
+    name:
+      family: Kehr
+      given: B.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Rasche
+      given: F.
+      honourific: null
+      lineage: null
+  date: 2011-07
+  date_type: published
+  datestamp: '2012-04-10 14:19:34'
+  dir: disk0/00/00/11/32
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 1132
+  full_text_status: none
+  ispublished: pub
+  issn: 1545-4963
+  item_issues_count: 0
+  key: fu_mi_publications1132
+  lastmod: '2012-05-16 14:17:03'
+  metadata_visibility: show
+  number: 4
+  official_url: http://www.computer.org/csdl/trans/tb/2011/04/ttb2011040976.html
+  pagerange: 976-986
+  publication: 'IEEE/ACM Transactions on Computational Biology and Bioinformatics '
+  publisher: IEEE computer society, TCBB
+  refereed: 'TRUE'
+  related_url:
+  - type: pub
+    url: http://www.computer.org/portal/web/tcbb
+  rev_number: 12
+  status_changed: '2012-05-16 14:17:03'
+  subjects:
+  - G400
+  title: Determination of Glycan Structure from Tandem Mass Spectra
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1132
   userid: 132
-  status_changed: '2014-03-18 14:13:29'
-  abstract: Mass spectrometry coupled to high-performance liquid chromatography (HPLC-MS)
+  volume: 8
+- abstract: "Motivation: Liquid chromatography coupled to mass spectrometry (LC-MS)\
+    \ and combined with tandem mass spectrometry (LC-MS/MS) have become a prominent\
+    \ tool for the analysis of complex proteomic samples. An important step in a typical\
+    \ workflow is the combination of results from multiple LC-MS experiments to improve\
+    \ confidence in the obtained measurements or to compare results from different\
+    \ samples. To do so, a suitable mapping or alignment between the data sets needs\
+    \ to be estimated. The alignment has to correct for variations in mass and elution\
+    \ time which are present in all mass spectrometry experiments. \r\n\r\nResults:\
+    \ We propose a novel algorithm to align LC-MS samples and to match corresponding\
+    \ ion species across samples. Our algorithm matches landmark signals between two\
+    \ data sets using a geometric technique based on pose clustering. Variations in\
+    \ mass and retention time are corrected by an affine dewarping function estimated\
+    \ from matched landmarks. We use the pairwise dewarping in an algorithm for aligning\
+    \ multiple samples. We show that our pose clustering approach is fast and reliable\
+    \ as compared to previous approaches. It is robust in the presence of noise and\
+    \ able to accurately align samples with only few common ion species. In addition,\
+    \ we can easily handle different kinds of LC-MS data and adopt our algorithm to\
+    \ new mass spectrometry technologies. \r\n\r\nAvailability: This algorithm is\
+    \ implemented as part of the OpenMS software library for shotgun proteomics and\
+    \ available under the Lesser GNU Public License (LGPL) at www.openms.de"
+  bibtex: "@article{fu_mi_publications1133,\n abstract = {Motivation: Liquid chromatography\
+    \ coupled to mass spectrometry (LC-MS) and combined with tandem mass spectrometry\
+    \ (LC-MS/MS) have become a prominent tool for the analysis of complex proteomic\
+    \ samples. An important step in a typical workflow is the combination of results\
+    \ from multiple LC-MS experiments to improve confidence in the obtained measurements\
+    \ or to compare results from different samples. To do so, a suitable mapping or\
+    \ alignment between the data sets needs to be estimated. The alignment has to\
+    \ correct for variations in mass and elution time which are present in all mass\
+    \ spectrometry experiments. \n\nResults: We propose a novel algorithm to align\
+    \ LC-MS samples and to match corresponding ion species across samples. Our algorithm\
+    \ matches landmark signals between two data sets using a geometric technique based\
+    \ on pose clustering. Variations in mass and retention time are corrected by an\
+    \ affine dewarping function estimated from matched landmarks. We use the pairwise\
+    \ dewarping in an algorithm for aligning multiple samples. We show that our pose\
+    \ clustering approach is fast and reliable as compared to previous approaches.\
+    \ It is robust in the presence of noise and able to accurately align samples with\
+    \ only few common ion species. In addition, we can easily handle different kinds\
+    \ of LC-MS data and adopt our algorithm to new mass spectrometry technologies.\
+    \ \n\nAvailability: This algorithm is implemented as part of the OpenMS software\
+    \ library for shotgun proteomics and available under the Lesser GNU Public License\
+    \ (LGPL) at www.openms.de},\n author = {E. Lange and C. Gr{\\\"o}pl and O. Schulz-Trieglaff\
+    \ and A. Leinenbach and Ch. Huber and K. Reinert},\n booktitle = {Proceedings\
+    \ of the 15th Annual International Conference on Intelligent      Systems for\
+    \ Molecular Biology (ISMB) \\&amp; 6th European Conference on  Computational Biology\
+    \ (ECCB)},\n journal = {Oxford Journals},\n number = {13},\n pages = {i273--i281},\n\
+    \ publisher = {Oxford University Press},\n title = {A Geometric Approach for the\
+    \ Alignment of Liquid Chromatography-Mass        Spectrometry Data},\n url = {http://publications.imp.fu-berlin.de/1133/},\n\
+    \ volume = {23},\n year = {2007}\n}\n\n"
+  creators:
+  - id: null
+    name:
+      family: Lange
+      given: E.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Schulz-Trieglaff
+      given: O.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Leinenbach
+      given: A.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Huber
+      given: Ch.
+      honourific: null
+      lineage: null
+  - id: knut.reinert@fu-berlin.de
+    name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: 2007
+  date_type: published
+  datestamp: '2012-04-10 14:34:51'
+  dir: disk0/00/00/11/33
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 1133
+  event_title: "Proceedings of the 15th Annual International Conference on Intelligent\t\
+    Systems for Molecular Biology (ISMB) &amp; 6th European Conference on \tComputational\
+    \ Biology (ECCB)"
+  full_text_status: none
+  id_number: 'doi: 10.1093/bioinformatics/btm209'
+  ispublished: pub
+  issn: 1460-2059 (online), 1367-4803 (print)
+  item_issues_count: 0
+  key: fu_mi_publications1133
+  lastmod: '2012-04-10 14:34:51'
+  metadata_visibility: show
+  number: 13
+  official_url: http://bioinformatics.oxfordjournals.org/content/23/13/i273.long
+  pagerange: i273-i281
+  publication: Oxford Journals
+  publisher: Oxford University Press
+  refereed: 'TRUE'
+  rev_number: 7
+  status_changed: '2012-04-10 14:34:51'
+  subjects:
+  - G400
+  succeeds: 378
+  title: "A Geometric Approach for the Alignment of Liquid Chromatography-Mass\tSpectrometry\
+    \ Data"
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1133
+  userid: 132
+  volume: 23
+- abstract: "Background: Proteases play an essential part in a variety of biological\
+    \ processes. Beside their importance\r\nunder healthy conditions they are also\
+    \ known to have a crucial role in complex diseases like cancer.\r\nIt was shown\
+    \ in the last years that not only the fragments produced by proteases but also\
+    \ their dynamics,\r\nespecially ex vivo, can serve as biomarkers. But so far,\
+    \ only a few approaches were taken to explicitly\r\nmodel the dynamics of proteolysis\
+    \ in the context of mass spectrometry.\r\n\r\nResults: We introduce a new concept\
+    \ model proteolytic processes, the degradation graph. The degra-\r\ndation graph\
+    \ is an extension of the cleavage graph, a data structure to reconstruct and visualize\
+    \ the\r\nproteolytic process. In contrast to previous approaches we extended the\
+    \ model to incorporate endoproteolytic\r\nprocesses and present a method to construct\
+    \ a degradation graph from mass spectrometry\r\ntime-series data. Based on a degradation\
+    \ graph and the intensities extracted from the mass spectra it is\r\npossible\
+    \ to estimate reaction rates of the underlying processes. We further suggest a\
+    \ score to rate different\r\ndegradation graphs in their ability to explain the\
+    \ observed data. This score is used in an iterative\r\nheuristic to improve the\
+    \ structure of the initially constructed degradation graph.\r\n\r\nConclusion:\
+    \ We show that the proposed method is able to recover all degraded and generated\r\
+    \npeptides, the underlying reactions, and the reaction rates of proteolytic processes\
+    \ based on mass spectrometry\r\ntime-series data. We use simulated and real data\
+    \ to demonstrate that a given process can be\r\nreconstructed even in the presence\
+    \ of extensive noise, isobaric signals and false identications. While the\r\n\
+    model is currently only validated on peptide data it is also applicable to proteins,\
+    \ as long as the necessary\r\ntime series data can be produced."
+  bibtex: "@article{fu_mi_publications1143,\n abstract = {Background: Proteases play\
+    \ an essential part in a variety of biological processes. Beside their importance\n\
+    under healthy conditions they are also known to have a crucial role in complex\
+    \ diseases like cancer.\nIt was shown in the last years that not only the fragments\
+    \ produced by proteases but also their dynamics,\nespecially ex vivo, can serve\
+    \ as biomarkers. But so far, only a few approaches were taken to explicitly\n\
+    model the dynamics of proteolysis in the context of mass spectrometry.\n\nResults:\
+    \ We introduce a new concept model proteolytic processes, the degradation graph.\
+    \ The degra-\ndation graph is an extension of the cleavage graph, a data structure\
+    \ to reconstruct and visualize the\nproteolytic process. In contrast to previous\
+    \ approaches we extended the model to incorporate endoproteolytic\nprocesses and\
+    \ present a method to construct a degradation graph from mass spectrometry\ntime-series\
+    \ data. Based on a degradation graph and the intensities extracted from the mass\
+    \ spectra it is\npossible to estimate reaction rates of the underlying processes.\
+    \ We further suggest a score to rate different\ndegradation graphs in their ability\
+    \ to explain the observed data. This score is used in an iterative\nheuristic\
+    \ to improve the structure of the initially constructed degradation graph.\n\n\
+    Conclusion: We show that the proposed method is able to recover all degraded and\
+    \ generated\npeptides, the underlying reactions, and the reaction rates of proteolytic\
+    \ processes based on mass spectrometry\ntime-series data. We use simulated and\
+    \ real data to demonstrate that a given process can be\nreconstructed even in\
+    \ the presence of extensive noise, isobaric signals and false identications. While\
+    \ the\nmodel is currently only validated on peptide data it is also applicable\
+    \ to proteins, as long as the necessary\ntime series data can be produced.},\n\
+    \ author = {S. Aiche and K. Reinert and Ch. Sch{\\\"u}tte and D. Hildebrand and\
+    \ H. Schl{\\\"u}ter and T. O. F. Conrad},\n journal = {PLoS ONE},\n month = {July},\n\
+    \ number = {7},\n pages = {e40656},\n publisher = {Public Library of Science},\n\
+    \ title = {Inferring Proteolytic Processes from Mass Spectrometry Time Series\
+    \ Data Using Degradation Graphs},\n url = {http://publications.imp.fu-berlin.de/1143/},\n\
+    \ volume = {7},\n year = {2012}\n}\n\n"
+  creators:
+  - name:
+      family: Aiche
+      given: S.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Sch\xFCtte"
+      given: Ch.
+      honourific: null
+      lineage: null
+  - name:
+      family: Hildebrand
+      given: D.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Schl\xFCter"
+      given: H.
+      honourific: null
+      lineage: null
+  - name:
+      family: Conrad
+      given: T. O. F.
+      honourific: null
+      lineage: null
+  date: '2012-07-17'
+  date_type: published
+  datestamp: '2012-06-11 17:28:03'
+  dir: disk0/00/00/11/43
+  divisions:
+  - group_comp-proteomics
+  - inst_math
+  - group_algbioinf
+  - inst_compsci
+  - group_biocomputing
+  eprint_status: archive
+  eprintid: 1143
+  full_text_status: none
+  ispublished: pub
+  issn: 1932-6203
+  item_issues_count: 0
+  key: fu_mi_publications1143
+  lastmod: '2013-04-10 11:52:42'
+  metadata_visibility: show
+  number: 7
+  official_url: http://dx.plos.org/10.1371/journal.pone.0040656
+  pagerange: e40656
+  publication: PLoS ONE
+  publisher: Public Library of Science
+  refereed: 'TRUE'
+  related_url:
+  - type: null
+    url: http://www.plosone.org/article/info%3Adoi%2F10.1371%2Fjournal.pone.0040656
+  - type: pub
+    url: http://plosone.org
+  rev_number: 18
+  status_changed: '2013-04-10 11:52:42'
+  subjects:
+  - G150
+  - C790
+  - G490
+  title: Inferring Proteolytic Processes from Mass Spectrometry Time Series Data Using
+    Degradation Graphs
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1143
+  userid: 1
+  volume: 7
+- abstract: "Motivation: During the last years NGS sequencing has become a key technology\
+    \ for many applications in the biomedical sciences. Throughput continues to increase\
+    \ and new protocols provide longer reads than currently available. In almost all\
+    \ applications, read mapping is a first step. Hence, it is crucial to have algorithms\
+    \ and implementations that perform fast, with high sensitivity, and are able to\
+    \ deal with long reads and a large absolute number of indels.\r\n\r\nResults:\
+    \ RazerS is a read mapping program with adjustable sensitivity based on counting\
+    \ q-grams. In this work we propose the successor RazerS 3 which now supports shared-memory\
+    \ parallelism, an additional seed-based filter with adjustable sensitivity, a\
+    \ much faster, banded version of the Myers\u2019 bit-vector algorithm for verification,\
+    \ memory saving measures and support for the SAM output format. This leads to\
+    \ a much improved performance for mapping reads, in particular long reads with\
+    \ many errors. We extensively compare RazerS 3 with other popular read mappers\
+    \ and show that its results are often superior to them in terms of sensitivity\
+    \ while exhibiting practical and often competetive run times. In addition, RazerS\
+    \ 3 works without a precomputed index.\r\n\r\nAvailability and Implementation:\
+    \ Source code and binaries are freely available for download at http://www.seqan.de/projects/razers.\
+    \ RazerS 3 is implemented in C++ and OpenMP under a GPL license using the SeqAn\
+    \ library and supports Linux, Mac OS X, and Windows."
+  bibtex: "@article{fu_mi_publications1159,\n abstract = {Motivation: During the last\
+    \ years NGS sequencing has become a key technology for many applications in the\
+    \ biomedical sciences. Throughput continues to increase and new protocols provide\
+    \ longer reads than currently available. In almost all applications, read mapping\
+    \ is a first step. Hence, it is crucial to have algorithms and implementations\
+    \ that perform fast, with high sensitivity, and are able to deal with long reads\
+    \ and a large absolute number of indels.\n\nResults: RazerS is a read mapping\
+    \ program with adjustable sensitivity based on counting q-grams. In this work\
+    \ we propose the successor RazerS 3 which now supports shared-memory parallelism,\
+    \ an additional seed-based filter with adjustable sensitivity, a much faster,\
+    \ banded version of the Myers? bit-vector algorithm for verification, memory saving\
+    \ measures and support for the SAM output format. This leads to a much improved\
+    \ performance for mapping reads, in particular long reads with many errors. We\
+    \ extensively compare RazerS 3 with other popular read mappers and show that its\
+    \ results are often superior to them in terms of sensitivity while exhibiting\
+    \ practical and often competetive run times. In addition, RazerS 3 works without\
+    \ a precomputed index.\n\nAvailability and Implementation: Source code and binaries\
+    \ are freely available for download at http://www.seqan.de/projects/razers. RazerS\
+    \ 3 is implemented in C++ and OpenMP under a GPL license using the SeqAn library\
+    \ and supports Linux, Mac OS X, and Windows.},\n author = {D. Weese and M. Holtgrewe\
+    \ and K. Reinert},\n journal = {Bioinformatics},\n month = {August},\n number\
+    \ = {20},\n pages = {2592--2599},\n publisher = {Oxford University Press},\n title\
+    \ = {RazerS 3: Faster, fully sensitive read mapping},\n url = {http://publications.imp.fu-berlin.de/1159/},\n\
+    \ volume = {28},\n year = {2012}\n}\n\n"
+  creators:
+  - name:
+      family: Weese
+      given: D.
+      honourific: null
+      lineage: null
+  - name:
+      family: Holtgrewe
+      given: M.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: '2012-08-24'
+  date_type: published
+  datestamp: '2012-09-11 14:33:09'
+  dir: disk0/00/00/11/59
+  divisions:
+  - group_algbioinf
+  documents:
+  - content: published
+    docid: 569
+    eprintid: 1159
+    files:
+    - datasetid: document
+      fileid: 14153
+      filename: razers3.pdf
+      filesize: 195431
+      mime_type: application/pdf
+      mtime: '2017-03-03 14:41:14'
+      objectid: 569
+      uri: http://publications.imp.fu-berlin.de/id/file/14153
+    format: application/pdf
+    formatdesc: Main Article
+    language: en
+    main: razers3.pdf
+    mime_type: application/pdf
+    pos: 1
+    relation:
+    - type: http://eprints.org/relation/haspreviewThumbnailVersion
+      uri: /id/document/1225
+    - type: http://eprints.org/relation/hasVolatileVersion
+      uri: /id/document/1225
+    - type: http://eprints.org/relation/hasVersion
+      uri: /id/document/1225
+    rev_number: 4
+    security: public
+    uri: http://publications.imp.fu-berlin.de/id/document/569
+  - content: supplemental
+    docid: 570
+    eprintid: 1159
+    files:
+    - datasetid: document
+      fileid: 14156
+      filename: supplement.pdf
+      filesize: 324632
+      mime_type: application/pdf
+      mtime: '2017-03-03 14:41:14'
+      objectid: 570
+      uri: http://publications.imp.fu-berlin.de/id/file/14156
+    format: application/pdf
+    formatdesc: Supplemental Material
+    language: en
+    main: supplement.pdf
+    mime_type: application/pdf
+    pos: 2
+    relation:
+    - type: http://eprints.org/relation/hasVersion
+      uri: /id/document/1226
+    - type: http://eprints.org/relation/haspreviewThumbnailVersion
+      uri: /id/document/1226
+    - type: http://eprints.org/relation/hasVolatileVersion
+      uri: /id/document/1226
+    rev_number: 4
+    security: public
+    uri: http://publications.imp.fu-berlin.de/id/document/570
+  eprint_status: archive
+  eprintid: 1159
+  full_text_status: public
+  id_number: 10.1093/bioinformatics/bts505
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications1159
+  lastmod: '2017-03-03 14:41:14'
+  metadata_visibility: show
+  number: 20
+  official_url: http://bioinformatics.oxfordjournals.org/content/28/20/2592
+  pagerange: 2592-2599
+  publication: Bioinformatics
+  publisher: Oxford University Press
+  refereed: 'TRUE'
+  rev_number: 26
+  status_changed: '2013-08-10 09:35:00'
+  subjects:
+  - C
+  - G
+  title: 'RazerS 3: Faster, fully sensitive read mapping'
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1159
+  userid: 30
+  volume: 28
+- abstract: "Motivation: The reliable detection of genomic variation in resequencing\
+    \ data is still a major challenge, especially for variants larger than a few base\
+    \ pairs. Sequencing reads crossing boundaries of structural variation carry the\
+    \ potential for their identification, but are difficult to map.\r\n\r\nResults:\
+    \ Here we present a method for \u2018split\u2019 read mapping, where prefix and\
+    \ suffix match of a read may be interrupted by a longer gap in the read-to-reference\
+    \ alignment. We use this method to accurately detect medium-sized insertions and\
+    \ long deletions with precise breakpoints in genomic resequencing data. Compared\
+    \ with alternative split mapping methods, SplazerS significantly improves sensitivity\
+    \ for detecting large indel events, especially in variant-rich regions. Our method\
+    \ is robust in the presence of sequencing errors as well as alignment errors due\
+    \ to genomic mutations/divergence, and can be used on reads of variable lengths.\
+    \ Our analysis shows that SplazerS is a versatile tool applicable to unanchored\
+    \ or single-end as well as anchored paired-end reads. In addition, application\
+    \ of SplazerS to targeted resequencing data led to the interesting discovery of\
+    \ a complete, possibly functional gene retrocopy variant.\r\n\r\nAvailability:\
+    \ SplazerS is available from http://www.seqan.de/projects/ splazers."
+  bibtex: "@article{fu_mi_publications1160,\n abstract = {Motivation: The reliable\
+    \ detection of genomic variation in resequencing data is still a major challenge,\
+    \ especially for variants larger than a few base pairs. Sequencing reads crossing\
+    \ boundaries of structural variation carry the potential for their identification,\
+    \ but are difficult to map.\n\nResults: Here we present a method for ?split? read\
+    \ mapping, where prefix and suffix match of a read may be interrupted by a longer\
+    \ gap in the read-to-reference alignment. We use this method to accurately detect\
+    \ medium-sized insertions and long deletions with precise breakpoints in genomic\
+    \ resequencing data. Compared with alternative split mapping methods, SplazerS\
+    \ significantly improves sensitivity for detecting large indel events, especially\
+    \ in variant-rich regions. Our method is robust in the presence of sequencing\
+    \ errors as well as alignment errors due to genomic mutations/divergence, and\
+    \ can be used on reads of variable lengths. Our analysis shows that SplazerS is\
+    \ a versatile tool applicable to unanchored or single-end as well as anchored\
+    \ paired-end reads. In addition, application of SplazerS to targeted resequencing\
+    \ data led to the interesting discovery of a complete, possibly functional gene\
+    \ retrocopy variant.\n\nAvailability: SplazerS is available from http://www.seqan.de/projects/\
+    \ splazers.},\n author = {A.-K. Emde and M. H. Schulz and D. Weese and R. Sun\
+    \ and M. Vingron and V. M. Kalscheuer and S. A. Haas and K. Reinert},\n journal\
+    \ = {Bioinformatics},\n month = {January},\n number = {5},\n pages = {619--627},\n\
+    \ publisher = {Oxford University Press},\n title = {Detecting genomic indel variants\
+    \ with exact breakpoints in single- and paired-end sequencing data using SplazerS},\n\
+    \ url = {http://publications.imp.fu-berlin.de/1160/},\n volume = {28},\n year\
+    \ = {2012}\n}\n\n"
+  creators:
+  - name:
+      family: Emde
+      given: A.-K.
+      honourific: null
+      lineage: null
+  - name:
+      family: Schulz
+      given: M. H.
+      honourific: null
+      lineage: null
+  - name:
+      family: Weese
+      given: D.
+      honourific: null
+      lineage: null
+  - name:
+      family: Sun
+      given: R.
+      honourific: null
+      lineage: null
+  - name:
+      family: Vingron
+      given: M.
+      honourific: null
+      lineage: null
+  - name:
+      family: Kalscheuer
+      given: V. M.
+      honourific: null
+      lineage: null
+  - name:
+      family: Haas
+      given: S. A.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: '2012-01-11'
+  date_type: published
+  datestamp: '2012-09-12 08:40:15'
+  dir: disk0/00/00/11/60
+  divisions:
+  - group_algbioinf
+  documents:
+  - docid: 516
+    eprintid: 1160
+    files:
+    - datasetid: document
+      fileid: 14191
+      filename: 2012_Emde_Detecting_genomic_indel_variants_with_exact_breakpoints_in_single-_and_paired-end_sequencing_data_using_SplazerS-1.pdf
+      filesize: 575317
+      mime_type: application/pdf
+      mtime: '2017-03-03 14:41:14'
+      objectid: 516
+      uri: http://publications.imp.fu-berlin.de/id/file/14191
+    format: application/pdf
+    formatdesc: Original Paper
+    language: en
+    main: 2012_Emde_Detecting_genomic_indel_variants_with_exact_breakpoints_in_single-_and_paired-end_sequencing_data_using_SplazerS-1.pdf
+    mime_type: application/pdf
+    pos: 2
+    relation:
+    - type: http://eprints.org/relation/hasVersion
+      uri: /id/document/1227
+    - type: http://eprints.org/relation/haspreviewThumbnailVersion
+      uri: /id/document/1227
+    - type: http://eprints.org/relation/hasVolatileVersion
+      uri: /id/document/1227
+    rev_number: 4
+    security: public
+    uri: http://publications.imp.fu-berlin.de/id/document/516
+  eprint_status: archive
+  eprintid: 1160
+  full_text_status: public
+  id_number: 10.1093/bioinformatics/bts019
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications1160
+  lastmod: '2017-03-03 14:41:14'
+  metadata_visibility: show
+  number: 5
+  official_url: http://bioinformatics.oxfordjournals.org/content/28/5/619
+  pagerange: 619-627
+  publication: Bioinformatics
+  publisher: Oxford University Press
+  refereed: 'TRUE'
+  rev_number: 18
+  status_changed: '2012-09-12 08:40:15'
+  subjects:
+  - C
+  - G
+  title: Detecting genomic indel variants with exact breakpoints in single- and paired-end
+    sequencing data using SplazerS
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1160
+  userid: 30
+  volume: 28
+- abstract: "We present Masai, a read mapper representing the state-of-the-art in\
+    \ terms of speed and accuracy. Our tool is an order of magnitude faster than RazerS\
+    \ 3 and mrFAST, 2\u20134 times faster and more accurate than Bowtie 2 and BWA.\
+    \ The novelties of our read mapper are filtration with approximate seeds and a\
+    \ method for multiple backtracking. Approximate seeds, compared with exact seeds,\
+    \ increase filtration specificity while preserving sensitivity. Multiple backtracking\
+    \ amortizes the cost of searching a large set of seeds by taking advantage of\
+    \ the repetitiveness of next-generation sequencing data. Combined together, these\
+    \ two methods significantly speed up approximate search on genomic data sets.\
+    \ Masai is implemented in C++ using the SeqAn library. The source code is distributed\
+    \ under the BSD license and binaries for Linux, Mac OS X and Windows can be freely\
+    \ downloaded from http://www.seqan.de/projects/masai."
+  bibtex: "@article{fu_mi_publications1161,\n abstract = {We present Masai, a read\
+    \ mapper representing the state-of-the-art in terms of speed and accuracy. Our\
+    \ tool is an order of magnitude faster than RazerS 3 and mrFAST, 2?4 times faster\
+    \ and more accurate than Bowtie 2 and BWA. The novelties of our read mapper are\
+    \ filtration with approximate seeds and a method for multiple backtracking. Approximate\
+    \ seeds, compared with exact seeds, increase filtration specificity while preserving\
+    \ sensitivity. Multiple backtracking amortizes the cost of searching a large set\
+    \ of seeds by taking advantage of the repetitiveness of next-generation sequencing\
+    \ data. Combined together, these two methods significantly speed up approximate\
+    \ search on genomic data sets. Masai is implemented in C++ using the SeqAn library.\
+    \ The source code is distributed under the BSD license and binaries for Linux,\
+    \ Mac OS X and Windows can be freely downloaded from http://www.seqan.de/projects/masai.},\n\
+    \ author = {E. Siragusa and D. Weese and K. Reinert},\n journal = {Oxford Journals},\n\
+    \ month = {January},\n number = {7},\n pages = {e78},\n publisher = {Oxford University\
+    \ Press},\n title = {Fast and accurate read mapping with approximate seeds and\
+    \ multiple backtracking},\n url = {http://publications.imp.fu-berlin.de/1161/},\n\
+    \ volume = {41},\n year = {2013}\n}\n\n"
+  creators:
+  - name:
+      family: Siragusa
+      given: E.
+      honourific: null
+      lineage: null
+  - name:
+      family: Weese
+      given: D.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: '2013-01-28'
+  date_type: published
+  datestamp: '2012-09-12 08:48:19'
+  dir: disk0/00/00/11/61
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 1161
+  full_text_status: none
+  id_number: 10.1093/nar/gkt005
+  ispublished: pub
+  issn: Print ISSN 0305-1048; Online ISSN 1362-4962
+  item_issues_count: 0
+  key: fu_mi_publications1161
+  lastmod: '2013-08-10 09:39:39'
+  metadata_visibility: show
+  number: 7
+  official_url: http://nar.oxfordjournals.org/content/41/7/e78
+  pagerange: e78
+  publication: Oxford Journals
+  publisher: Oxford University Press
+  refereed: 'TRUE'
+  rev_number: 19
+  status_changed: '2013-08-10 09:39:39'
+  subjects:
+  - C
+  - G
+  title: Fast and accurate read mapping with approximate seeds and multiple backtracking
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1161
+  userid: 30
+  volume: 41
+- abstract: "During the course of evolution, an organism\u2019s genome can undergo\
+    \ changes that affect the large-scale structure of the genome. These changes include\
+    \ gene gain, loss, duplication, chromosome fusion, fission, and rearrangement.\
+    \ When gene gain and loss occurs in addition to other types of rearrangement,\
+    \ breakpoints of rearrangement can exist that are only detectable by comparison\
+    \ of three or more genomes. An arbitrarily large number of these \u201Chidden\u201D\
+    \ breakpoints can exist among genomes that exhibit no rearrangements in pairwise\
+    \ comparisons. \r\n\r\nWe present an extension of the multichromosomal breakpoint\
+    \ median problem to genomes that have undergone gene gain and loss. We then demonstrate\
+    \ that the median distance among three genomes can be used to calculate a lower\
+    \ bound on the number of hidden breakpoints present. We provide an implementation\
+    \ of this calculation including the median distance, along with some practical\
+    \ improvements on the time complexity of the underlying algorithm. \r\n\r\nWe\
+    \ apply our approach to measure the abundance of hidden breakpoints in simulated\
+    \ data sets under a wide range of evolutionary scenarios. We demonstrate that\
+    \ in simulations the hidden breakpoint counts depend strongly on relative rates\
+    \ of inversion and gene gain/loss. Finally we apply current multiple genome aligners\
+    \ to the simulated genomes, and show that all aligners introduce a high degree\
+    \ of error in hidden breakpoint counts, and that this error grows with evolutionary\
+    \ distance in the simulation. Our results suggest that hidden breakpoint error\
+    \ may be pervasive in genome alignments. "
+  bibtex: "@incollection{fu_mi_publications1168,\n abstract = {During the course of\
+    \ evolution, an organism?s genome can undergo changes that affect the large-scale\
+    \ structure of the genome. These changes include gene gain, loss, duplication,\
+    \ chromosome fusion, fission, and rearrangement. When gene gain and loss occurs\
+    \ in addition to other types of rearrangement, breakpoints of rearrangement can\
+    \ exist that are only detectable by comparison of three or more genomes. An arbitrarily\
+    \ large number of these ?hidden? breakpoints can exist among genomes that exhibit\
+    \ no rearrangements in pairwise comparisons. \n\nWe present an extension of the\
+    \ multichromosomal breakpoint median problem to genomes that have undergone gene\
+    \ gain and loss. We then demonstrate that the median distance among three genomes\
+    \ can be used to calculate a lower bound on the number of hidden breakpoints present.\
+    \ We provide an implementation of this calculation including the median distance,\
+    \ along with some practical improvements on the time complexity of the underlying\
+    \ algorithm. \n\nWe apply our approach to measure the abundance of hidden breakpoints\
+    \ in simulated data sets under a wide range of evolutionary scenarios. We demonstrate\
+    \ that in simulations the hidden breakpoint counts depend strongly on relative\
+    \ rates of inversion and gene gain/loss. Finally we apply current multiple genome\
+    \ aligners to the simulated genomes, and show that all aligners introduce a high\
+    \ degree of error in hidden breakpoint counts, and that this error grows with\
+    \ evolutionary distance in the simulation. Our results suggest that hidden breakpoint\
+    \ error may be pervasive in genome alignments. },\n address = {Berlin},\n author\
+    \ = {B. Kehr and K. Reinert and A. E. Darling},\n booktitle = {Lecture Notes in\
+    \ Computer Science: Algorithms in Bioinformatics},\n editor = {B. Raphael and\
+    \ J. Tang},\n pages = {391--403},\n publisher = {Springer-Verlag},\n title = {Hidden\
+    \ Breakpoints in Genome Alignments },\n url = {http://publications.imp.fu-berlin.de/1168/},\n\
+    \ volume = {7534},\n year = {2012}\n}\n\n"
+  book_title: 'Lecture Notes in Computer Science: Algorithms in Bioinformatics'
+  creators:
+  - id: birte.kehr@fu-berlin.de
+    name:
+      family: Kehr
+      given: B.
+      honourific: null
+      lineage: null
+  - id: knut.reinert@fu-berlin.de
+    name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Darling
+      given: A. E.
+      honourific: null
+      lineage: null
+  date: 2012
+  date_type: published
+  datestamp: '2012-10-16 11:59:27'
+  dir: disk0/00/00/11/68
+  divisions:
+  - group_algbioinf
+  editors:
+  - name:
+      family: Raphael
+      given: B.
+      honourific: null
+      lineage: null
+  - name:
+      family: Tang
+      given: J.
+      honourific: null
+      lineage: null
+  eprint_status: archive
+  eprintid: 1168
+  full_text_status: none
+  isbn: 978-3-642-33121-3
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications1168
+  lastmod: '2012-10-16 12:04:02'
+  metadata_visibility: show
+  official_url: http://www.springerlink.com/content/u776nx9n7h013887/
+  pagerange: 391-403
+  place_of_pub: Berlin
+  publisher: Springer-Verlag
+  refereed: 'TRUE'
+  related_url:
+  - url: http://www.springerlink.com/content/978-3-642-33121-3/
+  rev_number: 11
+  status_changed: '2012-10-16 12:04:02'
+  subjects:
+  - G400
+  title: 'Hidden Breakpoints in Genome Alignments '
+  type: book_section
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1168
+  userid: 132
+  volume: 7534
+- abstract: We present in this paper scalable algorithms for optimal string similarity
+    search and join. Our methods are variations of those applied in Masai [15], our
+    recently published tool for mapping high-throughput DNA sequencing data with unpreceded
+    speed and accuracy. The key features of our approach are filtration with approximate
+    seeds and methods for multiple backtracking. Approximate seeds, compared to exact
+    seeds, increase filtration specificity while preserving sensitivity. Multiple
+    backtracking amortizes the cost of searching a large set of seeds. Combined together,
+    these two methods significantly speed up string similarity search and join operations.
+    Our tool is implemented in C++ and OpenMP using the SeqAn library. The source
+    code is distributed under the BSD license and can be freely downloaded from http://www.seqan.de/projects/edbt2013.
+  bibtex: "@inproceedings{fu_mi_publications1225,\n abstract = {We present in this\
+    \ paper scalable algorithms for optimal string similarity search and join. Our\
+    \ methods are variations of those applied in Masai [15], our recently published\
+    \ tool for mapping high-throughput DNA sequencing data with unpreceded speed and\
+    \ accuracy. The key features of our approach are filtration with approximate seeds\
+    \ and methods for multiple backtracking. Approximate seeds, compared to exact\
+    \ seeds, increase filtration specificity while preserving sensitivity. Multiple\
+    \ backtracking amortizes the cost of searching a large set of seeds. Combined\
+    \ together, these two methods significantly speed up string similarity search\
+    \ and join operations. Our tool is implemented in C++ and OpenMP using the SeqAn\
+    \ library. The source code is distributed under the BSD license and can be freely\
+    \ downloaded from http://www.seqan.de/projects/edbt2013.},\n address = {New York,\
+    \ NY, USA},\n author = {E. Siragusa and D. Weese and K. Reinert},\n booktitle\
+    \ = {Proceedings of the Joint EDBT/ICDT 2013 Workshops},\n keywords = {approximate\
+    \ seeds, backtracking, banded Myers bit-vector, banded dynamic programming, filtration,\
+    \ radix tree, suffix tree},\n pages = {370--374},\n publisher = {ACM},\n series\
+    \ = {EDBT '13},\n title = {Scalable string similarity search/join with approximate\
+    \ seeds and multiple backtracking},\n url = {http://publications.imp.fu-berlin.de/1225/},\n\
+    \ year = {2013}\n}\n\n"
+  creators:
+  - name:
+      family: Siragusa
+      given: E.
+      honourific: null
+      lineage: null
+  - name:
+      family: Weese
+      given: D.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: 2013
+  date_type: published
+  datestamp: '2013-03-28 12:24:08'
+  dir: disk0/00/00/12/25
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 1225
+  event_location: Genoa, Italy
+  event_title: Proceedings of the Joint EDBT/ICDT 2013 Workshops
+  event_type: workshop
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications1225
+  keywords: approximate seeds, backtracking, banded Myers bit-vector, banded dynamic
+    programming, filtration, radix tree, suffix tree
+  lastmod: '2013-08-10 11:41:05'
+  metadata_visibility: show
+  official_url: http://doi.acm.org/10.1145/2457317.2457386
+  pagerange: 370-374
+  place_of_pub: New York, NY, USA
+  pres_type: paper
+  publisher: ACM
+  refereed: 'TRUE'
+  related_url:
+  - url: http://dl.acm.org/citation.cfm?id=2457386&bnc=1
+  rev_number: 18
+  series: EDBT '13
+  status_changed: '2013-08-10 11:41:05'
+  subjects:
+  - G400
+  title: Scalable string similarity search/join with approximate seeds and multiple
+    backtracking
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1225
+  userid: 132
+- abstract: "Recent advances in sequencing technology allow to produce billions of\
+    \ base pairs per day in the form of reads of length 100 bp an longer and current\
+    \ developments promise the personal $1,000 genome in a couple of years. The analysis\
+    \ of these unprecedented amounts of data demands for efficient data structures\
+    \ and algorithms. One such data structures is the substring index, that represents\
+    \ all substrings or substrings up to a certain length contained in a given text.\r\
+    \nIn this thesis we propose 3 substring indices, which we extend to be applicable\
+    \ to millions of sequences. We devise internal and external memory construction\
+    \ algorithms and a uniform framework for accessing the generalized suffix tree.\
+    \ Additionally we propose different index-based applications, e.g. exact and approximate\
+    \ pattern matching and different repeat search algorithms.\r\nSecond, we present\
+    \ the read mapping tool RazerS, which aligns millions of single or paired-end\
+    \ reads of arbitrary lengths to their potential genomic origin using either Hamming\
+    \ or edit distance. Our tool can work either lossless or with a user-defined loss\
+    \ rate at higher speeds. Given the loss rate, we present a novel approach that\
+    \ guarantees not to lose more reads than specified. This enables the user to adapt\
+    \ to the problem at hand and provides a seamless tradeoff between sensitivity\
+    \ and running time. We compare RazerS with other state-of-the-art read mappers\
+    \ and show that it has the highest sensitivity and a comparable performance on\
+    \ various real-world datasets.\r\nAt last, we propose a general approach for frequency\
+    \ based string mining, which has many applications, e.g. in contrast data mining.\
+    \ Our contribution is a novel and lightweight algorithm that is faster and uses\
+    \ less memory than the best available algorithms. We show its applicability for\
+    \ mining multiple databases with a variety of frequency constraints. As such,\
+    \ we use the notion of entropy from information theory to generalize the emerging\
+    \ substring mining problem to multiple databases. To demonstrate the improvement\
+    \ of our algorithm we compared to recent approaches on real-world experiments\
+    \ of various string domains, e.g. natural language, DNA, or protein sequences."
+  bibtex: "@phdthesis{fu_mi_publications1288,\n abstract = {Recent advances in sequencing\
+    \ technology allow to produce billions of base pairs per day in the form of reads\
+    \ of length 100 bp an longer and current developments promise the personal \\\
+    $1,000 genome in a couple of years. The analysis of these unprecedented amounts\
+    \ of data demands for efficient data structures and algorithms. One such data\
+    \ structures is the substring index, that represents all substrings or substrings\
+    \ up to a certain length contained in a given text.\nIn this thesis we propose\
+    \ 3 substring indices, which we extend to be applicable to millions of sequences.\
+    \ We devise internal and external memory construction algorithms and a uniform\
+    \ framework for accessing the generalized suffix tree. Additionally we propose\
+    \ different index-based applications, e.g. exact and approximate pattern matching\
+    \ and different repeat search algorithms.\nSecond, we present the read mapping\
+    \ tool RazerS, which aligns millions of single or paired-end reads of arbitrary\
+    \ lengths to their potential genomic origin using either Hamming or edit distance.\
+    \ Our tool can work either lossless or with a user-defined loss rate at higher\
+    \ speeds. Given the loss rate, we present a novel approach that guarantees not\
+    \ to lose more reads than specified. This enables the user to adapt to the problem\
+    \ at hand and provides a seamless tradeoff between sensitivity and running time.\
+    \ We compare RazerS with other state-of-the-art read mappers and show that it\
+    \ has the highest sensitivity and a comparable performance on various real-world\
+    \ datasets.\nAt last, we propose a general approach for frequency based string\
+    \ mining, which has many applications, e.g. in contrast data mining. Our contribution\
+    \ is a novel and lightweight algorithm that is faster and uses less memory than\
+    \ the best available algorithms. We show its applicability for mining multiple\
+    \ databases with a variety of frequency constraints. As such, we use the notion\
+    \ of entropy from information theory to generalize the emerging substring mining\
+    \ problem to multiple databases. To demonstrate the improvement of our algorithm\
+    \ we compared to recent approaches on real-world experiments of various string\
+    \ domains, e.g. natural language, DNA, or protein sequences.},\n author = {D.\
+    \ Weese},\n keywords = {HTS; full-text index; frequency string mining; read mapping;\
+    \ SeqAn},\n month = {June},\n school = {Freie Universit{\\\"a}t Berlin},\n title\
+    \ = {Indices and Applications in High-Throughput Sequencing},\n url = {http://publications.imp.fu-berlin.de/1288/},\n\
+    \ year = {2013}\n}\n\n"
+  creators:
+  - id: david.weese@fu-berlin.de
+    name:
+      family: Weese
+      given: D.
+      honourific: null
+      lineage: null
+  date: '2013-06-05'
+  date_type: published
+  datestamp: '2013-06-15 19:50:31'
+  department: Department of Mathematics and Computer Science
+  dir: disk0/00/00/12/88
+  divisions:
+  - group_algbioinf
+  documents:
+  - content: published
+    docid: 554
+    eprintid: 1288
+    files:
+    - datasetid: document
+      fileid: 16089
+      filename: thesis_weese12.pdf
+      filesize: 2839678
+      mime_type: application/pdf
+      mtime: '2017-03-03 14:41:25'
+      objectid: 554
+      uri: http://publications.imp.fu-berlin.de/id/file/16089
+    format: application/pdf
+    formatdesc: PhD Thesis
+    language: en
+    main: thesis_weese12.pdf
+    mime_type: application/pdf
+    pos: 1
+    relation:
+    - type: http://eprints.org/relation/haspreviewThumbnailVersion
+      uri: /id/document/1246
+    - type: http://eprints.org/relation/hasVolatileVersion
+      uri: /id/document/1246
+    - type: http://eprints.org/relation/hasVersion
+      uri: /id/document/1246
+    rev_number: 5
+    security: public
+    uri: http://publications.imp.fu-berlin.de/id/document/554
+  eprint_status: archive
+  eprintid: 1288
+  full_text_status: public
+  institution: "Freie Universit\xE4t Berlin"
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications1288
+  keywords: HTS; full-text index; frequency string mining; read mapping; SeqAn
+  lastmod: '2017-03-03 14:41:25'
+  metadata_visibility: show
+  official_url: http://www.diss.fu-berlin.de/diss/receive/FUDISS_thesis_000000094456
+  pages: 196
+  rev_number: 19
+  status_changed: '2013-06-15 19:54:07'
+  subjects:
+  - C
+  - G
+  thesis_type: phd
+  title: Indices and Applications in High-Throughput Sequencing
+  type: thesis
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1288
+  userid: 30
+- abstract: We evaluated 25 protocol variants of 14 independent computational methods
+    for exon identification, transcript reconstruction and expression-level quantification
+    from RNA-seq data. Our results show that most algorithms are able to identify
+    discrete transcript components with high success rates but that assembly of complete
+    isoform structures poses a major challenge even when all constituent elements
+    are identified. Expression-level estimates also varied widely across methods,
+    even when based on similar transcript models. Consequently, the complexity of
+    higher eukaryotic genomes imposes severe limitations on transcript recall and
+    splice product discrimination that are likely to remain limiting factors for the
+    analysis of current-generation RNA-seq data.
+  bibtex: "@article{fu_mi_publications1380,\n abstract = {We evaluated 25 protocol\
+    \ variants of 14 independent computational methods for exon identification, transcript\
+    \ reconstruction and expression-level quantification from RNA-seq data. Our results\
+    \ show that most algorithms are able to identify discrete transcript components\
+    \ with high success rates but that assembly of complete isoform structures poses\
+    \ a major challenge even when all constituent elements are identified. Expression-level\
+    \ estimates also varied widely across methods, even when based on similar transcript\
+    \ models. Consequently, the complexity of higher eukaryotic genomes imposes severe\
+    \ limitations on transcript recall and splice product discrimination that are\
+    \ likely to remain limiting factors for the analysis of current-generation RNA-seq\
+    \ data.},\n author = {T. Steijger and J. F. Abril and P. G. Engstr{\\\"o}m and\
+    \ F. Kokocinski and The RGASP Consortium and H. Richard and M. H. Schulz and D.\
+    \ Weese and T. Hubbard and R. Guig{\\'o} and J. Harrow and P. Bertone},\n journal\
+    \ = {Nature Methods},\n month = {November},\n number = {12},\n pages = {1177--1184},\n\
+    \ publisher = {Nature Publishing Group},\n title = {Assessment of transcript reconstruction\
+    \ methods for RNA-seq},\n url = {http://publications.imp.fu-berlin.de/1380/},\n\
+    \ volume = {10},\n year = {2013}\n}\n\n"
+  contact_email: david.weese@fu-berlin.de
+  creators:
+  - name:
+      family: Steijger
+      given: T.
+      honourific: null
+      lineage: null
+  - name:
+      family: Abril
+      given: J. F.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Engstr\xF6m"
+      given: P. G.
+      honourific: null
+      lineage: null
+  - name:
+      family: Kokocinski
+      given: F.
+      honourific: null
+      lineage: null
+  - name:
+      family: The RGASP Consortium
+      given: null
+      honourific: null
+      lineage: null
+  - name:
+      family: Richard
+      given: H.
+      honourific: null
+      lineage: null
+  - name:
+      family: Schulz
+      given: M. H.
+      honourific: null
+      lineage: null
+  - name:
+      family: Weese
+      given: D.
+      honourific: null
+      lineage: null
+  - name:
+      family: Hubbard
+      given: T.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Guig\xF3"
+      given: R.
+      honourific: null
+      lineage: null
+  - name:
+      family: Harrow
+      given: J.
+      honourific: null
+      lineage: null
+  - name:
+      family: Bertone
+      given: P.
+      honourific: null
+      lineage: null
+  date: '2013-11-03'
+  date_type: published
+  datestamp: '2014-02-20 22:54:03'
+  dir: disk0/00/00/13/80
+  divisions:
+  - group_algbioinf
+  documents:
+  - content: published
+    docid: 595
+    eprintid: 1380
+    files:
+    - datasetid: document
+      fileid: 17299
+      filename: nmeth.2714.pdf
+      filesize: 649888
+      mime_type: application/pdf
+      mtime: '2017-03-03 14:41:32'
+      objectid: 595
+      uri: http://publications.imp.fu-berlin.de/id/file/17299
+    format: application/pdf
+    language: en
+    main: nmeth.2714.pdf
+    mime_type: application/pdf
+    pos: 1
+    relation:
+    - type: http://eprints.org/relation/haspreviewThumbnailVersion
+      uri: /id/document/1267
+    - type: http://eprints.org/relation/hasVolatileVersion
+      uri: /id/document/1267
+    - type: http://eprints.org/relation/hasVersion
+      uri: /id/document/1267
+    rev_number: 4
+    security: public
+    uri: http://publications.imp.fu-berlin.de/id/document/595
+  eprint_status: archive
+  eprintid: 1380
+  full_text_status: public
+  id_number: 10.1038/nmeth.2714
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications1380
+  lastmod: '2017-03-03 14:41:32'
+  metadata_visibility: show
+  number: 12
+  official_url: http://dx.doi.org/10.1038/nmeth.2714
+  pagerange: 1177-1184
+  publication: Nature Methods
+  publisher: Nature Publishing Group
+  refereed: 'TRUE'
+  rev_number: 20
+  status_changed: '2014-02-21 05:42:01'
+  subjects:
+  - C
+  - G400
+  title: Assessment of transcript reconstruction methods for RNA-seq
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1380
+  userid: 30
+  volume: 10
+- abstract: Mass spectrometry coupled to high-performance liquid chromatography (HPLC-MS)
     is evolving more quickly than ever. A wide range of different instrument types
     and experimental setups are commonly used. Modern instruments acquire huge amounts
     of data, thus requiring tools for an efficient and automated data analysis. Most
@@ -4815,1909 +1640,100 @@
     fashion. The implementation is portable and has been tested under Windows, Mac
     OS X, and Linux. TOPPAS is open-source software and available free of charge at
     http://www.OpenMS.de/TOPPAS .
-  title: 'TOPPAS: a graphical workflow editor for the analysis of high-throughput
-    proteomics data'
-- eprintid: 2004
-  refereed: 'TRUE'
-  number: 1
-  metadata_visibility: show
-  id_number: doi:10.1186/s13073-016-0383-z
-  date_type: published
-  full_text_status: none
-  item_issues_count: 0
-  dir: disk0/00/00/20/04
-  issn: 1756-994X
-  eprint_status: archive
-  subjects:
-  - G400
-  divisions:
-  - group_algbioinf
-  volume: 8
-  date: '2016-12-13'
-  official_url: http://dx.doi.org/10.1186/s13073-016-0383-z
-  uri: http://publications.imp.fu-berlin.de/id/eprint/2004
-  lastmod: '2017-01-12 09:36:57'
-  ispublished: pub
-  publication: Genome Medicine
-  datestamp: '2017-01-12 09:36:57'
+  bibtex: "@article{fu_mi_publications1396,\n abstract = {Mass spectrometry coupled\
+    \ to high-performance liquid chromatography (HPLC-MS) is evolving more quickly\
+    \ than ever. A wide range of different instrument types and experimental setups\
+    \ are commonly used. Modern instruments acquire huge amounts of data, thus requiring\
+    \ tools for an efficient and automated data analysis. Most existing software for\
+    \ analyzing HPLC-MS data is monolithic and tailored toward a specific application.\
+    \ A more flexible alternative consists of pipeline-based tool kits allowing the\
+    \ construction of custom analysis workflows from small building blocks, e.g.,\
+    \ the Trans Proteomics Pipeline (TPP) or The OpenMS Proteomics Pipeline (TOPP).\
+    \ One drawback, however, is the hurdle of setting up complex workflows using command\
+    \ line tools. We present TOPPAS, The OpenMS Proteomics Pipeline ASsistant, a graphical\
+    \ user interface (GUI) for rapid composition of HPLC-MS analysis workflows. Workflow\
+    \ construction reduces to simple drag-and-drop of analysis tools and adding connections\
+    \ in between. Integration of external tools into these workflows is possible as\
+    \ well. Once workflows have been developed, they can be deployed in other workflow\
+    \ management systems or batch processing systems in a fully automated fashion.\
+    \ The implementation is portable and has been tested under Windows, Mac OS X,\
+    \ and Linux. TOPPAS is open-source software and available free of charge at http://www.OpenMS.de/TOPPAS\
+    \ .},\n author = {J. Junker and C. Bielow and A. Bertsch and M. Sturm and K. Reinert\
+    \ and O. Kohlbacher},\n journal = {J. Proteome Res.},\n month = {July},\n number\
+    \ = {7},\n pages = {3914--3920},\n publisher = {ACS Publications},\n title = {TOPPAS:\
+    \ a graphical workflow editor for the analysis of high-throughput proteomics data},\n\
+    \ url = {http://publications.imp.fu-berlin.de/1396/},\n volume = {11},\n year\
+    \ = {2012}\n}\n\n"
   creators:
-  - name:
-      lineage:
-      family: Jäger
-      given: Marten
-      honourific:
-  - name:
-      lineage:
-      family: Schubach
-      given: Max
-      honourific:
-  - name:
-      honourific:
-      given: Tomasz
-      family: Zemojtel
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: Knut
-      family: Reinert
-  - name:
-      family: Church
-      honourific:
-      given: Deanna M.
-      lineage:
-  - name:
-      given: Peter N.
-      honourific:
-      family: Robinson
-      lineage:
-  userid: 132
-  rev_number: 7
-  publisher: BioMed Central (Springer Nature)
-  type: article
-  title: Alternate-locus aware variant calling in whole genome sequencing
-  status_changed: '2017-01-12 09:36:57'
-  abstract: "BackgroundThe last two human genome assemblies have extended
-    the previous linear golden-path paradigm of the human genome to a graph-like model
-    to better represent regions with a high degree of structural variability. The
-    new model offers opportunities to improve the technical validity of variant calling
-    in whole-genome sequencing (WGS).MethodsWe developed an algorithm
-    that analyzes the patterns of variant calls in the 178 structurally variable regions
-    of the GRCh38 genome assembly, and infers whether a given sample is most likely
-    to contain sequences from the primary assembly, an alternate locus, or their heterozygous
-    combination at each of these 178 regions. We investigate 121 in-house WGS datasets
-    that have been aligned to the GRCh37 and GRCh38 assemblies.ResultsWe
-    show that stretches of sequences that are largely but not entirely identical between
-    the primary assembly and an alternate locus can result in multiple variant calls
-    against regions of the primary assembly. In WGS analysis, this results in characteristic
-    and recognizable patterns of variant calls at positions that we term alignable
-    scaffold-discrepant positions (ASDPs). In 121 in-house genomes, on average 51.8±3.8
-    of the 178 regions were found to correspond best to an alternate locus rather
-    than the primary assembly sequence, and filtering these genomes with our algorithm
-    led to the identification of 7863 variant calls per genome that colocalized with
-    ASDPs. Additionally, we found that 437 of 791 genome-wide association study hits
-    located within one of the regions corresponded to ASDPs.ConclusionsOur
-    algorithm uses the information contained in the 178 structurally variable regions
-    of the GRCh38 genome assembly to avoid spurious variant calls in cases where samples
-    contain an alternate locus rather than the corresponding segment of the primary
-    assembly. These results suggest the great potential of fully incorporating the
-    resources of graph-like genome assemblies into variant calling, but also underscore
-    the importance of developing computational resources that will allow a full reconstruction
-    of the genotype in personal genomes. Our algorithm is freely available at https://github.com/charite/asdpex."
-- status_changed: '2009-03-11 11:27:10'
-  title: A Polyhedral Approach to Sequence Alignment Problems
-  rev_number: 3
-  type: article
-  userid: 1
-  creators:
-  - name:
-      family: Kececioglu
-      honourific:
-      given: J. D.
-      lineage:
-  - name:
-      honourific:
-      given: H.-P.
-      family: Lenhof
-      lineage:
-  - name:
-      lineage:
-      family: Mehlhorn
-      given: K.
-      honourific:
-  - name:
-      family: Reinert
-      honourific:
-      given: K.
-      lineage:
-  - name:
-      honourific:
-      given: M.
-      family: Vingron
-      lineage:
-  datestamp: '2017-03-03 14:40:14'
-  publication: Discrete Applied Mathematics
-  lastmod: '2017-03-03 14:40:14'
-  ispublished: pub
-  uri: http://publications.imp.fu-berlin.de/id/eprint/370
-  date: 2000
-  pagerange: 143-186
-  volume: 104
-  subjects:
-  - G400
-  divisions:
-  - group_algbioinf
-  eprint_status: archive
-  dir: disk0/00/00/03/70
-  item_issues_count: 0
-  full_text_status: none
-  metadata_visibility: show
-  eprintid: 370
-  refereed: 'TRUE'
-- eprint_status: archive
-  dir: disk0/00/00/11/68
-  date: 2012
-  pagerange: 391-403
-  place_of_pub: Berlin
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  volume: 7534
-  eprintid: 1168
-  refereed: 'TRUE'
-  item_issues_count: 0
-  metadata_visibility: show
-  full_text_status: none
-  date_type: published
-  creators:
-  - name:
-      lineage:
-      family: Kehr
-      honourific:
-      given: B.
-    id: birte.kehr@fu-berlin.de
-  - name:
-      given: K.
-      honourific:
-      family: Reinert
-      lineage:
-    id: knut.reinert@fu-berlin.de
-  - name:
-      lineage:
-      honourific:
-      given: A. E.
-      family: Darling
-    id:
-  related_url:
-  - url: http://www.springerlink.com/content/978-3-642-33121-3/
-  datestamp: '2012-10-16 11:59:27'
-  title: 'Hidden Breakpoints in Genome Alignments '
-  editors:
-  - name:
-      family: Raphael
-      honourific:
-      given: B.
-      lineage:
-  - name:
-      lineage:
-      honourific:
+  - id: null
+    name:
+      family: Junker
       given: J.
-      family: Tang
-  abstract: "During the course of evolution, an organism’s genome can undergo changes
-    that affect the large-scale structure of the genome. These changes include gene
-    gain, loss, duplication, chromosome fusion, fission, and rearrangement. When gene
-    gain and loss occurs in addition to other types of rearrangement, breakpoints
-    of rearrangement can exist that are only detectable by comparison of three or
-    more genomes. An arbitrarily large number of these “hidden” breakpoints can exist
-    among genomes that exhibit no rearrangements in pairwise comparisons. We
-    present an extension of the multichromosomal breakpoint median problem to genomes
-    that have undergone gene gain and loss. We then demonstrate that the median distance
-    among three genomes can be used to calculate a lower bound on the number of hidden
-    breakpoints present. We provide an implementation of this calculation including
-    the median distance, along with some practical improvements on the time complexity
-    of the underlying algorithm. We apply our approach to measure the abundance
-    of hidden breakpoints in simulated data sets under a wide range of evolutionary
-    scenarios. We demonstrate that in simulations the hidden breakpoint counts depend
-    strongly on relative rates of inversion and gene gain/loss. Finally we apply current
-    multiple genome aligners to the simulated genomes, and show that all aligners
-    introduce a high degree of error in hidden breakpoint counts, and that this error
-    grows with evolutionary distance in the simulation. Our results suggest that hidden
-    breakpoint error may be pervasive in genome alignments. "
-  status_changed: '2012-10-16 12:04:02'
-  userid: 132
-  publisher: Springer-Verlag
-  rev_number: 11
-  type: book_section
-  official_url: http://www.springerlink.com/content/u776nx9n7h013887/
-  book_title: 'Lecture Notes in Computer Science: Algorithms in Bioinformatics'
-  ispublished: pub
-  lastmod: '2012-10-16 12:04:02'
-  isbn: 978-3-642-33121-3
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1168
-- item_issues_count: 0
-  date_type: published
-  full_text_status: none
-  metadata_visibility: show
-  id_number: doi:10.1186/1471-2105-15-99
-  refereed: 'TRUE'
-  eprintid: 1437
-  date: '2014-04-09'
-  volume: 15
-  subjects:
-  - G400
-  divisions:
-  - group_algbioinf
-  eprint_status: archive
-  issn: 1471-2105
-  dir: disk0/00/00/14/37
-  lastmod: '2014-08-19 12:35:56'
-  ispublished: pub
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1437
-  official_url: http://www.biomedcentral.com/1471-2105/15/99/abstract
-  abstract: "BackgroundRecent advances in rapid, low-cost sequencing have
-    opened up the opportunity to study complete genome sequences. The computational
-    approach of multiple genome alignment allows investigation of evolutionarily related
-    genomes in an integrated fashion, providing a basis for downstream analyses such
-    as rearrangement studies and phylogenetic inference.Graphs have proven
-    to be a powerful tool for coping with the complexity of genome-scale sequence
-    alignments. The potential of graphs to intuitively represent all aspects of genome
-    alignments led to the development of graph-based approaches for genome alignment.
-    These approaches construct a graph from a set of local alignments, and derive
-    a genome alignment through identification and removal of graph substructures that
-    indicate errors in the alignment.ResultsWe compare the structures
-    of commonly used graphs in terms of their abilities to represent alignment information.
-    We describe how the graphs can be transformed into each other, and identify and
-    classify graph substructures common to one or more graphs. Based on previous approaches,
-    we compile a list of modifications that remove these substructures.ConclusionWe
-    show that crucial pieces of alignment information, associated with inversions
-    and duplications, are not visible in the structure of all graphs. If we neglect
-    vertex or edge labels, the graphs differ in their information content. Still,
-    many ideas are shared among all graph-based approaches. Based on these findings,
-    we outline a conceptual framework for graph-based genome alignment that can assist
-    in the development of future genome alignment tools. "
-  status_changed: '2014-08-19 12:35:56'
-  title: 'Genome alignment with graph data structures: a comparison'
-  type: article
-  publisher: BioMed Central
-  rev_number: 12
-  userid: 132
-  creators:
-  - id:
+      honourific: null
+      lineage: null
+  - id: null
     name:
-      lineage:
-      honourific:
-      given: B.
-      family: Kehr
-  - id:
-    name:
-      family: Trappe
-      honourific:
-      given: K.
-      lineage:
-  - id:
-    name:
-      honourific:
-      given: M.
-      family: Holtgrewe
-      lineage:
-  - name:
-      lineage:
-      family: Reinert
-      given: K.
-      honourific:
-    id: knut.reinert@fu-berlin.de
-  datestamp: '2014-08-19 12:35:56'
-  publication: BMC Bioinformatics
-- userid: 30
-  publisher: BioMed Central
-  rev_number: 11
-  type: article
-  title: 'STELLAR: fast and exact local alignments'
-  abstract: "BackgroundLarge-scale comparison of genomic sequences requires reliable
-    tools for the search of local alignments. Practical local aligners are in general
-    fast, but heuristic, and hence sometimes miss significant matches.ResultsWe
-    present here the local pairwise aligner STELLAR that has full sensitivity for
-    ε-alignments, i.e. guarantees to report all local alignments of a given minimal
-    length and maximal error rate. The aligner is composed of two steps, filtering
-    and verification. We apply the SWIFT algorithm for lossless filtering, and have
-    developed a new verification strategy that we prove to be exact. Our results on
-    simulated and real genomic data confirm and quantify the conjecture that heuristic
-    tools like BLAST or BLAT miss a large percentage of significant local alignments.ConclusionsSTELLAR
-    is very practical and fast on very long sequences which makes it a suitable new
-    tool for finding local alignments between genomic sequences under the edit distance
-    model. Binaries are freely available for Linux, Windows, and Mac OS X at http://www.seqan.de/projects/stellar.
-    The source code is freely distributed with the SeqAn C++ library version 1.3 and
-    later at http://www.seqan.de."
-  status_changed: '2011-10-08 13:20:36'
-  datestamp: '2011-10-08 13:20:36'
-  publication: BMC Bioinformatics
-  creators:
-  - name:
-      family: Kehr
-      given: B.
-      honourific:
-      lineage:
-  - name:
-      family: Weese
-      given: D.
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      family: Reinert
-      given: K.
-      honourific:
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1092
-  lastmod: '2011-10-08 13:20:36'
-  ispublished: pub
-  official_url: http://www.biomedcentral.com/1471-2105/12/S9/S15
-  divisions:
-  - group_algbioinf
-  subjects:
-  - C400
-  - G400
-  volume: 12
-  pagerange: S15
-  date: '2011-10-03'
-  dir: disk0/00/00/10/92
-  issn: 1471-2105
-  eprint_status: archive
-  metadata_visibility: show
-  date_type: published
-  full_text_status: none
-  item_issues_count: 0
-  eprintid: 1092
-  refereed: 'TRUE'
-  number: S9
-- official_url: http://doi.org/10.1101/301085
-  uri: http://publications.imp.fu-berlin.de/id/eprint/2284
-  book_title: Optimum Search Schemes for Approximate String Matching Using Bidirectional
-    FM-Index
-  lastmod: '2018-11-12 14:25:35'
-  ispublished: pub
-  related_url:
-  - url: https://www.biorxiv.org/content/early/2018/04/14/301085
-  datestamp: '2018-11-12 14:25:35'
-  publication: bioRxiv, The Preprint Server for Biology
-  creators:
-  - name:
-      given: Kiavash
-      honourific:
-      family: Kianfar
-      lineage:
-  - name:
-      lineage:
-      family: Pockrandt
-      honourific:
-      given: Christopher
-  - name:
-      lineage:
-      family: Torkamandi
-      given: Bahman
-      honourific:
-  - name:
-      given: Haochen
-      honourific:
-      family: Luo
-      lineage:
-  - name:
-      given: Knut
-      honourific:
-      family: Reinert
-      lineage:
-  userid: 132
-  rev_number: 5
-  type: article
-  title: Optimum Search Schemes for Approximate String Matching Using Bidirectional
-    FM-Index
-  status_changed: '2018-11-12 14:25:35'
-  abstract: Finding approximate occurrences of a pattern in a text using a full-text
-    index is a central problem in bioinformatics and has been extensively researched.
-    Bidirectional indices have opened new possibilities in this regard allowing the
-    search to start from anywhere within the pattern and extend in both directions.
-    In particular, use of search schemes (partitioning the pattern and searching the
-    pieces in certain orders with given bounds on errors) can yield significant speed-ups.
-    However, finding optimal search schemes is a difficult combinatorial optimization
-    problem. Here for the first time, we propose a mixed integer program (MIP) capable
-    to solve this optimization problem for Hamming distance with given number of pieces.
-    Our experiments show that the optimal search schemes found by our MIP significantly
-    improve the performance of search in bidirectional FM-index upon previous ad-hoc
-    solutions. For example, approximate matching of 101-bp Illumina reads (with two
-    errors) becomes 35 times faster than standard backtracking. Moreover, despite
-    being performed purely in the index, the running time of search using our optimal
-    schemes (for up to two errors) is comparable to the best state-of-the-art aligners,
-    which benefit from combining search in index with in-text verification using dynamic
-    programming. As a result, we anticipate a full-fledged aligner that employs an
-    intelligent combination of search in the bidirectional FM-index using our optimal
-    search schemes and in-text verification using dynamic programming outperforms
-    today's best aligners. The development of such an aligner, called FAMOUS (Fast
-    Approximate string Matching using OptimUm search Schemes), is ongoing as our future
-    work.
-  eprintid: 2284
-  refereed: 'FALSE'
-  id_number: doi:10.1101/301085
-  metadata_visibility: show
-  date_type: published
-  full_text_status: none
-  dir: disk0/00/00/22/84
-  eprint_status: archive
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  date: '2018-04-14'
-- publisher: Dagstuhl LIPIcs
-  rev_number: 8
-  editors:
-  - name:
-      lineage:
-      given: Russell
-      honourific:
-      family: Schwartz
-  - name:
-      honourific:
-      given: Knut
-      family: Reinert
-      lineage:
-  status_changed: '2017-11-23 12:21:14'
-  official_url: http://drops.dagstuhl.de/opus/volltexte/2017/7635/
-  uri: http://publications.imp.fu-berlin.de/id/eprint/2133
-  lastmod: '2017-11-23 12:21:14'
-  ispublished: pub
-  pages: 14
-  dir: disk0/00/00/21/33
-  eprint_status: archive
-  divisions:
-  - group_algbioinf
-  pagerange: 185(13:1)-198(13:14)
-  number: 88
-  date_type: published
-  metadata_visibility: show
-  id_number: 'DOI: 10.4230/LIPIcs.WABI.2017.13'
-  datestamp: '2017-11-23 12:21:14'
-  related_url:
-  - url: http://www.dagstuhl.de/dagpub/978-3-95977-050-7
-  creators:
-  - name:
-      family: Kim
-      honourific:
-      given: Jongkyu
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: Knut
-      family: Reinert
-  type: book_section
-  userid: 132
-  abstract: "Motivation: Comprehensive identification of structural variations
-    (SVs) is a crucial task for studying genetic diversity and diseases. However,
-    it remains challenging. There is only a marginal consensus between different methods,
-    and our understanding of SVs is substantially limited.In general, integration
-    of multiple pieces of evidence including split-read, read-pair, soft-clip, and
-    read-depth yields the best result regarding accuracy. However, doing this step
-    by step is usually cumbersome and computationally expensive. Result: We
-    present Vaquita, an accurate and fast tool for the identification of structural
-    variations, which leverages all four types of evidence in a single program. After
-    merging SVs from split-reads and discordant read-pairs, Vaquita realigns the soft-clipped
-    reads to the selected regions using a fast bit-vector algorithm. Furthermore,
-    it also considers the discrepancy of depth distribution around breakpoints using
-    Kullback-Leibler divergence. Finally, Vaquita provides an additional metric for
-    candidate selection based on voting, and also provides robust prioritization based
-    on rank aggregation. We show that Vaquita is robust in terms of sequencing coverage,
-    insertion size of the library, and read length, and is comparable or even better
-    for the identification of deletions, inversions, duplications, and translocations
-    than state-of-the-art tools, using both simulated and real datasets. In addition,
-    Vaquita is more than eight times faster than any other tools in comparison. Availability:
-    Vaquita is implemented in C++ using the SeqAn library. The source code is
-    distributed under the BSD license and can be downloaded at http://github.com/seqan/vaquita"
-  title: 'Vaquita: Fast and Accurate Identification of Structural Variation Using
-    Combined Evidence'
-  isbn: 978-3-95977-050-7
-  book_title: 17th International Workshop on Algorithms in Bioinformatics (WABI 2017)
-  subjects:
-  - G400
-  place_of_pub: Saarbrücken/Wadern
-  date: 2017-08
-  refereed: 'TRUE'
-  eprintid: 2133
-  full_text_status: none
-  series: LIPICS
-- item_issues_count: 0
-  metadata_visibility: show
-  full_text_status: none
-  refereed: 'TRUE'
-  eprintid: 371
-  pagerange: 840-856
-  date: 2007
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  volume: 155
-  eprint_status: archive
-  dir: disk0/00/00/03/71
-  ispublished: pub
-  lastmod: '2017-03-03 14:40:14'
-  uri: http://publications.imp.fu-berlin.de/id/eprint/371
-  title: Integer Linear Programming Approaches for Non-unique Probe Selection
-  status_changed: '2009-03-11 11:27:10'
-  userid: 1
-  type: article
-  rev_number: 3
-  creators:
-  - name:
-      lineage:
-      family: Klau
-      honourific:
-      given: G. W.
-  - name:
-      lineage:
-      family: Rahmann
-      honourific:
-      given: S.
-  - name:
-      family: Schliep
-      honourific:
-      given: A.
-      lineage:
-  - name:
-      lineage:
-      given: M.
-      honourific:
-      family: Vingron
-  - name:
-      lineage:
-      family: Reinert
-      honourific:
-      given: K.
-  publication: Discrete Applied Mathematics
-  datestamp: '2017-03-03 14:40:14'
-- ispublished: pub
-  lastmod: '2017-03-03 14:40:14'
-  uri: http://publications.imp.fu-berlin.de/id/eprint/372
-  event_title: "Proceedings of the Twelfth International Conference on IntelligentSystems
-    for Molecular Biology (ISMB-04)"
-  creators:
-  - name:
-      lineage:
-      honourific:
-      given: G. W.
-      family: Klau
-  - name:
-      family: Rahmann
-      given: S.
-      honourific:
-      lineage:
-  - name:
-      honourific:
-      given: A.
-      family: Schliep
-      lineage:
-  - name:
-      lineage:
-      given: K.
-      honourific:
-      family: Reinert
-  datestamp: '2017-03-03 14:40:14'
-  status_changed: '2009-03-11 11:27:11'
-  title: Optimal Robust Non-Unique Probe Selection Using Integer Linear Programming
-  rev_number: 3
-  type: conference_item
-  userid: 1
-  refereed: 'TRUE'
-  eprintid: 372
-  item_issues_count: 0
-  full_text_status: none
-  metadata_visibility: show
-  eprint_status: archive
-  dir: disk0/00/00/03/72
-  date: 2004
-  pagerange: 186-193
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-- lastmod: '2017-03-03 14:40:14'
-  ispublished: pub
-  uri: http://publications.imp.fu-berlin.de/id/eprint/373
-  creators:
-  - name:
-      lineage:
-      family: Klein
-      honourific:
-      given: C. L.
-  - name:
-      lineage:
-      honourific:
-      given: O.
-      family: Kohlbacher
-  - name:
-      given: K.
-      honourific:
-      family: Reinert
-      lineage:
-  datestamp: '2017-03-03 14:40:14'
-  publication: FEBS Journal
-  status_changed: '2009-03-11 11:27:11'
-  title: "Reference methods and materials in standardisation and quality assurance(abstract)"
-  rev_number: 3
-  type: article
-  userid: 1
-  number: Supplement 1
-  eprintid: 373
-  refereed: 'TRUE'
-  item_issues_count: 0
-  full_text_status: none
-  metadata_visibility: show
-  eprint_status: archive
-  dir: disk0/00/00/03/73
-  date: 2005
-  pagerange: 490-504
-  volume: 272
-  subjects:
-  - G400
-  divisions:
-  - group_algbioinf
-- divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  date: 2006
-  dir: disk0/00/00/03/75
-  eprint_status: archive
-  metadata_visibility: show
-  full_text_status: none
-  item_issues_count: 0
-  refereed: 'TRUE'
-  eprintid: 375
-  userid: 1
-  type: conference_item
-  rev_number: 3
-  title: TOPP - The OpenMS Proteomics Pipeline
-  status_changed: '2009-03-11 11:27:12'
-  abstract: "Motivation: Experimental techniques in proteomics have seen rapiddevelopment
-    over the last few years. Volume and complexity of thedata have both been
-    growing at a similar rate. Accordingly, datamanagement and analysis are
-    one of the major challenges in proteomics.Flexible algorithms are required
-    to handle changing experimentalsetups and to assist in developing and validating
-    new methods. Inorder to facilitate these studies, it would be desirable
-    to havea flexible `toolbox' of versatile and user-friendly applicationsallowing
-    for rapid construction of computational workflows in proteomics.Results:
-    We describe a set of tools for proteomics data analysis-- TOPP, The OpenMS
-    Proteomics Pipeline. TOPP provides a set of computationaltools which can
-    be easily combined into analysis pipelines even bynon-experts and can be
-    used in proteomics workflows. These applicationsrange from useful utilities
-    (file format conversion, peak picking)over wrapper applications for known
-    applications (e.g. Mascot) tocompletely new algorithmic techniques for data
-    reduction and dataanalysis. We anticipate that TOPP will greatly facilitate
-    rapid prototypingof proteomics data evaluation pipelines. As such, we describe
-    thebasic concepts and the current abilities of TOPP and illustrate theseconcepts
-    in the context of two example applications: the identificationof peptides
-    from a raw data set through database search and the complexanalysis of a
-    standard addition experiment for the absolute quantitationof biomarkers.
-    The latter example demonstrates TOPP's ability toconstruct flexible analysis
-    pipelines in support of complex experimentalsetups. Availability: The TOPP
-    components are available as open-sourcesoftware under the lesser GNU public
-    license (LGPL). Source codeis available from the project web site at www.OpenMS.de"
-  datestamp: '2009-04-14 14:25:23'
-  creators:
-  - name:
-      family: Kohlbacher
-      given: O.
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      family: Reinert
-      honourific:
-      given: K.
-  - name:
-      family: Gröpl
-      honourific:
+      family: Bielow
       given: C.
-      lineage:
-  - name:
-      family: Lange
-      given: E.
-      honourific:
-      lineage:
-  - name:
-      family: Pfeiffer
-      given: N.
-      honourific:
-      lineage:
-  - name:
-      family: Schulz-Trieglaff
-      honourific:
-      given: O.
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: M.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Bertsch
+      given: A.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
       family: Sturm
-  uri: http://publications.imp.fu-berlin.de/id/eprint/375
-  event_title: "Proceedings of the 5th European Conference on Computational Biology(ECCB
-    2006)"
-  lastmod: '2009-04-14 14:25:23'
-  ispublished: pub
-- ispublished: pub
-  lastmod: '2017-03-03 14:40:14'
-  uri: http://publications.imp.fu-berlin.de/id/eprint/374
-  status_changed: '2009-03-11 11:27:12'
-  title: "Differenzielle Proteomanalyse -- Experimentelle Methoden, AlgorithmischeHerausforderungen"
-  type: article
-  rev_number: 3
-  userid: 1
-  creators:
-  - name:
-      honourific:
-      given: O.
-      family: Kohlbacher
-      lineage:
-  - name:
-      honourific:
-      given: K.
-      family: Reinert
-      lineage:
-  publication: it -- Information technology
-  datestamp: '2017-03-03 14:40:14'
-  item_issues_count: 0
-  full_text_status: none
-  metadata_visibility: show
-  refereed: 'TRUE'
-  eprintid: 374
-  pagerange: 31-38
-  date: 2004
-  volume: 46
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  eprint_status: archive
-  dir: disk0/00/00/03/74
-- eprint_status: archive
-  dir: disk0/00/00/15/51
-  issn: 1367-4803
-  date: 2015
-  pagerange: 2963-2971
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  volume: 31
-  refereed: 'TRUE'
-  eprintid: 1551
-  number: 18
-  item_issues_count: 0
-  id_number: doi:10.1093/bioinformatics/btv309
-  metadata_visibility: show
-  date_type: published
-  full_text_status: none
-  creators:
-  - name:
-      lineage:
-      given: L.
-      honourific:
-      family: Kuchenbecker
-  - name:
-      lineage:
-      family: Nienen
-      honourific:
       given: M.
-  - name:
-      lineage:
-      honourific:
-      given: J.
-      family: Hecht
-  - name:
-      lineage:
-      honourific:
-      given: A. U.
-      family: Neumann
-  - name:
-      honourific:
-      given: N.
-      family: Babel
-      lineage:
-  - name:
-      lineage:
-      family: Reinert
-      given: K.
-      honourific:
-  - name:
-      honourific:
-      given: P. N.
-      family: Robinson
-      lineage:
-  datestamp: '2015-06-02 12:53:46'
-  publication: Bioinformatics
-  title: IMSEQ - a fast and error aware approach to immunogenetic sequence analysis
-  status_changed: '2016-02-25 11:24:07'
-  abstract: "Motivation: Recombined T and B cell receptor repertoires are increasingly
-    being studied using next generation sequencing (NGS) in order to interrogate the
-    repertoire composition as well as changes in the distribution of receptor clones
-    under different physiological and disease states. This type of analysis requires
-    efficient and unambiguous clonotype assignment to a large number of NGS read sequences,
-    including the identification of the incorporated V and J gene segments and the
-    CDR3 sequence. Current tools have deficits with respect to performance, accuracy
-    and documentation of their underlying algorithms and usage.Results: We
-    present IMSEQ, a method to derive clonotype repertoires from next generation sequencing
-    data with sophisticated routines for handling errors stemming from PCR and sequencing
-    artefacts. The application can handle different kinds of input data originating
-    from single- or paired-end sequencing in different configurations and is generic
-    regarding the species and gene of interest. We have carefully evaluated our method
-    with simulated and real world data and show that IMSEQ is superior to other tools
-    with respect to its clonotyping as well as standalone error correction and runtime
-    performance.Availability: IMSEQ was implemented in C++ using the SeqAn
-    library for efficient sequence analysis. It is freely available under the GPLv2
-    open source license and can be downloaded at www.imtools.org. "
-  userid: 132
-  type: article
-  publisher: Oxford University Press (online advanced access)
-  rev_number: 11
-  official_url: http://dx.doi.org/10.1093/bioinformatics/btv309
-  ispublished: pub
-  lastmod: '2016-02-25 11:24:07'
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1551
-- datestamp: '2009-03-11 17:18:04'
-  creators:
-  - name:
-      lineage:
-      given: E.
-      honourific:
-      family: Lange
-  type: other
-  rev_number: 3
-  userid: 1
-  status_changed: '2009-03-11 11:26:54'
-  abstract: "High throughput analysis of proteins using mass spectrometry requiresan
-    efficient signal preprocessing which reduces the amount of datawith minimal
-    loss of information. Therefore the peaks that belongto a peptide have to
-    be detected, and important features like theirpeak centroid position, the
-    height and the area have to be determined.Here we present a peak picking
-    algorithm which detects peaks in anoisy mass spectrum using its continuous
-    wavelet transform. By adaptingthe wavelet to the theoretical peak shape,
-    each peaks centroid positionis precisely identified; thus, overlapping peaks
-    (e.g. caused byelectronspray ionization) are well separated. Representing
-    each peaknot only by its centroid position and area but also by the parametersof
-    the best fitting asymmetric lorentzian or hyperbolic secant squaredfunctions,
-    yields valuable information about the original peak shapefor further analysis.
-    Given a mass spectrum with 100,000 raw datapoints representing 200 peaks,
-    our algorithm stored 5 parametersper peak, and was able to reduce the memory
-    requirement down to 1percent."
-  title: Peak picking in mass spectra
-  uri: http://publications.imp.fu-berlin.de/id/eprint/344
-  ispublished: pub
-  lastmod: '2009-03-11 17:18:04'
-  dir: disk0/00/00/03/44
-  eprint_status: archive
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  date: 2004
-  eprintid: 344
-  refereed: 'TRUE'
-  full_text_status: none
-  metadata_visibility: show
-  item_issues_count: 0
-- creators:
-  - name:
-      honourific:
-      given: E.
-      family: Lange
-      lineage:
-  - name:
-      family: Gröpl
-      honourific:
-      given: C.
-      lineage:
-  - name:
-      given: K.
-      honourific:
-      family: Reinert
-      lineage:
-  - name:
-      lineage:
-      family: Hildebrandt
-      honourific:
-      given: A.
-  datestamp: '2009-04-14 14:22:41'
-  title: High Accuracy Peak-Picking of Proteomics Data using Wavelet Techniques
-  status_changed: '2009-03-11 11:27:13'
-  userid: 1
-  rev_number: 3
-  type: conference_item
-  lastmod: '2009-04-14 14:22:41'
-  ispublished: pub
-  event_title: Proceedings of the 11th Pacific Symposium on Biocomputing (PSB-06)
-  uri: http://publications.imp.fu-berlin.de/id/eprint/376
-  eprint_status: archive
-  dir: disk0/00/00/03/76
-  date: 2006
-  pagerange: 243-254
-  subjects:
-  - G400
-  divisions:
-  - group_algbioinf
-  eprintid: 376
-  refereed: 'TRUE'
-  item_issues_count: 0
-  metadata_visibility: show
-  full_text_status: none
-- dir: disk0/00/00/03/77
-  eprint_status: archive
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  date: 2005
-  refereed: 'TRUE'
-  eprintid: 377
-  full_text_status: none
-  metadata_visibility: show
-  item_issues_count: 0
-  datestamp: '2009-04-14 14:33:24'
-  creators:
-  - name:
-      family: Lange
-      given: E.
-      honourific:
-      lineage:
-  - name:
-      family: Gröpl
-      given: C.
-      honourific:
-      lineage:
-  - name:
-      family: Reinert
-      honourific:
-      given: K.
-      lineage:
-  - name:
-      lineage:
-      given: A.
-      honourific:
-      family: Hildebrandt
-  rev_number: 3
-  publisher: Dagstuhl Online Publication Server (DROPS)
-  type: conference_item
-  userid: 1
-  status_changed: '2009-03-11 11:27:14'
-  title: High-accuracy peak picking of proteomics data
-  official_url: http://www.dagstuhl.de/05471/
-  event_title: Computational Proteomics
-  uri: http://publications.imp.fu-berlin.de/id/eprint/377
-  lastmod: '2009-04-14 14:33:24'
-  ispublished: pub
-  note: "Extended abstract for talk given at Dagstuhl Seminar 05471 on ComputationalProteomics,
-    20.-25. November 2005"
-- event_title: "Proceedings of the 15th Annual International Conference on IntelligentSystems
-    for Molecular Biology (ISMB) &amp; 6th European Conference on Computational
-    Biology (ECCB)"
-  userid: 132
-  type: article
-  title: "A Geometric Approach for the Alignment of Liquid Chromatography-MassSpectrometry
-    Data"
-  abstract: "Motivation: Liquid chromatography coupled to mass spectrometry (LC-MS)
-    and combined with tandem mass spectrometry (LC-MS/MS) have become a prominent
-    tool for the analysis of complex proteomic samples. An important step in a typical
-    workflow is the combination of results from multiple LC-MS experiments to improve
-    confidence in the obtained measurements or to compare results from different samples.
-    To do so, a suitable mapping or alignment between the data sets needs to be estimated.
-    The alignment has to correct for variations in mass and elution time which are
-    present in all mass spectrometry experiments. Results: We propose a novel
-    algorithm to align LC-MS samples and to match corresponding ion species across
-    samples. Our algorithm matches landmark signals between two data sets using a
-    geometric technique based on pose clustering. Variations in mass and retention
-    time are corrected by an affine dewarping function estimated from matched landmarks.
-    We use the pairwise dewarping in an algorithm for aligning multiple samples. We
-    show that our pose clustering approach is fast and reliable as compared to previous
-    approaches. It is robust in the presence of noise and able to accurately align
-    samples with only few common ion species. In addition, we can easily handle different
-    kinds of LC-MS data and adopt our algorithm to new mass spectrometry technologies.
-    Availability: This algorithm is implemented as part of the OpenMS software
-    library for shotgun proteomics and available under the Lesser GNU Public License
-    (LGPL) at www.openms.de"
-  datestamp: '2012-04-10 14:34:51'
-  creators:
-  - id:
-    name:
-      lineage:
-      honourific:
-      given: E.
-      family: Lange
-  - name:
-      honourific:
-      given: C.
-      family: Gröpl
-      lineage:
-    id:
-  - name:
-      honourific:
-      given: O.
-      family: Schulz-Trieglaff
-      lineage:
-    id:
-  - name:
-      lineage:
-      family: Leinenbach
-      given: A.
-      honourific:
-    id:
-  - name:
-      lineage:
-      given: Ch.
-      honourific:
-      family: Huber
-    id:
+      honourific: null
+      lineage: null
   - id: knut.reinert@fu-berlin.de
     name:
-      lineage:
-      given: K.
-      honourific:
-      family: Reinert
-  succeeds: 378
-  full_text_status: none
-  refereed: 'TRUE'
-  eprintid: 1133
-  subjects:
-  - G400
-  date: 2007
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1133
-  lastmod: '2012-04-10 14:34:51'
-  ispublished: pub
-  official_url: http://bioinformatics.oxfordjournals.org/content/23/13/i273.long
-  publisher: Oxford University Press
-  rev_number: 7
-  status_changed: '2012-04-10 14:34:51'
-  publication: Oxford Journals
-  id_number: 'doi: 10.1093/bioinformatics/btm209'
-  metadata_visibility: show
-  date_type: published
-  item_issues_count: 0
-  number: 13
-  divisions:
-  - group_algbioinf
-  volume: 23
-  pagerange: i273-i281
-  dir: disk0/00/00/11/33
-  issn: 1460-2059 (online), 1367-4803 (print)
-  eprint_status: archive
-- creators:
-  - name:
-      family: Lange
-      given: E.
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      family: Tautenhahn
-      honourific:
-      given: R.
-  - name:
-      family: Neumann
-      honourific:
-      given: S.
-      lineage:
-  - name:
-      lineage:
-      family: Gröpl
-      given: C.
-      honourific:
-  datestamp: '2009-04-14 14:12:16'
-  publication: BMC Bioinformatics
-  status_changed: '2009-03-11 11:27:15'
-  title: "Critical assessment of alignment procedures for LC-MS proteomicsand metabolomic
-    measurements"
-  rev_number: 3
-  type: article
-  userid: 1
-  official_url: http://www.biomedcentral.com/1471-2105/9/375
-  ispublished: pub
-  lastmod: '2009-04-14 14:12:16'
-  uri: http://publications.imp.fu-berlin.de/id/eprint/379
-  eprint_status: archive
-  dir: disk0/00/00/03/79
-  date: 2008
-  volume: 9
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  number: 375
-  refereed: 'TRUE'
-  eprintid: 379
-  item_issues_count: 0
-  full_text_status: none
-  metadata_visibility: show
-- divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  volume: 15
-  pagerange: 203-210
-  date: 1999
-  dir: disk0/00/00/03/81
-  eprint_status: archive
-  metadata_visibility: show
-  full_text_status: none
-  item_issues_count: 0
-  eprintid: 381
-  refereed: 'TRUE'
-  number: 3
-  userid: 1
-  type: article
-  rev_number: 3
-  title: "An exact solution for the segment-to-segment multiple sequence alignmentproblem"
-  status_changed: '2009-03-11 11:27:16'
-  datestamp: '2017-03-03 14:40:14'
-  publication: BIOINFORMATICS
-  creators:
-  - name:
-      lineage:
-      given: H.-P.
-      honourific:
-      family: Lenhof
-  - name:
-      family: Morgenstern
-      given: B.
-      honourific:
-      lineage:
-  - name:
-      given: K.
-      honourific:
-      family: Reinert
-      lineage:
-  uri: http://publications.imp.fu-berlin.de/id/eprint/381
-  ispublished: pub
-  lastmod: '2017-03-03 14:40:14'
-- datestamp: '2017-03-03 14:40:14'
-  publication: Journal of Computational Biology
-  creators:
-  - name:
-      lineage:
-      honourific:
-      given: H.-P.
-      family: Lenhof
-  - name:
-      given: K.
-      honourific:
-      family: Reinert
-      lineage:
-  - name:
-      lineage:
-      given: M.
-      honourific:
-      family: Vingron
-  type: article
-  rev_number: 3
-  userid: 1
-  status_changed: '2009-03-11 11:27:16'
-  title: A Polyhedral Approach to RNA Sequence Structure Alignment
-  uri: http://publications.imp.fu-berlin.de/id/eprint/382
-  lastmod: '2017-03-03 14:40:14'
-  ispublished: pub
-  dir: disk0/00/00/03/82
-  eprint_status: archive
-  volume: 5
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  date: 1998
-  pagerange: 517-530
-  number: 3
-  refereed: 'TRUE'
-  eprintid: 382
-  full_text_status: none
-  metadata_visibility: show
-  item_issues_count: 0
-- datestamp: '2010-11-02 13:46:49'
-  creators:
-  - name:
-      lineage:
-      given: H.-P.
-      honourific:
-      family: Lenhof
-  - name:
       family: Reinert
       given: K.
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      given: M.
-      honourific:
-      family: Vingron
-  userid: 1
-  rev_number: 5
-  type: conference_item
-  title: A polyhedral approach to RNA sequence structure alignment
-  status_changed: '2010-11-02 13:46:56'
-  event_title: "Proceedings of the Second Annual International Conference on ComputationalMolecular
-    Biology (RECOMB-98)"
-  uri: http://publications.imp.fu-berlin.de/id/eprint/380
-  lastmod: '2010-11-02 13:46:56'
-  ispublished: pub
-  dir: disk0/00/00/03/80
-  eprint_status: archive
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  pagerange: 153-162
-  date: 1998
-  refereed: 'TRUE'
-  eprintid: 380
-  metadata_visibility: show
-  full_text_status: none
-  item_issues_count: 0
-- eprint_status: archive
-  dir: disk0/00/00/03/83
-  date: 2000
-  pagerange: 655-671
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  refereed: 'TRUE'
-  eprintid: 383
-  item_issues_count: 0
-  metadata_visibility: show
-  full_text_status: none
-  creators:
-  - name:
-      lineage:
-      honourific:
-      given: M.
-      family: Lermen
-  - name:
-      given: K.
-      honourific:
-      family: Reinert
-      lineage:
-  datestamp: '2017-03-03 14:40:14'
-  publication: Journal of Computational Biology
-  title: "The Practical Use of the A* Algorithm for Exact Multiple SequenceAlignment"
-  status_changed: '2009-03-11 11:27:17'
-  userid: 1
-  type: article
-  rev_number: 3
-  ispublished: pub
-  lastmod: '2017-03-03 14:40:14'
-  uri: http://publications.imp.fu-berlin.de/id/eprint/383
-- official_url: http://dx.doi.org/10.1093/bib/bbw089
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1981
-  lastmod: '2018-11-08 12:31:04'
-  ispublished: pub
-  datestamp: '2016-11-17 12:32:39'
-  publication: Briefings in Bioinformatics
-  creators:
-  - name:
-      lineage:
-      family: Marschall
-      given: T.
-      honourific:
-    id:
-  - name:
-      lineage:
-      given: K.
-      honourific:
-      family: Reinert
-    id: knut.reinert@fu-berlin.de
-  - name:
-      lineage:
-      family: others
-      given: "(59 authors in total)"
-      honourific:
-    id:
-  publisher: Oxford University Press
-  type: article
-  rev_number: 17
-  userid: 132
-  abstract: Many disciplines, from human genetics and oncology to plant breeding,
-    microbiology and virology, commonly face the challenge of analyzing rapidly increasing
-    numbers of genomes. In case of Homo sapiens, the number of sequenced genomes will
-    approach hundreds of thousands in the next few years. Simply scaling up established
-    bioinformatics pipelines will not be sufficient for leveraging the full potential
-    of such rich genomic data sets. Instead, novel, qualitatively different computational
-    methods and paradigms are needed. We will witness the rapid extension of computational
-    pan-genomics, a new sub-area of research in computational biology. In this article,
-    we generalize existing definitions and understand a pan-genome as any collection
-    of genomic sequences to be analyzed jointly or to be used as a reference. We examine
-    already available approaches to construct and use pan-genomes, discuss the potential
-    benefits of future technologies and methodologies and review open challenges from
-    the vantage point of the above-mentioned biological disciplines. As a prominent
-    example for a computational paradigm shift, we particularly highlight the transition
-    from the representation of reference genomes as strings to representations as
-    graphs. We outline how this and other challenges from different application domains
-    translate into common computational problems, point out relevant bioinformatics
-    techniques and identify open problems in computer science. With this review, we
-    aim to increase awareness that a joint approach to computational pan-genomics
-    can help address many of the problems currently faced in various domains.
-  status_changed: '2018-11-08 12:31:04'
-  title: 'Computational pan-genomics: status, promises and challenges'
-  number: 1
-  refereed: 'TRUE'
-  eprintid: 1981
-  date_type: published
-  full_text_status: none
-  id_number: doi:10.1093/bib/bbw089
-  metadata_visibility: show
-  item_issues_count: 0
-  issn: 1467-5463 (Print), 1477-4054 (Online)
-  dir: disk0/00/00/19/81
-  eprint_status: archive
-  volume: 19
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  date: '2018-01-01'
-  pagerange: 118-135
-- refereed: 'TRUE'
-  eprintid: 384
-  full_text_status: none
-  metadata_visibility: show
-  item_issues_count: 0
-  series: LNBI
-  dir: disk0/00/00/03/84
-  eprint_status: archive
-  volume: 4360
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  date: 2007
-  pagerange: 19-32
-  uri: http://publications.imp.fu-berlin.de/id/eprint/384
-  event_title: Proc. of GCCB 2006
-  lastmod: '2017-03-03 14:40:14'
-  ispublished: pub
-  datestamp: '2017-03-03 14:40:14'
-  creators:
-  - name:
-      lineage:
-      honourific:
-      given: P.
-      family: May
-  - name:
-      lineage:
-      honourific:
-      given: G. W.
-      family: Klau
-  - name:
-      lineage:
-      honourific:
-      given: M.
-      family: Bauer
-  - name:
-      family: Steinke
-      honourific:
-      given: T.
-      lineage:
-  rev_number: 3
-  type: conference_item
-  userid: 1
-  status_changed: '2009-03-11 11:27:17'
-  title: "Accelerated microRNA Precursor Detection Using the Smith-WatermanAlgorithm
-    on FPGAs"
-- title: "Absolute Myoglobin Quantitation in Serum by Combining Two-DimensionalLiquid
-    Chromatography-Electrospray Ionization Mass Spectrometry andNovel Data Analysis
-    Algorithms"
-  status_changed: '2009-03-11 11:27:18'
-  userid: 1
-  rev_number: 3
-  type: article
-  creators:
-  - name:
-      honourific:
-      given: B. M.
-      family: Mayr
-      lineage:
-  - name:
-      lineage:
-      given: O.
-      honourific:
+      honourific: null
+      lineage: null
+  - id: null
+    name:
       family: Kohlbacher
-  - name:
-      family: Reinert
-      honourific:
-      given: K.
-      lineage:
-  - name:
-      lineage:
-      given: C.
-      honourific:
-      family: Gröpl
-  - name:
-      lineage:
-      family: Lange
-      honourific:
-      given: E.
-  - name:
-      lineage:
-      given: C. L.
-      honourific:
-      family: Klein
-  - name:
-      lineage:
-      given: Ch.
-      honourific:
-      family: Huber
-  publication: Journal of Proteome Research
-  datestamp: '2009-04-14 14:21:42'
-  lastmod: '2009-04-14 14:21:42'
-  ispublished: pub
-  uri: http://publications.imp.fu-berlin.de/id/eprint/385
-  date: 2006
-  pagerange: 414-421
-  subjects:
-  - G400
-  divisions:
-  - group_algbioinf
-  volume: 5
-  eprint_status: archive
-  dir: disk0/00/00/03/85
-  item_issues_count: 0
-  metadata_visibility: show
-  full_text_status: none
-  refereed: 'TRUE'
-  eprintid: 385
-- subjects:
-  - G400
-  divisions:
-  - group_algbioinf
-  date: 2007-06
-  dir: disk0/00/00/03/86
-  eprint_status: archive
-  full_text_status: none
-  metadata_visibility: show
-  item_issues_count: 0
-  refereed: 'TRUE'
-  eprintid: 386
-  type: other
-  rev_number: 3
-  userid: 1
-  status_changed: '2009-03-11 11:27:18'
-  title: "Bioinformatik: Aktuelle Proteinausstattung erlaubt Aussagenüber den Gesundheitszustand.
-    Software hilft Ärzten künftigbei der Diagnose."
-  datestamp: '2017-03-03 14:40:14'
-  creators:
-  - name:
-      lineage:
-      family: Meier
-      given: Ch.
-      honourific:
-  uri: http://publications.imp.fu-berlin.de/id/eprint/386
-  lastmod: '2017-03-03 14:40:14'
-  ispublished: pub
-  note: "Der Artikel eines freien Medienjournalisten beschreibt den Einsatzvon OpenMS
-    in der Proteomik"
-- date_type: published
-  full_text_status: none
-  metadata_visibility: show
-  id_number: 'DOI: 10.4230/DagRep.6.8.91'
-  eprintid: 2134
-  place_of_pub: Dagstuhl, Germany
-  date: 2017
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  eprint_status: archive
-  dir: disk0/00/00/21/34
-  ispublished: pub
-  lastmod: '2017-11-23 13:19:47'
-  pages: 40
-  uri: http://publications.imp.fu-berlin.de/id/eprint/2134
-  official_url: http://drops.dagstuhl.de/opus/volltexte/2017/6839
-  abstract: Next Generation Sequencing (NGS) data have begun to appear in many applications
-    that are clinically relevant, such as resequencing of cancer patients, disease-gene
-    discovery and diagnostics for rare diseases, microbiome analyses, and gene expression
-    profiling. The analysis of sequencing data is demanding because of the enormous
-    data volume and the need for fast turnaround time, accuracy, reproducibility,
-    and data security. This Dagstuhl Seminar aimed at a free and deep exchange of
-    ideas and needs between the communities of algorithmicists and theoreticians and
-    practitioners from the biomedical field. It identified several relevant fields
-    such as data structures and algorithms for large data sets, hardware acceleration,
-    new problems in the upcoming age of genomes, etc. which were discussed in breakout
-    groups.
-  status_changed: '2017-11-23 13:19:47'
-  title: 'Dagstuhl Reports, Vol. 6, No. 8, pp. 91-130: Next Generation Sequencing
-    (Dagstuhl Seminar 16351)'
-  rev_number: 6
-  publisher: Schloss Dagstuhl--Leibniz-Zentrum fuer Informatik
-  type: monograph
-  userid: 132
-  creators:
-  - name:
-      family: Meyers
-      given: Gene
-      honourific:
-      lineage:
-  - name:
-      family: Pop
-      honourific:
-      given: Mihai
-      lineage:
-  - name:
-      lineage:
-      family: Reinert
-      given: Knut
-      honourific:
-  - name:
-      given: Tandy
-      honourific:
-      family: Warnow
-      lineage:
-  datestamp: '2017-11-23 13:19:47'
-  monograph_type: documentation
-- rev_number: 4
-  type: article
-  userid: 1
-  status_changed: '2009-03-11 11:27:19'
-  abstract: The high degree of similarity between the mouse and human genomes is demonstrated
-    through analysis of the sequence of mouse chromosome 16 (Mmu 16), which was obtained
-    as part of a whole-genome shotgun assembly of the mouse genome. The mouse genome
-    is about 10% smaller than the human genome, owing to a lower repetitive DNA content.
-    Comparison of the structure and protein-coding potential of Mmu 16 with that of
-    the homologous segments of the human genome identifies regions of conserved synteny
-    with human chromosomes (Hsa) 3, 8, 12, 16, 21, and 22. Gene content and order
-    are highly conserved between Mmu 16 and the syntenic blocks of the human genome.
-    Of the 731 predicted genes on Mmu 16, 509 align with orthologs on the corre- sponding
-    portions of the human genome, 44 are likely paralogous to these genes, and 164
-    genes have homologs elsewhere in the human genome; there are 14 genes for which
-    we could find no human counterpart.
-  title: "A Comparison of Whole-Genome Shotgun-Derived Mouse Chromosome 16and the
-    Human Genome"
-  datestamp: '2009-11-24 15:48:00'
-  publication: Science
-  creators:
-  - name:
-      lineage:
-      honourific:
-      given: Richard
-      family: Mural
-  - name:
-      family: Adams
-      given: M. D.
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      given: K.
-      honourific:
-      family: Reinert
-  uri: http://publications.imp.fu-berlin.de/id/eprint/387
-  ispublished: pub
-  lastmod: '2009-11-24 15:49:20'
-  volume: 296
-  subjects:
-  - G400
-  divisions:
-  - group_algbioinf
-  date: 2002
-  pagerange: 1661-1671
-  dir: disk0/00/00/03/87
-  eprint_status: archive
-  full_text_status: none
-  metadata_visibility: show
-  item_issues_count: 0
-  eprintid: 387
-  refereed: 'TRUE'
-- volume: 287
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  date: 2000
-  pagerange: 2196-2203
-  dir: disk0/00/00/03/88
-  eprint_status: archive
-  full_text_status: none
-  metadata_visibility: show
-  item_issues_count: 0
-  number: 5461
-  eprintid: 388
-  refereed: 'TRUE'
-  type: article
-  rev_number: 3
-  userid: 1
-  status_changed: '2009-03-11 11:27:20'
-  title: A Whole-Genome Assembly of Drosophila
-  datestamp: '2009-04-03 12:23:26'
-  publication: Science
-  creators:
-  - name:
-      lineage:
-      given: E. W.
-      honourific:
-      family: Myers
-  - name:
-      lineage:
-      honourific:
-      given: G. G.
-      family: Sutton
-  - name:
-      given: A. L.
-      honourific:
-      family: Delcher
-      lineage:
-  - name:
-      lineage:
-      given: D. P.
-      honourific:
-      family: Dew
-  - name:
-      lineage:
-      honourific:
-      given: M. J.
-      family: Flanigan
-  - name:
-      family: Kravitz
-      given: S. A.
-      honourific:
-      lineage:
-  - name:
-      family: Mobarry
-      honourific:
-      given: C. M.
-      lineage:
-  - name:
-      family: Reinert
-      given: K.
-      honourific:
-      lineage:
-  - name:
-      honourific:
-      given: K. A.
-      family: Remington
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: E. L.
-      family: Anson
-  - name:
-      lineage:
-      family: Bolanos
-      honourific:
-      given: R.
-  - name:
-      family: Chou
-      given: H.-H.
-      honourific:
-      lineage:
-  - name:
-      honourific:
-      given: C. M.
-      family: Jordan
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: A. L.
-      family: Halpern
-  - name:
-      lineage:
-      honourific:
-      given: S.
-      family: Lonardi
-  - name:
-      honourific:
-      given: E. M.
-      family: Beasly
-      lineage:
-  - name:
-      family: Brandon
-      given: R. C.
-      honourific:
-      lineage:
-  - name:
-      honourific:
-      given: L.
-      family: Chen
-      lineage:
-  - name:
-      lineage:
-      family: Dunn
-      honourific:
-      given: P. J.
-  - name:
-      lineage:
-      given: Z.
-      honourific:
-      family: Lai
-  - name:
-      lineage:
-      honourific:
-      given: Y.
-      family: Liang
-  - name:
-      lineage:
-      family: Nusskern
-      honourific:
-      given: D. R.
-  - name:
-      lineage:
-      family: Zhan
-      honourific:
-      given: M.
-  - name:
-      lineage:
-      family: Zhang
-      honourific:
-      given: Q.
-  - name:
-      lineage:
-      honourific:
-      given: X. H.
-      family: Zheng
-  - name:
-      lineage:
-      family: Rubin
-      honourific:
-      given: G. M.
-  - name:
-      lineage:
-      family: Adams
-      given: M. D.
-      honourific:
-  - name:
-      given: J. C.
-      honourific:
-      family: Venter
-      lineage:
-  uri: http://publications.imp.fu-berlin.de/id/eprint/388
-  lastmod: '2009-04-03 12:23:26'
-  ispublished: pub
-  keywords: ASSEMBLY
-- eprintid: 1473
-  refereed: 'TRUE'
-  number: 3
-  metadata_visibility: show
-  id_number: doi:10.1074/mcp.R112.025163
-  date_type: published
-  full_text_status: none
-  item_issues_count: 0
-  dir: disk0/00/00/14/73
-  issn: 1535-9476
-  eprint_status: archive
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  volume: 12
-  pagerange: 549-556
-  date: '2013-03-01'
-  official_url: http://dx.doi.org/10.1074/mcp.R112.025163
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1473
-  ispublished: pub
-  lastmod: '2014-12-09 12:32:07'
-  publication: Molecular & Cellular Proteomics
-  datestamp: '2014-12-09 12:32:07'
-  creators:
-  - name:
-      lineage:
-      family: Nahnsen
-      honourific:
-      given: S.
-  - name:
-      lineage:
-      given: C.
-      honourific:
-      family: Bielow
-  - name:
-      given: K.
-      honourific:
-      family: Reinert
-      lineage:
-  - name:
-      lineage:
-      honourific:
       given: O.
-      family: Kohlbacher
-  userid: 132
-  rev_number: 7
-  type: article
-  title: Tools for Label-free Peptide Quantification
-  abstract: The increasing scale and complexity of quantitative proteomics studies
-    complicate subsequent analysis of the acquired data. Untargeted label-free quantification,
-    based either on feature intensities or on spectral counting, is a method that
-    scales particularly well with respect to the number of samples. It is thus an
-    excellent alternative to labeling techniques. In order to profit from this scalability,
-    however, data analysis has to cope with large amounts of data, process them automatically,
-    and do a thorough statistical analysis in order to achieve reliable results. We
-    review the state of the art with respect to computational tools for label-free
-    quantification in untargeted proteomics. The two fundamental approaches are feature-based
-    quantification, relying on the summed-up mass spectrometric intensity of peptides,
-    and spectral counting, which relies on the number of MS/MS spectra acquired for
-    a certain protein. We review the current algorithmic approaches underlying some
-    widely used software packages and briefly discuss the statistical strategies for
-    analyzing the data.
-  status_changed: '2014-12-09 12:32:07'
-- eprint_status: archive
-  issn: 0003-2700
-  dir: disk0/00/00/13/97
-  date: '2013-02-08'
-  pagerange: 3309-3317
-  volume: 85
+      honourific: null
+      lineage: null
+  date: '2012-07-06'
+  date_type: published
+  datestamp: '2014-03-18 14:13:29'
+  dir: disk0/00/00/13/96
   divisions:
   - group_algbioinf
+  eprint_status: archive
+  eprintid: 1396
+  full_text_status: none
+  id_number: 'doi: 10.1021/pr300187f'
+  ispublished: pub
+  issn: 1535-3893
+  item_issues_count: 0
+  key: fu_mi_publications1396
+  lastmod: '2014-03-18 14:13:29'
+  metadata_visibility: show
+  number: 7
+  official_url: http://pubs.acs.org/doi/abs/10.1021/pr300187f
+  pagerange: 3914-3920
+  publication: J. Proteome Res.
+  publisher: ACS Publications
+  refereed: 'TRUE'
+  rev_number: 10
+  status_changed: '2014-03-18 14:13:29'
   subjects:
   - G400
-  number: 6
-  refereed: 'TRUE'
-  eprintid: 1397
-  item_issues_count: 0
-  full_text_status: none
-  date_type: published
-  id_number: doi 10.1021/ac303722j
-  metadata_visibility: show
-  creators:
-  - id:
-    name:
-      given: V.
-      honourific:
-      family: Neu
-      lineage:
-  - name:
-      lineage:
-      given: C.
-      honourific:
-      family: Bielow
-    id:
-  - name:
-      honourific:
-      given: I.
-      family: Gostomski
-      lineage:
-    id:
-  - name:
-      lineage:
-      family: Wintringer
-      given: R.
-      honourific:
-    id:
-  - id:
-    name:
-      lineage:
-      family: Braun
-      given: R.
-      honourific:
-  - name:
-      family: Reinert
-      honourific:
-      given: K.
-      lineage:
-    id: knut.reinert@fu-berlin.de
-  - name:
-      lineage:
-      family: Schneider
-      honourific:
-      given: P.
-    id:
-  - id:
-    name:
-      given: H.
-      honourific:
-      family: Stuppner
-      lineage:
-  - name:
-      lineage:
-      given: C.
-      honourific:
-      family: Huber
-    id:
-  publication: Analytical Chemistry
-  datestamp: '2014-03-18 14:56:17'
-  status_changed: '2014-03-18 14:56:17'
-  abstract: Rapid and efficient quality control according to the public authority
+  title: 'TOPPAS: a graphical workflow editor for the analysis of high-throughput
+    proteomics data'
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1396
+  userid: 132
+  volume: 11
+- abstract: Rapid and efficient quality control according to the public authority
     regulations is mandatory to guarantee safety of the pharmaceuticals and to save
     resources in the pharmaceutical industry. In the case of so-called "grandfather
     products" like the synthetic thyroid hormone thyroxine, strict regulations enforce
@@ -6740,133 +1756,126 @@
     of the method in terms of robustness and information content clearly show that
     UHPLC-HRMS is adequate for the rapid and reliable detection, identification, and
     semiquantitative determination of trace levels of impurities in synthetic pharmaceuticals.
-  title: Rapid and Comprehensive Impurity Profiling of Synthetic Thyroxine by Ultrahigh-Performance
-    Liquid Chromatography–High-Resolution Mass Spectrometry
-  type: article
-  publisher: American Chemical Society
-  rev_number: 9
-  userid: 132
-  official_url: http://pubs.acs.org/doi/abs/10.1021/ac303722j
-  ispublished: pub
-  lastmod: '2014-03-18 14:56:17'
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1397
-- date: 2014-12
-  pagerange: 196-203
-  divisions:
-  - group_algbioinf
-  subjects:
-  - C710
-  volume: 1371
-  eprint_status: archive
-  dir: disk0/00/00/14/63
-  item_issues_count: 0
-  metadata_visibility: show
-  full_text_status: none
-  date_type: published
-  eprintid: 1463
-  refereed: 'TRUE'
-  title: Ultrahigh-performance liquid chromatography-ultraviolet absorbance detection-high-resolution-mass
-    spectrometry combined with automated data processing for studying the kinetics
-    of oxidative thermal degradation of thyroxine in the solid state
-  abstract: "Received 29 June 2014Received in revised form29 September 2014Accepted
-    24 October 2014 Available online 30 October 2014Keywords:ThyroxineUltrahigh-performance
-    liquid chromatographyElectrospray ionization Orbitrap mass spectrometryKineticsDrug
-    degradationBioinformatics1. IntroductionLevothyroxine (T4) is a well-known
-    and widely used drug for the treatment of hypothyroidism. The therapy is usually
-    based on substitution of the natural hormone by a long-term treatment with synthetic
-    levothyroxine [1]. It is a narrow therapeutic index drug, for which individual
-    dosage levels of patients need to be established over several weeks. Consequently,
-    products differing in content of levothyroxine due to compound instability or
-    problems in formu- lation can lead to wrong medication and potentially cause severe
-    health problems [2,3].∗ Corresponding author. Tel.:+43 0 662 8044 5704; fax:
-    +43 0 662 8044 5751. E-mail addresses: volker.a.neu@basf.com (V. Neu), chris.bielow@fu-berlin.de
-    (C. Bielow), reinert@inf.fu-berlin.de (K. Reinert), c.huber@sbg.ac.at (C.G. Huber).http://dx.doi.org/10.1016/j.chroma.2014.10.0710021-9673/©
-    2014 Elsevier B.V. All rights reserved.abstractLevothyroxine as active
-    pharmaceutical ingredient of formulations used for the treatment of hypothy- roidism
-    is distributed worldwide and taken by millions of people. An important issue in
-    terms of compound stability is its capability to react with ambient oxygen, especially
-    in case of long term com- pound storage at elevated temperature. In this study
-    we demonstrate that ultrahigh-performance liquid chromatography coupled to UV
-    spectrometry and high-resolution mass spectrometry (UHPLC-UV-HRMS) represent very
-    useful approaches to investigate the influence of ambient oxygen on the degradation
-    kinet- ics of levothyroxine in the solid state at enhanced degradation conditions.
-    Moreover, the impurity pattern of oxidative degradation of levothyroxine is elucidated
-    and classified with respect to degradation kinetics at different oxygen levels.
-    Kinetic analysis of thyroxine bulk material at 100 ◦ C reveals bi-phasic degra-
-    dation kinetics with a distinct change in degradation phases dependent on the
-    availability of oxygen. The results clearly show that contact of the bulk material
-    to ambient oxygen is a key factor for fast compound degradation. Furthermore,
-    the combination of time-resolved HRMS data and automated data processing is shown
-    to allow insights into the kinetics and mechanism of impurity formation on individual
-    com- pound basis. By comparing degradation profiles, four main classes of profiles
-    linked to reaction pathways of thyroxine degradation were identifiable. Finally,
-    we show the capability of automated data process- ing for the matching of different
-    stressing conditions, in order to extract information about mechanistic similarities.
-    As a result, degradation kinetics is influenced by factors like availability of
-    oxygen, stressing time, or stressing temperature, while the degradation mechanisms
-    appear to be conserved."
-  status_changed: '2016-11-15 14:03:10'
-  userid: 29
-  type: article
-  rev_number: 12
+  bibtex: "@article{fu_mi_publications1397,\n abstract = {Rapid and efficient quality\
+    \ control according to the public authority regulations is mandatory to guarantee\
+    \ safety of the pharmaceuticals and to save resources in the pharmaceutical industry.\
+    \ In the case of so-called \"grandfather products\" like the synthetic thyroid\
+    \ hormone thyroxine, strict regulations enforce a detailed chemical analysis in\
+    \ order to characterize potentially toxic or pharmacologically relevant impurities.\
+    \ We report a straightforward workflow for the comprehensive impurity profiling\
+    \ of synthetic thyroid hormones and impurities employing ultrahigh-performance\
+    \ liquid chromatography (UHPLC) hyphenated to high-resolution mass spectrometry\
+    \ (HRMS). Five different batches of synthetic thyroxin were analyzed resulting\
+    \ in the detection of 71 impurities within 3 min total analysis time. Structural\
+    \ elucidation of the compounds was accomplished via a combination of accurate\
+    \ mass measurements, computer based calculations of molecular formulas, multistage\
+    \ high-resolution mass spectrometry (HRMS(n)), and nuclear magnetic resonance\
+    \ spectroscopy, which enabled the identification of 71 impurities, of which 47\
+    \ have been unknown so far. Thirty of the latter were structurally elucidated,\
+    \ including products of deiodination, aliphatic chain oxidation, as well as dimeric\
+    \ compounds as new class of thyroid hormone derivatives. Limits of detection for\
+    \ the thyroid compounds were in the 6 ng/mL range for negative electrospray ionization\
+    \ mass spectrometric detection in full scan mode. Within day and day-to-day repeatabilities\
+    \ of retention times and peak areas were below 0.5\\% and 3.5\\% R.SD. The performance\
+    \ characteristics of the method in terms of robustness and information content\
+    \ clearly show that UHPLC-HRMS is adequate for the rapid and reliable detection,\
+    \ identification, and semiquantitative determination of trace levels of impurities\
+    \ in synthetic pharmaceuticals.},\n author = {V. Neu and C. Bielow and I. Gostomski\
+    \ and R. Wintringer and R. Braun and K. Reinert and P. Schneider and H. Stuppner\
+    \ and C. Huber},\n journal = {Analytical Chemistry},\n month = {February},\n number\
+    \ = {6},\n pages = {3309--3317},\n publisher = {American Chemical Society},\n\
+    \ title = {Rapid and Comprehensive Impurity Profiling of Synthetic Thyroxine by\
+    \ Ultrahigh-Performance Liquid Chromatography?High-Resolution Mass Spectrometry},\n\
+    \ url = {http://publications.imp.fu-berlin.de/1397/},\n volume = {85},\n year\
+    \ = {2013}\n}\n\n"
   creators:
-  - name:
+  - id: null
+    name:
       family: Neu
       given: V.
-      honourific:
-      lineage:
-  - name:
+      honourific: null
+      lineage: null
+  - id: null
+    name:
       family: Bielow
       given: C.
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: K.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Gostomski
+      given: I.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Wintringer
+      given: R.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Braun
+      given: R.
+      honourific: null
+      lineage: null
+  - id: knut.reinert@fu-berlin.de
+    name:
       family: Reinert
-  - name:
+      given: K.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Schneider
+      given: P.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Stuppner
+      given: H.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
       family: Huber
-      honourific:
-      given: C. G.
-      lineage:
-  datestamp: '2014-11-19 15:15:57'
-  publication: Journal of chromatography A
-  lastmod: '2016-11-15 14:03:10'
-  ispublished: pub
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1463
-  official_url: http://linkinghub.elsevier.com/retrieve/pii/S0021967314016823
-- metadata_visibility: show
-  id_number: 'doi: 10.1021/ac303404e'
+      given: C.
+      honourific: null
+      lineage: null
+  date: '2013-02-08'
   date_type: published
-  full_text_status: none
-  item_issues_count: 0
-  refereed: 'TRUE'
-  eprintid: 1398
-  number: 4
+  datestamp: '2014-03-18 14:56:17'
+  dir: disk0/00/00/13/97
   divisions:
   - group_algbioinf
+  eprint_status: archive
+  eprintid: 1397
+  full_text_status: none
+  id_number: doi 10.1021/ac303722j
+  ispublished: pub
+  issn: 0003-2700
+  item_issues_count: 0
+  key: fu_mi_publications1397
+  lastmod: '2014-03-18 14:56:17'
+  metadata_visibility: show
+  number: 6
+  official_url: http://pubs.acs.org/doi/abs/10.1021/ac303722j
+  pagerange: 3309-3317
+  publication: Analytical Chemistry
+  publisher: American Chemical Society
+  refereed: 'TRUE'
+  rev_number: 9
+  status_changed: '2014-03-18 14:56:17'
   subjects:
   - G400
-  volume: 85
-  pagerange: 2385-2390
-  date: '2013-01-12'
-  dir: disk0/00/00/13/98
-  issn: 0003-2700
-  eprint_status: archive
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1398
-  ispublished: pub
-  lastmod: '2014-03-18 15:10:11'
-  official_url: http://pubs.acs.org/doi/abs/10.1021/ac303404e
-  userid: 132
-  publisher: American Chemical Society
-  rev_number: 7
+  title: "Rapid and Comprehensive Impurity Profiling of Synthetic Thyroxine by Ultrahigh-Performance\
+    \ Liquid Chromatography\u2013High-Resolution Mass Spectrometry"
   type: article
-  title: 'Investigation of Reaction Mechanisms of Drug Degradation in the Solid State:
-    A Kinetic Study Implementing Ultrahigh-Performance Liquid Chromatography and High-Resolution
-    Mass Spectrometry for Thermally Stressed Thyroxine'
-  status_changed: '2014-03-18 15:10:11'
-  abstract: A reaction scheme was derived for the thermal degradation of thyroxine
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1397
+  userid: 132
+  volume: 85
+- abstract: A reaction scheme was derived for the thermal degradation of thyroxine
     in the solid state, using data obtained from ultrahigh-performance liquid chromatography
     and high-resolution mass spectrometry (UHPLC-HRMS). To study the reaction mechanism
     and kinetics of the thermal degradation of the pharmaceutical in the solid state,
@@ -6883,197 +1892,5130 @@
     data using nuclear magnetic resonance spectroscopy, this comprehensive body of
     data sheds light on an elaborate, radical-driven reaction scheme, explaining the
     presence or formation of impurities in thermally stressed thyroxine.
-  publication: Analytical Chemistry
-  datestamp: '2014-03-18 15:10:11'
+  bibtex: "@article{fu_mi_publications1398,\n abstract = {A reaction scheme was derived\
+    \ for the thermal degradation of thyroxine in the solid state, using data obtained\
+    \ from ultrahigh-performance liquid chromatography and high-resolution mass spectrometry\
+    \ (UHPLC-HRMS). To study the reaction mechanism and kinetics of the thermal degradation\
+    \ of the pharmaceutical in the solid state, a workflow was developed by generating\
+    \ compound-specific, time-dependent degradation or formation curves of at least\
+    \ 13 different degradation products. Such curves allowed one to distinguish between\
+    \ first- and second-generation degradation products, as well as impurities resulting\
+    \ from chemical synthesis. The structures of the degradation products were derived\
+    \ from accurate molecular masses and multistage mass spectrometry. Deiodination\
+    \ and oxidative side chain degradation were found to be the major degradation\
+    \ reactions, resulting in the formation of deiodinated thyroxines, as well as\
+    \ acetic acid, benzoic acid, formaldehyde, acetamide, hydroxyacetic acid, oxoacetic\
+    \ acid, hydroxyacetamide, or oxoacetamide derivatives of thyroxine or deiodinated\
+    \ thyroxine. Upon additional structural verification of mass spectrometric data\
+    \ using nuclear magnetic resonance spectroscopy, this comprehensive body of data\
+    \ sheds light on an elaborate, radical-driven reaction scheme, explaining the\
+    \ presence or formation of impurities in thermally stressed thyroxine.},\n author\
+    \ = {V. Neu and C. Bielow and P. Schneider and K. Reinert and H. Stuppner and\
+    \ C. Huber},\n journal = {Analytical Chemistry},\n month = {January},\n number\
+    \ = {4},\n pages = {2385--2390},\n publisher = {American Chemical Society},\n\
+    \ title = {Investigation of Reaction Mechanisms of Drug Degradation in the Solid\
+    \ State: A Kinetic Study Implementing Ultrahigh-Performance Liquid Chromatography\
+    \ and High-Resolution Mass Spectrometry for Thermally Stressed Thyroxine},\n url\
+    \ = {http://publications.imp.fu-berlin.de/1398/},\n volume = {85},\n year = {2013}\n\
+    }\n\n"
   creators:
-  - id:
+  - id: null
     name:
-      lineage:
       family: Neu
-      honourific:
       given: V.
-  - name:
-      lineage:
-      given: C.
-      honourific:
-      family: Bielow
-    id:
-  - id:
+      honourific: null
+      lineage: null
+  - id: null
     name:
-      lineage:
-      honourific:
-      given: P.
+      family: Bielow
+      given: C.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
       family: Schneider
-  - name:
-      honourific:
-      given: K.
+      given: P.
+      honourific: null
+      lineage: null
+  - id: knut.reinert@fu-berlin.de
+    name:
       family: Reinert
-      lineage:
-    id: knut.reinert@fu-berlin.de
-  - name:
-      lineage:
+      given: K.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
       family: Stuppner
       given: H.
-      honourific:
-    id:
-  - id:
+      honourific: null
+      lineage: null
+  - id: null
     name:
       family: Huber
-      honourific:
       given: C.
-      lineage:
-- full_text_status: none
+      honourific: null
+      lineage: null
+  date: '2013-01-12'
   date_type: published
-  metadata_visibility: show
-  id_number: doi:10.1016/j.jbiotec.2017.05.016
-  eprintid: 2116
-  refereed: 'TRUE'
-  volume: 261
+  datestamp: '2014-03-18 15:10:11'
+  dir: disk0/00/00/13/98
   divisions:
   - group_algbioinf
+  eprint_status: archive
+  eprintid: 1398
+  full_text_status: none
+  id_number: 'doi: 10.1021/ac303404e'
+  ispublished: pub
+  issn: 0003-2700
+  item_issues_count: 0
+  key: fu_mi_publications1398
+  lastmod: '2014-03-18 15:10:11'
+  metadata_visibility: show
+  number: 4
+  official_url: http://pubs.acs.org/doi/abs/10.1021/ac303404e
+  pagerange: 2385-2390
+  publication: Analytical Chemistry
+  publisher: American Chemical Society
+  refereed: 'TRUE'
+  rev_number: 7
+  status_changed: '2014-03-18 15:10:11'
   subjects:
   - G400
-  date: '2017-11-10'
-  pagerange: 142-148
-  issn: 1681656
-  dir: disk0/00/00/21/16
-  eprint_status: archive
-  uri: http://publications.imp.fu-berlin.de/id/eprint/2116
-  ispublished: pub
-  lastmod: '2017-10-12 12:05:59'
-  official_url: http://doi.org/10.1016/j.jbiotec.2017.05.016
-  publisher: ELSEVIER
+  title: 'Investigation of Reaction Mechanisms of Drug Degradation in the Solid State:
+    A Kinetic Study Implementing Ultrahigh-Performance Liquid Chromatography and High-Resolution
+    Mass Spectrometry for Thermally Stressed Thyroxine'
   type: article
-  rev_number: 5
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1398
   userid: 132
-  abstract: "BackgroundIn recent years, several mass spectrometry-based omics
-    technologies emerged to investigate qualitative and quantitative changes within
-    thousands of biologically active components such as proteins, lipids and metabolites.
-    The research enabled through these methods potentially contributes to the diagnosis
-    and pathophysiology of human diseases as well as to the clarification of structures
-    and interactions between biomolecules. Simultaneously, technological advances
-    in the field of mass spectrometry leading to an ever increasing amount of data,
-    demand high standards in efficiency, accuracy and reproducibility of potential
-    analysis software.ResultsThis article presents the current state
-    and ongoing developments in OpenMS, a versatile open-source framework aimed at
-    enabling reproducible analyses of high-throughput mass spectrometry data. It provides
-    implementations of frequently occurring processing operations on MS data through
-    a clean application programming interface in C++ and Python. A collection of 185
-    tools and ready-made workflows for typical MS-based experiments enable convenient
-    analyses for non-developers and facilitate reproducible research without losing
-    flexibility.ConclusionsOpenMS will continue to increase its ease
-    of use for developers as well as users with improved continuous integration/deployment
-    strategies, regular trainings with updated training materials and multiple sources
-    of support. The active developer community ensures the incorporation of new features
-    to support state of the art research."
-  status_changed: '2017-10-12 12:05:59'
-  title: OpenMS – A platform for reproducible analysis of mass spectrometry data
-  datestamp: '2017-10-12 12:05:59'
-  publication: Journal of Biotechnology
+  volume: 85
+- abstract: "Motivation: Owing to recent advancements in high-throughput technologies,\
+    \ protein\u2013protein interaction networks of more and more species become available\
+    \ in public databases. The question of how to identify functionally conserved\
+    \ proteins across species attracts a lot of attention in computational biology.\
+    \ Network alignments provide a systematic way to solve this problem. However,\
+    \ most existing alignment tools encounter limitations in tackling this problem.\
+    \ Therefore, the demand for faster and more efficient alignment tools is growing.\r\
+    \n\r\nResults: We present a fast and accurate algorithm, NetCoffee, which allows\
+    \ to find a global alignment of multiple protein\u2013protein interaction networks.\
+    \ NetCoffee searches for a global alignment by maximizing a target function using\
+    \ simulated annealing on a set of weighted bipartite graphs that are constructed\
+    \ using a triplet approach similar to T-Coffee. To assess its performance, NetCoffee\
+    \ was applied to four real datasets. Our results suggest that NetCoffee remedies\
+    \ several limitations of previous algorithms, outperforms all existing alignment\
+    \ tools in terms of speed and nevertheless identifies biologically meaningful\
+    \ alignments.\r\n\r\nAvailability: The source code and data are freely available\
+    \ for download under the GNU GPL v3 license at https://code.google.com/p/netcoffee/. "
+  bibtex: "@article{fu_mi_publications1399,\n abstract = {Motivation: Owing to recent\
+    \ advancements in high-throughput technologies, protein?protein interaction networks\
+    \ of more and more species become available in public databases. The question\
+    \ of how to identify functionally conserved proteins across species attracts a\
+    \ lot of attention in computational biology. Network alignments provide a systematic\
+    \ way to solve this problem. However, most existing alignment tools encounter\
+    \ limitations in tackling this problem. Therefore, the demand for faster and more\
+    \ efficient alignment tools is growing.\n\nResults: We present a fast and accurate\
+    \ algorithm, NetCoffee, which allows to find a global alignment of multiple protein?protein\
+    \ interaction networks. NetCoffee searches for a global alignment by maximizing\
+    \ a target function using simulated annealing on a set of weighted bipartite graphs\
+    \ that are constructed using a triplet approach similar to T-Coffee. To assess\
+    \ its performance, NetCoffee was applied to four real datasets. Our results suggest\
+    \ that NetCoffee remedies several limitations of previous algorithms, outperforms\
+    \ all existing alignment tools in terms of speed and nevertheless identifies biologically\
+    \ meaningful alignments.\n\nAvailability: The source code and data are freely\
+    \ available for download under the GNU GPL v3 license at https://code.google.com/p/netcoffee/.\
+    \ },\n author = {J. Hu and B. Kehr and K. Reinert},\n journal = {Bioinformatics},\n\
+    \ month = {February},\n number = {4},\n pages = {540--548},\n publisher = {Oxford\
+    \ University Press},\n title = {NetCoffee: a fast and accurate global alignment\
+    \ approach to identify functionally conserved proteins in multiple networks},\n\
+    \ url = {http://publications.imp.fu-berlin.de/1399/},\n volume = {30},\n year\
+    \ = {2014}\n}\n\n"
+  creators:
+  - id: jialu.hu@fu-berlin.de
+    name:
+      family: Hu
+      given: J.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Kehr
+      given: B.
+      honourific: null
+      lineage: null
+  - id: knut.reinert@fu-berlin.de
+    name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: '2014-02-15'
+  date_type: published
+  datestamp: '2014-03-18 15:26:45'
+  dir: disk0/00/00/13/99
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 1399
+  full_text_status: none
+  id_number: 'doi: 10.1093/bioinformatics/btt715'
+  ispublished: pub
+  issn: 1367-4803
+  item_issues_count: 0
+  key: fu_mi_publications1399
+  lastmod: '2014-08-19 14:46:18'
+  metadata_visibility: show
+  number: 4
+  official_url: http://bioinformatics.oxfordjournals.org/cgi/doi/10.1093/bioinformatics/btt715
+  pagerange: 540-548
+  publication: Bioinformatics
+  publisher: Oxford University Press
+  refereed: 'TRUE'
+  rev_number: 9
+  status_changed: '2014-08-19 14:46:18'
+  subjects:
+  - G400
+  title: 'NetCoffee: a fast and accurate global alignment approach to identify functionally
+    conserved proteins in multiple networks'
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1399
+  userid: 132
+  volume: 30
+- abstract: "Background\r\nLiquid chromatography mass spectrometry (LC-MS) maps in\
+    \ shotgun proteomics are often too complex to select every detected peptide signal\
+    \ for fragmentation by tandem mass spectrometry (MS/MS). Standard methods for\
+    \ precursor ion selection, commonly based on data dependent acquisition, select\
+    \ highly abundant peptide signals in each spectrum. However, these approaches\
+    \ produce redundant information and are biased towards high-abundance proteins.\r\
+    \n\r\nResults\r\nWe present two algorithms for inclusion list creation that formulate\
+    \ precursor ion selection as an optimization problem. Given an LC-MS map, the\
+    \ first approach maximizes the number of selected precursors given constraints\
+    \ such as a limited number of acquisitions per RT fraction. Second, we introduce\
+    \ a protein sequence-based inclusion list that can be used to monitor proteins\
+    \ of interest. Given only the protein sequences, we create an inclusion list that\
+    \ optimally covers the whole protein set. Additionally, we propose an iterative\
+    \ precursor ion selection that aims at reducing the redundancy obtained with data\
+    \ dependent LC-MS/MS. We overcome the risk of erroneous assignments by including\
+    \ methods for retention time and proteotypicity predictions. We show that our\
+    \ method identifies a set of proteins requiring fewer precursors than standard\
+    \ approaches. Thus, it is well suited for precursor ion selection in experiments\
+    \ with limited sample amount or analysis time.\r\n\r\nConclusions\r\nWe present\
+    \ three approaches to precursor ion selection with LC-MALDI MS/MS. Using a well-defined\
+    \ protein standard and a complex human cell lysate, we demonstrate that our methods\
+    \ outperform standard approaches. Our algorithms are implemented as part of OpenMS\
+    \ and are available under http://www.openms.de.\r\n"
+  bibtex: "@article{fu_mi_publications1400,\n abstract = {Background\nLiquid chromatography\
+    \ mass spectrometry (LC-MS) maps in shotgun proteomics are often too complex to\
+    \ select every detected peptide signal for fragmentation by tandem mass spectrometry\
+    \ (MS/MS). Standard methods for precursor ion selection, commonly based on data\
+    \ dependent acquisition, select highly abundant peptide signals in each spectrum.\
+    \ However, these approaches produce redundant information and are biased towards\
+    \ high-abundance proteins.\n\nResults\nWe present two algorithms for inclusion\
+    \ list creation that formulate precursor ion selection as an optimization problem.\
+    \ Given an LC-MS map, the first approach maximizes the number of selected precursors\
+    \ given constraints such as a limited number of acquisitions per RT fraction.\
+    \ Second, we introduce a protein sequence-based inclusion list that can be used\
+    \ to monitor proteins of interest. Given only the protein sequences, we create\
+    \ an inclusion list that optimally covers the whole protein set. Additionally,\
+    \ we propose an iterative precursor ion selection that aims at reducing the redundancy\
+    \ obtained with data dependent LC-MS/MS. We overcome the risk of erroneous assignments\
+    \ by including methods for retention time and proteotypicity predictions. We show\
+    \ that our method identifies a set of proteins requiring fewer precursors than\
+    \ standard approaches. Thus, it is well suited for precursor ion selection in\
+    \ experiments with limited sample amount or analysis time.\n\nConclusions\nWe\
+    \ present three approaches to precursor ion selection with LC-MALDI MS/MS. Using\
+    \ a well-defined protein standard and a complex human cell lysate, we demonstrate\
+    \ that our methods outperform standard approaches. Our algorithms are implemented\
+    \ as part of OpenMS and are available under http://www.openms.de.},\n author =\
+    \ {A. Zerck and E. Nordhoff and H. Lehrach and K. Reinert},\n journal = {BMC Bioinformatics},\n\
+    \ month = {February},\n number = {1},\n pages = {56},\n publisher = {BioMed Central},\n\
+    \ title = {Optimal precursor ion selection for LC-MALDI MS/MS},\n url = {http://publications.imp.fu-berlin.de/1400/},\n\
+    \ volume = {14},\n year = {2013}\n}\n\n"
+  creators:
+  - id: null
+    name:
+      family: Zerck
+      given: A.
+      honourific: null
+      lineage: null
+  - id: nordhoff@molgen.mpg.de
+    name:
+      family: Nordhoff
+      given: E.
+      honourific: null
+      lineage: null
+  - id: lehrach@molgen.mpg.de
+    name:
+      family: Lehrach
+      given: H.
+      honourific: null
+      lineage: null
+  - id: knut.reinert@fu-berlin.de
+    name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: '2013-02-18'
+  date_type: published
+  datestamp: '2014-03-18 15:56:36'
+  dir: disk0/00/00/14/00
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 1400
+  full_text_status: none
+  id_number: 'doi: 10.1186/1471-2105-14-56'
+  ispublished: pub
+  issn: 1471-2105
+  item_issues_count: 0
+  key: fu_mi_publications1400
+  lastmod: '2014-03-18 16:04:51'
+  metadata_visibility: show
+  number: 1
+  official_url: http://www.biomedcentral.com/1471-2105/14/56
+  pagerange: 56
+  publication: BMC Bioinformatics
+  publisher: BioMed Central
+  refereed: 'TRUE'
+  rev_number: 9
+  status_changed: '2014-03-18 16:04:51'
+  subjects:
+  - G400
+  title: Optimal precursor ion selection for LC-MALDI MS/MS
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1400
+  userid: 132
+  volume: 14
+- bibtex: "@article{fu_mi_publications1401,\n author = {S. Wandelt and D. Deng and\
+    \ S. Gerdjikov and S. Mishra and P. Mitankin and M. Patil and E. Siragusa and\
+    \ A. Tiskin and W. Wang and J. Wang and U. Leser},\n journal = {SIGMOD Record},\n\
+    \ month = {March},\n number = {1},\n title = {State-of-the-art in String Similarity\
+    \ Search and Join},\n url = {http://publications.imp.fu-berlin.de/1401/},\n volume\
+    \ = {43},\n year = {2014}\n}\n\n"
+  creators:
+  - id: null
+    name:
+      family: Wandelt
+      given: S.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Deng
+      given: D.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Gerdjikov
+      given: S.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Mishra
+      given: S.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Mitankin
+      given: P.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Patil
+      given: M.
+      honourific: null
+      lineage: null
+  - id: enrico.siragusa@fu-berlin.de
+    name:
+      family: Siragusa
+      given: E.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Tiskin
+      given: A.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Wang
+      given: W.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Wang
+      given: J.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Leser
+      given: U.
+      honourific: null
+      lineage: null
+  date: 2014-03
+  date_type: published
+  datestamp: '2014-03-18 16:51:01'
+  dir: disk0/00/00/14/01
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 1401
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications1401
+  lastmod: '2014-08-19 16:41:18'
+  metadata_visibility: show
+  number: 1
+  official_url: http://www.sigmod.org/publications/sigmod-record/1403/index.html
+  publication: SIGMOD Record
+  refereed: 'TRUE'
+  related_url:
+  - url: http://www2.informatik.hu-berlin.de/~wandelt/searchjoincompetition2013/
+  rev_number: 11
+  status_changed: '2014-08-19 16:41:18'
+  subjects:
+  - G400
+  title: State-of-the-art in String Similarity Search and Join
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1401
+  userid: 132
+  volume: 43
+- abstract: "Background\r\n\r\nRecent advances in rapid, low-cost sequencing have\
+    \ opened up the opportunity to study complete genome sequences. The computational\
+    \ approach of multiple genome alignment allows investigation of evolutionarily\
+    \ related genomes in an integrated fashion, providing a basis for downstream analyses\
+    \ such as rearrangement studies and phylogenetic inference.\r\n\r\nGraphs have\
+    \ proven to be a powerful tool for coping with the complexity of genome-scale\
+    \ sequence alignments. The potential of graphs to intuitively represent all aspects\
+    \ of genome alignments led to the development of graph-based approaches for genome\
+    \ alignment. These approaches construct a graph from a set of local alignments,\
+    \ and derive a genome alignment through identification and removal of graph substructures\
+    \ that indicate errors in the alignment.\r\n\r\nResults\r\n\r\nWe compare the\
+    \ structures of commonly used graphs in terms of their abilities to represent\
+    \ alignment information. We describe how the graphs can be transformed into each\
+    \ other, and identify and classify graph substructures common to one or more graphs.\
+    \ Based on previous approaches, we compile a list of modifications that remove\
+    \ these substructures.\r\n\r\nConclusion\r\n\r\nWe show that crucial pieces of\
+    \ alignment information, associated with inversions and duplications, are not\
+    \ visible in the structure of all graphs. If we neglect vertex or edge labels,\
+    \ the graphs differ in their information content. Still, many ideas are shared\
+    \ among all graph-based approaches. Based on these findings, we outline a conceptual\
+    \ framework for graph-based genome alignment that can assist in the development\
+    \ of future genome alignment tools. "
+  bibtex: "@article{fu_mi_publications1437,\n abstract = {Background\n\nRecent advances\
+    \ in rapid, low-cost sequencing have opened up the opportunity to study complete\
+    \ genome sequences. The computational approach of multiple genome alignment allows\
+    \ investigation of evolutionarily related genomes in an integrated fashion, providing\
+    \ a basis for downstream analyses such as rearrangement studies and phylogenetic\
+    \ inference.\n\nGraphs have proven to be a powerful tool for coping with the complexity\
+    \ of genome-scale sequence alignments. The potential of graphs to intuitively\
+    \ represent all aspects of genome alignments led to the development of graph-based\
+    \ approaches for genome alignment. These approaches construct a graph from a set\
+    \ of local alignments, and derive a genome alignment through identification and\
+    \ removal of graph substructures that indicate errors in the alignment.\n\nResults\n\
+    \nWe compare the structures of commonly used graphs in terms of their abilities\
+    \ to represent alignment information. We describe how the graphs can be transformed\
+    \ into each other, and identify and classify graph substructures common to one\
+    \ or more graphs. Based on previous approaches, we compile a list of modifications\
+    \ that remove these substructures.\n\nConclusion\n\nWe show that crucial pieces\
+    \ of alignment information, associated with inversions and duplications, are not\
+    \ visible in the structure of all graphs. If we neglect vertex or edge labels,\
+    \ the graphs differ in their information content. Still, many ideas are shared\
+    \ among all graph-based approaches. Based on these findings, we outline a conceptual\
+    \ framework for graph-based genome alignment that can assist in the development\
+    \ of future genome alignment tools. },\n author = {B. Kehr and K. Trappe and M.\
+    \ Holtgrewe and K. Reinert},\n journal = {BMC Bioinformatics},\n month = {April},\n\
+    \ publisher = {BioMed Central},\n title = {Genome alignment with graph data structures:\
+    \ a comparison},\n url = {http://publications.imp.fu-berlin.de/1437/},\n volume\
+    \ = {15},\n year = {2014}\n}\n\n"
+  creators:
+  - id: null
+    name:
+      family: Kehr
+      given: B.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Trappe
+      given: K.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Holtgrewe
+      given: M.
+      honourific: null
+      lineage: null
+  - id: knut.reinert@fu-berlin.de
+    name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: '2014-04-09'
+  date_type: published
+  datestamp: '2014-08-19 12:35:56'
+  dir: disk0/00/00/14/37
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 1437
+  full_text_status: none
+  id_number: doi:10.1186/1471-2105-15-99
+  ispublished: pub
+  issn: 1471-2105
+  item_issues_count: 0
+  key: fu_mi_publications1437
+  lastmod: '2014-08-19 12:35:56'
+  metadata_visibility: show
+  official_url: http://www.biomedcentral.com/1471-2105/15/99/abstract
+  publication: BMC Bioinformatics
+  publisher: BioMed Central
+  refereed: 'TRUE'
+  rev_number: 12
+  status_changed: '2014-08-19 12:35:56'
+  subjects:
+  - G400
+  title: 'Genome alignment with graph data structures: a comparison'
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1437
+  userid: 132
+  volume: 15
+- abstract: "The Konstanz Information Miner is a user-friendly\r\ngraphical workflow\
+    \ designer with a broad user base in industry and academia. Its broad range of\
+    \ embedded tools and its powerful data mining and visualization tools render it\
+    \ ideal for scientific workflows. It is thus used more and more in a broad range\
+    \ of applications. However, the free version typically runs on a desktop computer,\
+    \ restricting users if they want to tap into computing power. The grid and cloud\
+    \ User Support Environment is a free and open source project created for parallelized\
+    \ and distributed systems, but the creation of workflows with the included components\
+    \ has a steeper learning curve.\r\nIn this work we suggest an easy to implement\
+    \ solution\r\ncombining the ease-of-use of the Konstanz Information Miner\r\n\
+    with the computational power of distributed computing infrastructures. We present\
+    \ a solution permitting the conversion of workflows between the two platforms.\
+    \ This enables a convenient development, debugging, and maintenance of scientific\
+    \ workflows on the desktop. These workflows can then be deployed on a cloud or\
+    \ grid, thus permitting large-scale computation.\r\nTo achieve our goals, we relied\
+    \ on a Common Tool Description\r\nXML file format which describes the execution\
+    \ of arbitrary\r\nprograms in a structured and easily readable and parseable way.\
+    \ In order to integrate external programs into we employed the Generic KNIME Nodes\
+    \ extension."
+  bibtex: "@inproceedings{fu_mi_publications1441,\n abstract = {The Konstanz Information\
+    \ Miner is a user-friendly\ngraphical workflow designer with a broad user base\
+    \ in industry and academia. Its broad range of embedded tools and its powerful\
+    \ data mining and visualization tools render it ideal for scientific workflows.\
+    \ It is thus used more and more in a broad range of applications. However, the\
+    \ free version typically runs on a desktop computer, restricting users if they\
+    \ want to tap into computing power. The grid and cloud User Support Environment\
+    \ is a free and open source project created for parallelized and distributed systems,\
+    \ but the creation of workflows with the included components has a steeper learning\
+    \ curve.\nIn this work we suggest an easy to implement solution\ncombining the\
+    \ ease-of-use of the Konstanz Information Miner\nwith the computational power\
+    \ of distributed computing infrastructures. We present a solution permitting the\
+    \ conversion of workflows between the two platforms. This enables a convenient\
+    \ development, debugging, and maintenance of scientific workflows on the desktop.\
+    \ These workflows can then be deployed on a cloud or grid, thus permitting large-scale\
+    \ computation.\nTo achieve our goals, we relied on a Common Tool Description\n\
+    XML file format which describes the execution of arbitrary\nprograms in a structured\
+    \ and easily readable and parseable way. In order to integrate external programs\
+    \ into we employed the Generic KNIME Nodes extension.},\n author = {L. de la Garza\
+    \ and J. Kr{\\\"u}ger and Ch. Sch{\\\"a}rfe and M. R{\\\"o}ttig and S. Aiche and\
+    \ K. Reinert and O. Kohlbacher},\n booktitle = {IWSG (International Workshop on\
+    \ Science Gateways)},\n title = {From the Desktop to the Grid: conversion of KNIME\
+    \ Workflows to gUSE},\n url = {http://publications.imp.fu-berlin.de/1441/},\n\
+    \ year = {2013}\n}\n\n"
+  contact_email: stephan.aiche@fu-berlin.de
+  creators:
+  - id: null
+    name:
+      family: de la Garza
+      given: L.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: "Kr\xFCger"
+      given: J.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: "Sch\xE4rfe"
+      given: Ch.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: "R\xF6ttig"
+      given: M.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Aiche
+      given: S.
+      honourific: null
+      lineage: null
+  - id: knut.reinert@fu-berlin.de
+    name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Kohlbacher
+      given: O.
+      honourific: null
+      lineage: null
+  date: 2013
+  date_type: published
+  datestamp: '2014-08-19 14:26:35'
+  dir: disk0/00/00/14/41
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 1441
+  event_dates: 3-5 June 2013
+  event_location: Zurich, Switzerland
+  event_title: IWSG (International Workshop on Science Gateways)
+  event_type: workshop
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications1441
+  lastmod: '2014-08-19 14:26:35'
+  metadata_visibility: show
+  official_url: http://www.informatik.uni-trier.de/~ley/db/conf/iwsg/iwsg2013.html
+  pres_type: paper
+  refereed: 'TRUE'
+  rev_number: 17
+  status_changed: '2014-08-19 14:26:35'
+  subjects:
+  - G400
+  title: 'From the Desktop to the Grid: conversion of KNIME Workflows to gUSE'
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1441
+  userid: 132
+- abstract: "Computational mass spectrometry is a fast evolving field that has attracted\
+    \ increased attention over the last couple of years.\r\nThe performance of software\
+    \ solutions determines the success of analysis to a great extent. New algorithms\
+    \ are required to reflect new experimental procedures and deal with new instrument\
+    \ generations.\r\n\r\nOne essential component of algorithm development is the\
+    \ validation (as well as comparison) of software on a broad range of\r\ndata sets.\
+    \ This requires a gold standard (or so-called ground truth), which is usually\
+    \ obtained by manual annotation of a real data set.\r\nComprehensive manually\
+    \ annotated public data sets for mass spectrometry data are labor-intensive to\
+    \ produce and their quality strongly depends on \r\nthe skill of the human expert.\
+    \ Some parts of the data may even be impossible to annotate due to high levels\
+    \ of noise or other ambiguities.\r\nFurthermore, manually annotated data is usually\
+    \ not available for all steps in a typical computational analysis pipeline.\r\n\
+    We thus developed the most comprehensive simulation software to date, which allows\
+    \ to generate multiple levels of ground truth\r\nand features a plethora of settings\
+    \ to reflect experimental conditions and instrument settings.\r\nThe simulator\
+    \ is used to generate several distinct types of data. The data are subsequently\
+    \ employed to evaluate existing algorithms.\r\nAdditionally, we employ simulation\
+    \ to determine the influence of instrument attributes and sample complexity on\
+    \ the ability of\r\nalgorithms to recover information. The results give valuable\
+    \ hints on how to optimize experimental setups.\r\n\r\nFurthermore, this thesis\
+    \ introduces two quantitative approaches, namely a decharging algorithm based\
+    \ on integer linear programming \r\nand a new workflow for identification of differentially\
+    \ expressed proteins for a large in vitro study on toxic compounds.\r\nDecharging\
+    \ infers the uncharged mass of a peptide (or protein) by clustering all its charge\
+    \ variants. The latter occur frequently under certain experimental conditions.\r\
+    \nWe employ simulation to show that decharging is robust against missing values\
+    \ even for high complexity data and that the algorithm outperforms\r\nother solutions\
+    \ in terms of mass accuracy and run time on real data.\r\nThe last part of this\
+    \ thesis deals with a new state-of-the-art workflow for protein quantification\
+    \ based on isobaric tags for relative and absolute quantitation (iTRAQ). We devise\r\
+    \na new approach to isotope correction, propose an experimental design, introduce\
+    \ new metrics of iTRAQ data quality, and\r\nconfirm putative properties of iTRAQ\
+    \ data using a novel approach.\r\n\r\nAll tools developed as part of this thesis\
+    \ are implemented in OpenMS, a C++ library for computational mass spectrometry."
+  bibtex: "@phdthesis{fu_mi_publications1444,\n abstract = {Computational mass spectrometry\
+    \ is a fast evolving field that has attracted increased attention over the last\
+    \ couple of years.\nThe performance of software solutions determines the success\
+    \ of analysis to a great extent. New algorithms are required to reflect new experimental\
+    \ procedures and deal with new instrument generations.\n\nOne essential component\
+    \ of algorithm development is the validation (as well as comparison) of software\
+    \ on a broad range of\ndata sets. This requires a gold standard (or so-called\
+    \ ground truth), which is usually obtained by manual annotation of a real data\
+    \ set.\nComprehensive manually annotated public data sets for mass spectrometry\
+    \ data are labor-intensive to produce and their quality strongly depends on \n\
+    the skill of the human expert. Some parts of the data may even be impossible to\
+    \ annotate due to high levels of noise or other ambiguities.\nFurthermore, manually\
+    \ annotated data is usually not available for all steps in a typical computational\
+    \ analysis pipeline.\nWe thus developed the most comprehensive simulation software\
+    \ to date, which allows to generate multiple levels of ground truth\nand features\
+    \ a plethora of settings to reflect experimental conditions and instrument settings.\n\
+    The simulator is used to generate several distinct types of data. The data are\
+    \ subsequently employed to evaluate existing algorithms.\nAdditionally, we employ\
+    \ simulation to determine the influence of instrument attributes and sample complexity\
+    \ on the ability of\nalgorithms to recover information. The results give valuable\
+    \ hints on how to optimize experimental setups.\n\nFurthermore, this thesis introduces\
+    \ two quantitative approaches, namely a decharging algorithm based on integer\
+    \ linear programming \nand a new workflow for identification of differentially\
+    \ expressed proteins for a large in vitro study on toxic compounds.\nDecharging\
+    \ infers the uncharged mass of a peptide (or protein) by clustering all its charge\
+    \ variants. The latter occur frequently under certain experimental conditions.\n\
+    We employ simulation to show that decharging is robust against missing values\
+    \ even for high complexity data and that the algorithm outperforms\nother solutions\
+    \ in terms of mass accuracy and run time on real data.\nThe last part of this\
+    \ thesis deals with a new state-of-the-art workflow for protein quantification\
+    \ based on isobaric tags for relative and absolute quantitation (iTRAQ). We devise\n\
+    a new approach to isotope correction, propose an experimental design, introduce\
+    \ new metrics of iTRAQ data quality, and\nconfirm putative properties of iTRAQ\
+    \ data using a novel approach.\n\nAll tools developed as part of this thesis are\
+    \ implemented in OpenMS, a C++ library for computational mass spectrometry.},\n\
+    \ address = {Berlin, Germany},\n author = {C. Bielow},\n month = {October},\n\
+    \ school = {Freie Universit{\\\"a}t Berlin},\n title = {Quantification and Simulation\
+    \ of Liquid Chromatography-Mass Spectrometry Data},\n url = {http://publications.imp.fu-berlin.de/1444/},\n\
+    \ year = {2012}\n}\n\n"
   creators:
   - name:
-      lineage:
-      honourific:
-      given: Julianus
-      family: Pfeuffer
+      family: Bielow
+      given: C.
+      honourific: null
+      lineage: null
+  date: '2012-10-29'
+  date_type: published
+  datestamp: '2014-08-20 09:50:37'
+  department: Mathematics and Computer Science
+  dir: disk0/00/00/14/44
+  divisions:
+  - group_algbioinf
+  documents:
+  - content: published
+    docid: 616
+    eprintid: 1444
+    files:
+    - datasetid: document
+      fileid: 18031
+      filename: thesis_noCV.pdf
+      filesize: 4488171
+      mime_type: application/pdf
+      mtime: '2017-03-03 14:41:36'
+      objectid: 616
+      uri: http://publications.imp.fu-berlin.de/id/file/18031
+    format: application/pdf
+    formatdesc: Thesis (without CV)
+    language: en
+    main: thesis_noCV.pdf
+    mime_type: application/pdf
+    pos: 1
+    relation:
+    - type: http://eprints.org/relation/hasVolatileVersion
+      uri: /id/document/1275
+    - type: http://eprints.org/relation/haspreviewThumbnailVersion
+      uri: /id/document/1275
+    - type: http://eprints.org/relation/hasVersion
+      uri: /id/document/1275
+    rev_number: 4
+    security: public
+    uri: http://publications.imp.fu-berlin.de/id/document/616
+  eprint_status: archive
+  eprintid: 1444
+  full_text_status: public
+  institution: "Freie Universit\xE4t Berlin"
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications1444
+  lastmod: '2017-03-03 14:41:36'
+  metadata_visibility: show
+  official_url: http://www.diss.fu-berlin.de/diss/receive/FUDISS_thesis_000000040013
+  place_of_pub: Berlin, Germany
+  rev_number: 10
+  status_changed: '2014-08-20 09:50:37'
+  subjects:
+  - G400
+  thesis_type: phd
+  title: Quantification and Simulation of Liquid Chromatography-Mass Spectrometry
+    Data
+  type: thesis
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1444
+  userid: 30
+- bibtex: "@phdthesis{fu_mi_publications1445,\n address = {Berlin, Germany},\n author\
+    \ = {S. Aiche},\n month = {September},\n school = {Freie Universit{\\\"a}t Berlin},\n\
+    \ title = {Inferring Proteolytic Processes from Mass Spectrometry Time Series\
+    \ Data},\n url = {http://publications.imp.fu-berlin.de/1445/},\n year = {2013}\n\
+    }\n\n"
+  creators:
+  - name:
+      family: Aiche
+      given: S.
+      honourific: null
+      lineage: null
+  date: '2013-09-30'
+  date_type: published
+  datestamp: '2014-08-20 10:50:26'
+  department: Mathematics and Computer Science
+  dir: disk0/00/00/14/45
+  divisions:
+  - group_algbioinf
+  documents:
+  - content: published
+    docid: 617
+    eprintid: 1445
+    files:
+    - datasetid: document
+      fileid: 18059
+      filename: thesis_aiche_no_cv.pdf
+      filesize: 3615721
+      mime_type: application/pdf
+      mtime: '2017-03-03 14:41:37'
+      objectid: 617
+      uri: http://publications.imp.fu-berlin.de/id/file/18059
+    format: application/pdf
+    language: en
+    main: thesis_aiche_no_cv.pdf
+    mime_type: application/pdf
+    pos: 1
+    relation:
+    - type: http://eprints.org/relation/hasVersion
+      uri: /id/document/1276
+    - type: http://eprints.org/relation/hasVolatileVersion
+      uri: /id/document/1276
+    - type: http://eprints.org/relation/haspreviewThumbnailVersion
+      uri: /id/document/1276
+    rev_number: 4
+    security: public
+    uri: http://publications.imp.fu-berlin.de/id/document/617
+  eprint_status: archive
+  eprintid: 1445
+  full_text_status: public
+  institution: "Freie Universit\xE4t Berlin"
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications1445
+  lastmod: '2017-03-03 14:41:37'
+  metadata_visibility: show
+  place_of_pub: Berlin, Germany
+  rev_number: 12
+  status_changed: '2014-08-20 10:50:26'
+  subjects:
+  - G400
+  thesis_type: phd
+  title: Inferring Proteolytic Processes from Mass Spectrometry Time Series Data
+  type: thesis
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1445
+  userid: 30
+- abstract: "Motivation: Next-generation sequencing (NGS) has revolutionized biomedical\
+    \ research in the past decade and led to a continuous stream of developments in\
+    \ bioinformatics, addressing the need for fast and space-efficient solutions for\
+    \ analyzing NGS data. Often researchers need to analyze a set of genomic sequences\
+    \ that stem from closely related species or are indeed individuals of the same\
+    \ species. Hence, the analyzed sequences are similar. For analyses where local\
+    \ changes in the examined sequence induce only local changes in the results, it\
+    \ is obviously desirable to examine identical or similar regions not repeatedly.\r\
+    \n\r\nResults: In this work, we provide a datatype that exploits data parallelism\
+    \ inherent in a set of similar sequences by analyzing shared regions only once.\
+    \ In real-world experiments, we show that algorithms that otherwise would scan\
+    \ each reference sequentially can be speeded up by a factor of 115.\r\n\r\nAvailability:\
+    \ The data structure and associated tools are publicly available at http://www.seqan.de/projects/jst\
+    \ and are part of SeqAn, the C++ template library for sequence analysis.\r\n\r\
+    \nContact: rene.rahn@fu-berlin.de"
+  bibtex: "@article{fu_mi_publications1448,\n abstract = {Motivation: Next-generation\
+    \ sequencing (NGS) has revolutionized biomedical research in the past decade and\
+    \ led to a continuous stream of developments in bioinformatics, addressing the\
+    \ need for fast and space-efficient solutions for analyzing NGS data. Often researchers\
+    \ need to analyze a set of genomic sequences that stem from closely related species\
+    \ or are indeed individuals of the same species. Hence, the analyzed sequences\
+    \ are similar. For analyses where local changes in the examined sequence induce\
+    \ only local changes in the results, it is obviously desirable to examine identical\
+    \ or similar regions not repeatedly.\n\nResults: In this work, we provide a datatype\
+    \ that exploits data parallelism inherent in a set of similar sequences by analyzing\
+    \ shared regions only once. In real-world experiments, we show that algorithms\
+    \ that otherwise would scan each reference sequentially can be speeded up by a\
+    \ factor of 115.\n\nAvailability: The data structure and associated tools are\
+    \ publicly available at http://www.seqan.de/projects/jst and are part of SeqAn,\
+    \ the C++ template library for sequence analysis.\n\nContact: rene.rahn@fu-berlin.de},\n\
+    \ author = {R. Rahn and D. Weese and K. Reinert},\n journal = {Bioinformatics},\n\
+    \ month = {July},\n title = {Journaled string tree--a scalable data structure\
+    \ for analyzing thousands of similar genomes on your laptop},\n url = {http://publications.imp.fu-berlin.de/1448/},\n\
+    \ year = {2014}\n}\n\n"
+  creators:
+  - name:
+      family: Rahn
+      given: R.
+      honourific: null
+      lineage: null
+  - name:
+      family: Weese
+      given: D.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: '2014-07-15'
+  date_type: published
+  datestamp: '2014-08-25 18:46:21'
+  dir: disk0/00/00/14/48
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 1448
+  full_text_status: none
+  id_number: doi:10.1093/bioinformatics/btu438
+  ispublished: pub
+  issn: Online ISSN 1460-2059 - Print ISSN 1367-4803
+  item_issues_count: 0
+  key: fu_mi_publications1448
+  lastmod: '2014-08-25 18:46:21'
+  metadata_visibility: show
+  official_url: http://dx.doi.org/10.1093/bioinformatics/btu438
+  publication: Bioinformatics
+  refereed: 'TRUE'
+  rev_number: 8
+  status_changed: '2014-08-25 18:46:21'
+  subjects:
+  - G400
+  title: Journaled string tree--a scalable data structure for analyzing thousands
+    of similar genomes on your laptop
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1448
+  userid: 132
+- abstract: "Quality control is increasingly recognized as a crucial\r\naspect of\
+    \ mass spectrometry based proteomics. Several\r\nrecent papers discuss relevant\
+    \ parameters for quality\r\ncontrol and present applications to extract these\
+    \ from the\r\ninstrumental raw data. What has been missing, however,\r\nis a standard\
+    \ data exchange format for reporting these\r\nperformance metrics. We therefore\
+    \ developed the qcML\r\nformat, an XML-based standard that follows the design\r\
+    \nprinciples of the related mzML, mzIdentML, mzQuantML,\r\nand TraML standards\
+    \ from the HUPO-PSI (Proteomics\r\nStandards Initiative). In addition to the XML\
+    \ format, we\r\nalso provide tools for the calculation of a wide range of\r\n\
+    quality metrics as well as a database format and interconversion tools, so that\
+    \ existing LIMS systems can easily add relational storage of the quality control\
+    \ data to their existing schema. We here describe the qcML specification, along\
+    \ with possible use cases and an illustrative example of the subsequent analysis\
+    \ possibilities. All information about qcML is available at http://code.google.com/p/qcml.\
+    \ Molecular & Cellular Proteomics 13: 10.1074/mcp.M113.035907, 1905\u20131913,\
+    \ 2014."
+  bibtex: "@article{fu_mi_publications1449,\n abstract = {Quality control is increasingly\
+    \ recognized as a crucial\naspect of mass spectrometry based proteomics. Several\n\
+    recent papers discuss relevant parameters for quality\ncontrol and present applications\
+    \ to extract these from the\ninstrumental raw data. What has been missing, however,\n\
+    is a standard data exchange format for reporting these\nperformance metrics. We\
+    \ therefore developed the qcML\nformat, an XML-based standard that follows the\
+    \ design\nprinciples of the related mzML, mzIdentML, mzQuantML,\nand TraML standards\
+    \ from the HUPO-PSI (Proteomics\nStandards Initiative). In addition to the XML\
+    \ format, we\nalso provide tools for the calculation of a wide range of\nquality\
+    \ metrics as well as a database format and interconversion tools, so that existing\
+    \ LIMS systems can easily add relational storage of the quality control data to\
+    \ their existing schema. We here describe the qcML specification, along with possible\
+    \ use cases and an illustrative example of the subsequent analysis possibilities.\
+    \ All information about qcML is available at http://code.google.com/p/qcml. Molecular\
+    \ \\& Cellular Proteomics 13: 10.1074/mcp.M113.035907, 1905?1913, 2014.},\n author\
+    \ = {M. Walzer and L. E. Pernas and S. Nasso and W. Bittremieux and S. Nahnsen\
+    \ and P. Kelchtermans and P. Pichler and H. W. P. van den Toorn and A. Staes and\
+    \ J. Vandenbussche and M. Mazanek and T. Taus and R. A. Scheltema and C. D. Kelstrup\
+    \ and L. Gatto and B. van Breukelen and S. Aiche and D. Valkenborg and K. Laukens\
+    \ and K. S. Lilley and J. V. Olsen and A. J. R. Heck and K. Mechtler and R. Aebersold\
+    \ and K. Gevaert and J. A. Vizcaino and H. Hermjakob and O. Kohlbacher and L.\
+    \ Martens},\n journal = {Molecular \\& Cellular Proteomics},\n month = {August},\n\
+    \ number = {8},\n pages = {1905--1913},\n title = {qcML: An Exchange Format for\
+    \ Quality Control Metrics from Mass Spectrometry Experiments},\n url = {http://publications.imp.fu-berlin.de/1449/},\n\
+    \ volume = {13},\n year = {2014}\n}\n\n"
+  creators:
+  - name:
+      family: Walzer
+      given: M.
+      honourific: null
+      lineage: null
+  - name:
+      family: Pernas
+      given: L. E.
+      honourific: null
+      lineage: null
+  - name:
+      family: Nasso
+      given: S.
+      honourific: null
+      lineage: null
+  - name:
+      family: Bittremieux
+      given: W.
+      honourific: null
+      lineage: null
+  - name:
+      family: Nahnsen
+      given: S.
+      honourific: null
+      lineage: null
+  - name:
+      family: Kelchtermans
+      given: P.
+      honourific: null
+      lineage: null
+  - name:
+      family: Pichler
+      given: P.
+      honourific: null
+      lineage: null
+  - name:
+      family: van den Toorn
+      given: H. W. P.
+      honourific: null
+      lineage: null
+  - name:
+      family: Staes
+      given: A.
+      honourific: null
+      lineage: null
+  - name:
+      family: Vandenbussche
+      given: J.
+      honourific: null
+      lineage: null
+  - name:
+      family: Mazanek
+      given: M.
+      honourific: null
+      lineage: null
+  - name:
+      family: Taus
+      given: T.
+      honourific: null
+      lineage: null
+  - name:
+      family: Scheltema
+      given: R. A.
+      honourific: null
+      lineage: null
+  - name:
+      family: Kelstrup
+      given: C. D.
+      honourific: null
+      lineage: null
+  - name:
+      family: Gatto
+      given: L.
+      honourific: null
+      lineage: null
+  - name:
+      family: van Breukelen
+      given: B.
+      honourific: null
+      lineage: null
+  - name:
+      family: Aiche
+      given: S.
+      honourific: null
+      lineage: null
+  - name:
+      family: Valkenborg
+      given: D.
+      honourific: null
+      lineage: null
+  - name:
+      family: Laukens
+      given: K.
+      honourific: null
+      lineage: null
+  - name:
+      family: Lilley
+      given: K. S.
+      honourific: null
+      lineage: null
+  - name:
+      family: Olsen
+      given: J. V.
+      honourific: null
+      lineage: null
+  - name:
+      family: Heck
+      given: A. J. R.
+      honourific: null
+      lineage: null
+  - name:
+      family: Mechtler
+      given: K.
+      honourific: null
+      lineage: null
+  - name:
+      family: Aebersold
+      given: R.
+      honourific: null
+      lineage: null
+  - name:
+      family: Gevaert
+      given: K.
+      honourific: null
+      lineage: null
+  - name:
+      family: Vizcaino
+      given: J. A.
+      honourific: null
+      lineage: null
+  - name:
+      family: Hermjakob
+      given: H.
+      honourific: null
+      lineage: null
+  - name:
+      family: Kohlbacher
+      given: O.
+      honourific: null
+      lineage: null
+  - name:
+      family: Martens
+      given: L.
+      honourific: null
+      lineage: null
+  date: '2014-08-01'
+  date_type: published
+  datestamp: '2014-08-25 19:14:40'
+  dir: disk0/00/00/14/49
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 1449
+  full_text_status: none
+  id_number: doi:10.1074/mcp.M113.035907
+  ispublished: pub
+  issn: 1535-9476
+  item_issues_count: 0
+  key: fu_mi_publications1449
+  lastmod: '2014-08-25 19:14:40'
+  metadata_visibility: show
+  number: 8
+  official_url: http://dx.doi.org/10.1074/mcp.M113.035907
+  pagerange: 1905-1913
+  publication: Molecular & Cellular Proteomics
+  refereed: 'TRUE'
+  rev_number: 7
+  status_changed: '2014-08-25 19:14:40'
+  subjects:
+  - G400
+  title: 'qcML: An Exchange Format for Quality Control Metrics from Mass Spectrometry
+    Experiments'
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1449
+  userid: 132
+  volume: 13
+- abstract: "Motivation: Automatic error correction of high-throughput sequencing\
+    \ data can have a dramatic impact on the amount of usable base pairs and their\
+    \ quality. It has been shown that the performance of tasks such as de novo genome\
+    \ assembly and SNP calling can be dramatically improved after read error correction.\
+    \ While a large number of methods specialized for correcting substitution errors\
+    \ as found in Illumina data exist, few methods for the correction of indel errors,\
+    \ common to technologies like 454 or Ion Torrent, have been proposed.Results:\
+    \ We present Fiona, a new stand-alone read error\xE2\uFFFD\uFFFDcorrection method.\
+    \ Fiona provides a new statistical approach for sequencing error detection and\
+    \ optimal error correction and estimates its parameters automatically. Fiona is\
+    \ able to correct substitution, insertion and deletion errors and can be applied\
+    \ to any sequencing technology. It uses an efficient implementation of the partial\
+    \ suffix array to detect read overlaps with different seed lengths in parallel.\
+    \ We tested Fiona on several real datasets from a variety of organisms with different\
+    \ read lengths and compared its performance with state-of-the-art methods. Fiona\
+    \ shows a constantly higher correction accuracy over a broad range of datasets\
+    \ from 454 and Ion Torrent sequencers, without compromise in speed.Conclusion:\
+    \ Fiona is an accurate parameter-free read error\xE2\uFFFD\uFFFDcorrection method\
+    \ that can be run on inexpensive hardware and can make use of multicore parallelization\
+    \ whenever available. Fiona was implemented using the SeqAn library for sequence\
+    \ analysis and is publicly available for download at http://www.seqan.de/projects/fiona.Contact:\
+    \ mschulz@mmci.uni-saarland.de or hugues.richard@upmc.frSupplementary information:\
+    \ Supplementary data are available at Bioinformatics online."
+  bibtex: "@article{fu_mi_publications1451,\n abstract = {Motivation: Automatic error\
+    \ correction of high-throughput sequencing data can have a dramatic impact on\
+    \ the amount of usable base pairs and their quality. It has been shown that the\
+    \ performance of tasks such as de novo genome assembly and SNP calling can be\
+    \ dramatically improved after read error correction. While a large number of methods\
+    \ specialized for correcting substitution errors as found in Illumina data exist,\
+    \ few methods for the correction of indel errors, common to technologies like\
+    \ 454 or Ion Torrent, have been proposed.Results: We present Fiona, a new stand-alone\
+    \ read error{\\^a}??correction method. Fiona provides a new statistical approach\
+    \ for sequencing error detection and optimal error correction and estimates its\
+    \ parameters automatically. Fiona is able to correct substitution, insertion and\
+    \ deletion errors and can be applied to any sequencing technology. It uses an\
+    \ efficient implementation of the partial suffix array to detect read overlaps\
+    \ with different seed lengths in parallel. We tested Fiona on several real datasets\
+    \ from a variety of organisms with different read lengths and compared its performance\
+    \ with state-of-the-art methods. Fiona shows a constantly higher correction accuracy\
+    \ over a broad range of datasets from 454 and Ion Torrent sequencers, without\
+    \ compromise in speed.Conclusion: Fiona is an accurate parameter-free read error{\\\
+    ^a}??correction method that can be run on inexpensive hardware and can make use\
+    \ of multicore parallelization whenever available. Fiona was implemented using\
+    \ the SeqAn library for sequence analysis and is publicly available for download\
+    \ at http://www.seqan.de/projects/fiona.Contact: mschulz@mmci.uni-saarland.de\
+    \ or hugues.richard@upmc.frSupplementary information: Supplementary data are available\
+    \ at Bioinformatics online.},\n author = {M. H. Schulz and D. Weese and M. Holtgrewe\
+    \ and V. Dimitrova and S. Niu and K. Reinert and H. Richard},\n journal = {Bioinformatics},\n\
+    \ number = {17},\n pages = {i356--i363},\n title = {Fiona: a parallel and automatic\
+    \ strategy for read error correction},\n url = {http://publications.imp.fu-berlin.de/1451/},\n\
+    \ volume = {30},\n year = {2014}\n}\n\n"
+  creators:
+  - name:
+      family: Schulz
+      given: M. H.
+      honourific: null
+      lineage: null
+  - name:
+      family: Weese
+      given: D.
+      honourific: null
+      lineage: null
+  - name:
+      family: Holtgrewe
+      given: M.
+      honourific: null
+      lineage: null
+  - name:
+      family: Dimitrova
+      given: V.
+      honourific: null
+      lineage: null
+  - name:
+      family: Niu
+      given: S.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  - name:
+      family: Richard
+      given: H.
+      honourific: null
+      lineage: null
+  date: 2014
+  date_type: published
+  datestamp: '2014-08-26 14:02:44'
+  dir: disk0/00/00/14/51
+  divisions:
+  - group_algbioinf
+  documents:
+  - content: supplemental
+    docid: 619
+    eprintid: 1451
+    files:
+    - datasetid: document
+      fileid: 18114
+      filename: Bioinformatics-2014-Schulz-i356-63.pdf
+      filesize: 472369
+      mime_type: application/pdf
+      mtime: '2017-03-03 14:41:37'
+      objectid: 619
+      uri: http://publications.imp.fu-berlin.de/id/file/18114
+    format: application/pdf
+    formatdesc: Main Article
+    language: en
+    main: Bioinformatics-2014-Schulz-i356-63.pdf
+    mime_type: application/pdf
+    pos: 1
+    relation:
+    - type: http://eprints.org/relation/hasVolatileVersion
+      uri: /id/document/1277
+    - type: http://eprints.org/relation/haspreviewThumbnailVersion
+      uri: /id/document/1277
+    - type: http://eprints.org/relation/hasVersion
+      uri: /id/document/1277
+    rev_number: 8
+    security: public
+    uri: http://publications.imp.fu-berlin.de/id/document/619
+  - docid: 620
+    eprintid: 1451
+    files:
+    - datasetid: document
+      fileid: 18117
+      filename: fiona_supplement.pdf
+      filesize: 249703
+      mime_type: application/pdf
+      mtime: '2017-03-03 14:41:37'
+      objectid: 620
+      uri: http://publications.imp.fu-berlin.de/id/file/18117
+    format: application/pdf
+    formatdesc: Supplemental Material
+    language: en
+    main: fiona_supplement.pdf
+    mime_type: application/pdf
+    pos: 2
+    relation:
+    - type: http://eprints.org/relation/hasVersion
+      uri: /id/document/1278
+    - type: http://eprints.org/relation/hasVolatileVersion
+      uri: /id/document/1278
+    - type: http://eprints.org/relation/haspreviewThumbnailVersion
+      uri: /id/document/1278
+    rev_number: 6
+    security: public
+    uri: http://publications.imp.fu-berlin.de/id/document/620
+  eprint_status: archive
+  eprintid: 1451
+  full_text_status: public
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications1451
+  lastmod: '2017-03-03 14:41:37'
+  metadata_visibility: show
+  number: 17
+  official_url: http://bioinformatics.oxfordjournals.org/content/30/17/i356.abstract
+  pagerange: i356-i363
+  publication: Bioinformatics
+  refereed: 'TRUE'
+  rev_number: 18
+  status_changed: '2014-08-26 14:06:03'
+  subjects:
+  - C
+  - G
+  title: 'Fiona: a parallel and automatic strategy for read error correction'
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1451
+  userid: 30
+  volume: 30
+- abstract: "MOTIVATION:Next-generation sequencing technologies produce unprecedented\
+    \ amounts of data, leading to completely new research fields. One of these is\
+    \ metagenomics, the study of large-size DNA samples containing a multitude of\
+    \ diverse organisms. A key problem in metagenomics is to functionally and taxonomically\
+    \ classify the sequenced DNA, to which end the well-known BLAST program is usually\
+    \ used. But BLAST has dramatic resource requirements at metagenomic scales of\
+    \ data, imposing a high financial or technical burden on the researcher. Multiple\
+    \ attempts have been made to overcome these limitations and  present a viable\
+    \ alternative to BLAST.RESULTS:In this work we present Lambda, our own alternative\
+    \ for BLAST in the context of sequence classification. In our tests, Lambda often\
+    \ outperforms the best tools at reproducing BLAST's results and is the fastest\
+    \ compared with the current state of the art at comparable levels of sensitivity.\r\
+    \nAVAILABILITY AND IMPLEMENTATION:Lambda was implemented in the SeqAn open-source\
+    \ C++ library for sequence analysis and is publicly available for download at\
+    \ http://www.seqan.de/projects/lambda.\r\nCONTACT:hannes.hauswedell@fu-berlin.de\r\
+    \nSUPPLEMENTARY INFORMATION:Supplementary data are available at Bioinformatics\
+    \ online."
+  bibtex: "@article{fu_mi_publications1453,\n abstract = {MOTIVATION:Next-generation\
+    \ sequencing technologies produce unprecedented amounts of data, leading to completely\
+    \ new research fields. One of these is metagenomics, the study of large-size DNA\
+    \ samples containing a multitude of diverse organisms. A key problem in metagenomics\
+    \ is to functionally and taxonomically classify the sequenced DNA, to which end\
+    \ the well-known BLAST program is usually used. But BLAST has dramatic resource\
+    \ requirements at metagenomic scales of data, imposing a high financial or technical\
+    \ burden on the researcher. Multiple attempts have been made to overcome these\
+    \ limitations and  present a viable alternative to BLAST.RESULTS:In this work\
+    \ we present Lambda, our own alternative for BLAST in the context of sequence\
+    \ classification. In our tests, Lambda often outperforms the best tools at reproducing\
+    \ BLAST's results and is the fastest compared with the current state of the art\
+    \ at comparable levels of sensitivity.\nAVAILABILITY AND IMPLEMENTATION:Lambda\
+    \ was implemented in the SeqAn open-source C++ library for sequence analysis and\
+    \ is publicly available for download at http://www.seqan.de/projects/lambda.\n\
+    CONTACT:hannes.hauswedell@fu-berlin.de\nSUPPLEMENTARY INFORMATION:Supplementary\
+    \ data are available at Bioinformatics online.},\n author = {H. Hauswedell and\
+    \ J. Singer and K. Reinert},\n journal = {Bioinformatics (Oxford, England)},\n\
+    \ month = {September},\n number = {17},\n pages = {i349--i355},\n publisher =\
+    \ {Oxford University Press},\n title = {Lambda: the local aligner for massive\
+    \ biological data},\n url = {http://publications.imp.fu-berlin.de/1453/},\n volume\
+    \ = {30},\n year = {2014}\n}\n\n"
+  creators:
+  - name:
+      family: Hauswedell
+      given: H.
+      honourific: null
+      lineage: null
+  - name:
+      family: Singer
+      given: J.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: 2014-09
+  datestamp: '2014-09-23 18:00:01'
+  dir: disk0/00/00/14/53
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 1453
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications1453
+  lastmod: '2016-11-15 14:03:47'
+  metadata_visibility: show
+  number: 17
+  official_url: http://bioinformatics.oxfordjournals.org/content/30/17/i349.full
+  pagerange: i349-i355
+  publication: Bioinformatics (Oxford, England)
+  publisher: Oxford University Press
+  refereed: 'TRUE'
+  rev_number: 13
+  status_changed: '2016-11-15 14:03:47'
+  title: 'Lambda: the local aligner for massive biological data'
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1453
+  userid: 29
+  volume: 30
+- abstract: "Abstract The reconstruction of the history of evolutionary genome-wide\
+    \ events among a set of related organisms is of great biological interest since\
+    \ it can help to reveal the genomic basis of phenotypes. The sequencing of whole\
+    \ genomes faciliates the study of gene families that vary in size through duplication\
+    \ and loss events, like transfer RNA. However, a high sequence similarity often\
+    \ does not allow one to distinguish between orthologs and paralogs. Previous methods\
+    \ have addressed this difficulty by taking into account flanking regions of members\
+    \ of a family independently. We go one step further by inferring the order of\
+    \ genes of (a set of) families for ancestral genomes by considering the order\
+    \ of these genes on sequenced genomes. We present a novel branch-and-cut algorithm\
+    \ to solve the two species small phylogeny problem in the evolutionary model of\
+    \ duplications and losses. On average, our implementation, DupLoCut, improves\
+    \ the running time of a recently proposed method in the experiments on six Vibrionaceae\
+    \ lineages by a factor of \xC3\xA2&lt;88&gt;\xC2\xBC200. Besides the mere improvement\
+    \ in running time, the efficiency of our approach allows us to extend our model\
+    \ from cherries of a species tree, that is, subtrees with two leaves, to the median\
+    \ of three species setting. Being able to determine the median of three species\
+    \ is of key importance to one of the most common approaches to ancestral reconstruction,\
+    \ and our experiments show that its repeated computation considerably reduces\
+    \ the number of duplications and losses along the tree both on simulated instances\
+    \ comprising 128 leaves and a set of Bacillus genomes. Furthermore, in our simulations\
+    \ we show that a reduction in cost goes hand in hand with an improvement of the\
+    \ predicted ancestral genomes. Finally, we prove that the small phylogeny problem\
+    \ in the duplication-loss model is NP-complete already for two species."
+  bibtex: "@article{fu_mi_publications1454,\n abstract = {Abstract The reconstruction\
+    \ of the history of evolutionary genome-wide events among a set of related organisms\
+    \ is of great biological interest since it can help to reveal the genomic basis\
+    \ of phenotypes. The sequencing of whole genomes faciliates the study of gene\
+    \ families that vary in size through duplication and loss events, like transfer\
+    \ RNA. However, a high sequence similarity often does not allow one to distinguish\
+    \ between orthologs and paralogs. Previous methods have addressed this difficulty\
+    \ by taking into account flanking regions of members of a family independently.\
+    \ We go one step further by inferring the order of genes of (a set of) families\
+    \ for ancestral genomes by considering the order of these genes on sequenced genomes.\
+    \ We present a novel branch-and-cut algorithm to solve the two species small phylogeny\
+    \ problem in the evolutionary model of duplications and losses. On average, our\
+    \ implementation, DupLoCut, improves the running time of a recently proposed method\
+    \ in the experiments on six Vibrionaceae lineages by a factor of {\\~A}?\\&lt;88\\\
+    &gt;{\\^A}?200. Besides the mere improvement in running time, the efficiency of\
+    \ our approach allows us to extend our model from cherries of a species tree,\
+    \ that is, subtrees with two leaves, to the median of three species setting. Being\
+    \ able to determine the median of three species is of key importance to one of\
+    \ the most common approaches to ancestral reconstruction, and our experiments\
+    \ show that its repeated computation considerably reduces the number of duplications\
+    \ and losses along the tree both on simulated instances comprising 128 leaves\
+    \ and a set of Bacillus genomes. Furthermore, in our simulations we show that\
+    \ a reduction in cost goes hand in hand with an improvement of the predicted ancestral\
+    \ genomes. Finally, we prove that the small phylogeny problem in the duplication-loss\
+    \ model is NP-complete already for two species.},\n author = {S. Andreotti and\
+    \ K. Reinert and S. Canzar},\n journal = {Journal of Computational Biology},\n\
+    \ month = {September},\n number = {9},\n pages = {643--59},\n title = {The duplication-loss\
+    \ small phylogeny problem: from cherries to trees.},\n url = {http://publications.imp.fu-berlin.de/1454/},\n\
+    \ volume = {20},\n year = {2013}\n}\n\n"
+  creators:
+  - name:
+      family: Andreotti
+      given: S.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  - name:
+      family: Canzar
+      given: S.
+      honourific: null
+      lineage: null
+  date: 2013-09
+  datestamp: '2014-09-24 08:36:24'
+  dir: disk0/00/00/14/54
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 1454
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications1454
+  lastmod: '2014-09-24 09:33:53'
+  metadata_visibility: show
+  number: 9
+  official_url: http://www.ncbi.nlm.nih.gov/pubmed/24000925
+  pagerange: 643-59
+  publication: Journal of Computational Biology
+  refereed: 'TRUE'
+  rev_number: 12
+  status_changed: '2014-09-24 09:33:53'
+  subjects:
+  - C
+  - G
+  title: 'The duplication-loss small phylogeny problem: from cherries to trees.'
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1454
+  userid: 30
+  volume: 20
+- abstract: "MOTIVATION:\r\nThe landscape of structural variation (SV) including complex\
+    \ duplication and translocation patterns is far from resolved. SV detection tools\
+    \ usually exhibit low agreement, are often geared toward certain types or size\
+    \ ranges of variation and struggle to correctly classify the type and exact size\
+    \ of SVs.\r\n\r\nRESULTS:\r\nWe present Gustaf (Generic mUlti-SpliT Alignment\
+    \ Finder), a sound generic multi-split SV detection tool that detects and classifies\
+    \ deletions, inversions, dispersed duplications and translocations of <span class='mathrm'>ge</span>30\
+    \ bp. Our approach is based on a generic multi-split alignment strategy that can\
+    \ identify SV breakpoints with base pair resolution. We show that Gustaf correctly\
+    \ identifies SVs, especially in the range from 30 to 100 bp, which we call the\
+    \ next-generation sequencing (NGS) twilight zone of SVs, as well as larger SVs\
+    \ &gt;500 bp. Gustaf performs better than similar tools in our benchmark and is\
+    \ furthermore able to correctly identify size and location of dispersed duplications\
+    \ and translocations, which otherwise might be wrongly classified, for example,\
+    \ as large deletions. Availability and implementation: Project information, paper\
+    \ benchmark and source code are available via http://www.seqan.de/projects/gustaf/.\r\
+    \n\r\nCONTACT:kathrin.trappe@fu-berlin.de."
+  bibtex: "@article{fu_mi_publications1455,\n abstract = {MOTIVATION:\nThe landscape\
+    \ of structural variation (SV) including complex duplication and translocation\
+    \ patterns is far from resolved. SV detection tools usually exhibit low agreement,\
+    \ are often geared toward certain types or size ranges of variation and struggle\
+    \ to correctly classify the type and exact size of SVs.\n\nRESULTS:\nWe present\
+    \ Gustaf (Generic mUlti-SpliT Alignment Finder), a sound generic multi-split SV\
+    \ detection tool that detects and classifies deletions, inversions, dispersed\
+    \ duplications and translocations of {\\ensuremath{<}}span class='mathrm'{\\ensuremath{>}}ge{\\\
+    ensuremath{<}}/span{\\ensuremath{>}}30 bp. Our approach is based on a generic\
+    \ multi-split alignment strategy that can identify SV breakpoints with base pair\
+    \ resolution. We show that Gustaf correctly identifies SVs, especially in the\
+    \ range from 30 to 100 bp, which we call the next-generation sequencing (NGS)\
+    \ twilight zone of SVs, as well as larger SVs \\&gt;500 bp. Gustaf performs better\
+    \ than similar tools in our benchmark and is furthermore able to correctly identify\
+    \ size and location of dispersed duplications and translocations, which otherwise\
+    \ might be wrongly classified, for example, as large deletions. Availability and\
+    \ implementation: Project information, paper benchmark and source code are available\
+    \ via http://www.seqan.de/projects/gustaf/.\n\nCONTACT:kathrin.trappe@fu-berlin.de.},\n\
+    \ author = {K. Trappe and A.-K. Emde and H.-C. Ehrlich and K. Reinert},\n journal\
+    \ = {Bioinformatics},\n month = {July},\n number = {24},\n pages = {3484--3490},\n\
+    \ publisher = {Oxford University Press},\n title = {Gustaf: Detecting and correctly\
+    \ classifying SVs in the NGS twilight zone},\n url = {http://publications.imp.fu-berlin.de/1455/},\n\
+    \ volume = {30},\n year = {2014}\n}\n\n"
+  creators:
+  - id: null
+    name:
+      family: Trappe
+      given: K.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Emde
+      given: A.-K.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Ehrlich
+      given: H.-C.
+      honourific: null
+      lineage: null
+  - id: knut.reinert@fu-berlin.de
+    name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: '2014-07-14'
+  date_type: published
+  datestamp: '2014-09-30 11:00:30'
+  dir: disk0/00/00/14/55
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 1455
+  full_text_status: none
+  ispublished: pub
+  issn: 1367-4803
+  item_issues_count: 0
+  key: fu_mi_publications1455
+  lastmod: '2014-12-10 15:11:44'
+  metadata_visibility: show
+  number: 24
+  official_url: http://bioinformatics.oxfordjournals.org/content/early/2014/07/29/bioinformatics.btu431.full
+  pagerange: 3484-3490
+  publication: Bioinformatics
+  publisher: Oxford University Press
+  refereed: 'TRUE'
+  rev_number: 12
+  status_changed: '2014-12-10 15:11:43'
+  subjects:
+  - G620
+  - G400
+  title: 'Gustaf: Detecting and correctly classifying SVs in the NGS twilight zone'
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1455
+  userid: 29
+  volume: 30
+- abstract: "MOTIVATION:Sequences and protein interaction data are of significance\
+    \ to understand the underlying molecular mechanism of organisms. Local network\
+    \ alignment is one of key systematic ways for predicting protein functions, identifying\
+    \ functional modules, and understanding the phylogeny from these data. Most of\
+    \ currently existing tools, however, encounter their limitations which are mainly\
+    \ concerned with scoring scheme, speed and scalability. Therefore, there are growing\
+    \ demands for sophisticated network evolution models and efficient local alignment\
+    \ algorithms.\r\nRESULTS:We developed a fast and scalable local network alignment\
+    \ tool so-called LocalAli for the identification of functionally conserved modules\
+    \ in multiple networks. In this algorithm, we firstly proposed a new framework\
+    \ to reconstruct the evolution history of conserved modules based on a maximum-parsimony\
+    \ evolutionary model. By relying on this model, LocalAli facilitates interpretation\
+    \ of resulting local alignments in terms of conserved modules which have been\
+    \ evolved from a common ancestral module through a series of evolutionary events.\
+    \ A meta-heuristic method simulated annealing was used to search for the optimal\
+    \ or near-optimal inner nodes (i.e. ancestral modules) of the evolutionary tree.\
+    \ To evaluate the performance and the statistical significance, LocalAli were\
+    \ tested on a total of 26 real datasets and 1040 randomly generated datasets.\
+    \ The results suggest that LocalAli outperforms all existing algorithms in terms\
+    \ of coverage, consistency and scalability, meanwhile retains a high precision\
+    \ in the identification of functionally coherent subnetworks.\r\n\r\nAVAILABILITY:The\
+    \ source code and test datasets are freely available for download under the GNU\
+    \ GPL v3 license at https://code.google.com/p/localali/.\r\n\r\nCONTACT:jialu.hu@fu-berlin.de\
+    \ or knut.reinert@fu-berlin.de."
+  bibtex: "@article{fu_mi_publications1457,\n abstract = {MOTIVATION:Sequences and\
+    \ protein interaction data are of significance to understand the underlying molecular\
+    \ mechanism of organisms. Local network alignment is one of key systematic ways\
+    \ for predicting protein functions, identifying functional modules, and understanding\
+    \ the phylogeny from these data. Most of currently existing tools, however, encounter\
+    \ their limitations which are mainly concerned with scoring scheme, speed and\
+    \ scalability. Therefore, there are growing demands for sophisticated network\
+    \ evolution models and efficient local alignment algorithms.\nRESULTS:We developed\
+    \ a fast and scalable local network alignment tool so-called LocalAli for the\
+    \ identification of functionally conserved modules in multiple networks. In this\
+    \ algorithm, we firstly proposed a new framework to reconstruct the evolution\
+    \ history of conserved modules based on a maximum-parsimony evolutionary model.\
+    \ By relying on this model, LocalAli facilitates interpretation of resulting local\
+    \ alignments in terms of conserved modules which have been evolved from a common\
+    \ ancestral module through a series of evolutionary events. A meta-heuristic method\
+    \ simulated annealing was used to search for the optimal or near-optimal inner\
+    \ nodes (i.e. ancestral modules) of the evolutionary tree. To evaluate the performance\
+    \ and the statistical significance, LocalAli were tested on a total of 26 real\
+    \ datasets and 1040 randomly generated datasets. The results suggest that LocalAli\
+    \ outperforms all existing algorithms in terms of coverage, consistency and scalability,\
+    \ meanwhile retains a high precision in the identification of functionally coherent\
+    \ subnetworks.\n\nAVAILABILITY:The source code and test datasets are freely available\
+    \ for download under the GNU GPL v3 license at https://code.google.com/p/localali/.\n\
+    \nCONTACT:jialu.hu@fu-berlin.de or knut.reinert@fu-berlin.de.},\n author = {J.\
+    \ Hu and K. Reinert},\n journal = {Bioinformatics},\n number = {1},\n pages =\
+    \ {363--372},\n publisher = {Oxford University Press},\n title = {LocalAli: An\
+    \ Evolutionary-based Local Alignment Approach to Identify Functionally Conserved\
+    \ Modules in Multiple Networks.},\n url = {http://publications.imp.fu-berlin.de/1457/},\n\
+    \ volume = {30},\n year = {2015}\n}\n\n"
+  creators:
+  - name:
+      family: Hu
+      given: J.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: 2015
+  date_type: published
+  datestamp: '2014-10-12 19:16:09'
+  dir: disk0/00/00/14/57
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 1457
+  full_text_status: none
+  id_number: 'doi: 10.1093/bioinformatics/btu652'
+  ispublished: pub
+  issn: 1367-4803
+  item_issues_count: 0
+  key: fu_mi_publications1457
+  lastmod: '2016-11-15 14:02:23'
+  metadata_visibility: show
+  number: 1
+  official_url: http://bioinformatics.oxfordjournals.org/cgi/doi/10.1093/bioinformatics/btu652
+  pagerange: 363-372
+  publication: Bioinformatics
+  publisher: Oxford University Press
+  refereed: 'TRUE'
+  rev_number: 16
+  status_changed: '2016-11-15 14:02:22'
+  subjects:
+  - C100
+  - G400
+  title: 'LocalAli: An Evolutionary-based Local Alignment Approach to Identify Functionally
+    Conserved Modules in Multiple Networks.'
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1457
+  userid: 29
+  volume: 30
+- abstract: "Received 29 June 2014\r\nReceived in revised form\r\n29 September 2014\r\
+    \nAccepted 24 October 2014 Available online 30 October 2014\r\nKeywords:\r\nThyroxine\r\
+    \nUltrahigh-performance liquid chromatography\r\nElectrospray ionization Orbitrap\
+    \ mass spectrometry\r\nKinetics\r\nDrug degradation\r\nBioinformatics\r\n1. Introduction\r\
+    \nLevothyroxine (T4) is a well-known and widely used drug for the treatment of\
+    \ hypothyroidism. The therapy is usually based on substitution of the natural\
+    \ hormone by a long-term treatment with synthetic levothyroxine [1]. It is a narrow\
+    \ therapeutic index drug, for which individual dosage levels of patients need\
+    \ to be established over several weeks. Consequently, products differing in content\
+    \ of levothyroxine due to compound instability or problems in formu- lation can\
+    \ lead to wrong medication and potentially cause severe health problems [2,3].\r\
+    \n\u2217 Corresponding author. Tel.:+43 0 662 8044 5704; fax: +43 0 662 8044 5751.\
+    \ E-mail addresses: volker.a.neu@basf.com (V. Neu), chris.bielow@fu-berlin.de\
+    \ (C. Bielow), reinert@inf.fu-berlin.de (K. Reinert), c.huber@sbg.ac.at (C.G.\
+    \ Huber).\r\nhttp://dx.doi.org/10.1016/j.chroma.2014.10.071\r\n0021-9673/\xA9\
+    \ 2014 Elsevier B.V. All rights reserved.\r\nabstract\r\nLevothyroxine as active\
+    \ pharmaceutical ingredient of formulations used for the treatment of hypothy-\
+    \ roidism is distributed worldwide and taken by millions of people. An important\
+    \ issue in terms of compound stability is its capability to react with ambient\
+    \ oxygen, especially in case of long term com- pound storage at elevated temperature.\
+    \ In this study we demonstrate that ultrahigh-performance liquid chromatography\
+    \ coupled to UV spectrometry and high-resolution mass spectrometry (UHPLC-UV-HRMS)\
+    \ represent very useful approaches to investigate the influence of ambient oxygen\
+    \ on the degradation kinet- ics of levothyroxine in the solid state at enhanced\
+    \ degradation conditions. Moreover, the impurity pattern of oxidative degradation\
+    \ of levothyroxine is elucidated and classified with respect to degradation kinetics\
+    \ at different oxygen levels. Kinetic analysis of thyroxine bulk material at 100\
+    \ \u25E6 C reveals bi-phasic degra- dation kinetics with a distinct change in\
+    \ degradation phases dependent on the availability of oxygen. The results clearly\
+    \ show that contact of the bulk material to ambient oxygen is a key factor for\
+    \ fast compound degradation. Furthermore, the combination of time-resolved HRMS\
+    \ data and automated data processing is shown to allow insights into the kinetics\
+    \ and mechanism of impurity formation on individual com- pound basis. By comparing\
+    \ degradation profiles, four main classes of profiles linked to reaction pathways\
+    \ of thyroxine degradation were identifiable. Finally, we show the capability\
+    \ of automated data process- ing for the matching of different stressing conditions,\
+    \ in order to extract information about mechanistic similarities. As a result,\
+    \ degradation kinetics is influenced by factors like availability of oxygen, stressing\
+    \ time, or stressing temperature, while the degradation mechanisms appear to be\
+    \ conserved."
+  bibtex: "@article{fu_mi_publications1463,\n abstract = {Received 29 June 2014\n\
+    Received in revised form\n29 September 2014\nAccepted 24 October 2014 Available\
+    \ online 30 October 2014\nKeywords:\nThyroxine\nUltrahigh-performance liquid chromatography\n\
+    Electrospray ionization Orbitrap mass spectrometry\nKinetics\nDrug degradation\n\
+    Bioinformatics\n1. Introduction\nLevothyroxine (T4) is a well-known and widely\
+    \ used drug for the treatment of hypothyroidism. The therapy is usually based\
+    \ on substitution of the natural hormone by a long-term treatment with synthetic\
+    \ levothyroxine [1]. It is a narrow therapeutic index drug, for which individual\
+    \ dosage levels of patients need to be established over several weeks. Consequently,\
+    \ products differing in content of levothyroxine due to compound instability or\
+    \ problems in formu- lation can lead to wrong medication and potentially cause\
+    \ severe health problems [2,3].\n? Corresponding author. Tel.:+43 0 662 8044 5704;\
+    \ fax: +43 0 662 8044 5751. E-mail addresses: volker.a.neu@basf.com (V. Neu),\
+    \ chris.bielow@fu-berlin.de (C. Bielow), reinert@inf.fu-berlin.de (K. Reinert),\
+    \ c.huber@sbg.ac.at (C.G. Huber).\nhttp://dx.doi.org/10.1016/j.chroma.2014.10.071\n\
+    0021-9673/{\\copyright} 2014 Elsevier B.V. All rights reserved.\nabstract\nLevothyroxine\
+    \ as active pharmaceutical ingredient of formulations used for the treatment of\
+    \ hypothy- roidism is distributed worldwide and taken by millions of people. An\
+    \ important issue in terms of compound stability is its capability to react with\
+    \ ambient oxygen, especially in case of long term com- pound storage at elevated\
+    \ temperature. In this study we demonstrate that ultrahigh-performance liquid\
+    \ chromatography coupled to UV spectrometry and high-resolution mass spectrometry\
+    \ (UHPLC-UV-HRMS) represent very useful approaches to investigate the influence\
+    \ of ambient oxygen on the degradation kinet- ics of levothyroxine in the solid\
+    \ state at enhanced degradation conditions. Moreover, the impurity pattern of\
+    \ oxidative degradation of levothyroxine is elucidated and classified with respect\
+    \ to degradation kinetics at different oxygen levels. Kinetic analysis of thyroxine\
+    \ bulk material at 100 ? C reveals bi-phasic degra- dation kinetics with a distinct\
+    \ change in degradation phases dependent on the availability of oxygen. The results\
+    \ clearly show that contact of the bulk material to ambient oxygen is a key factor\
+    \ for fast compound degradation. Furthermore, the combination of time-resolved\
+    \ HRMS data and automated data processing is shown to allow insights into the\
+    \ kinetics and mechanism of impurity formation on individual com- pound basis.\
+    \ By comparing degradation profiles, four main classes of profiles linked to reaction\
+    \ pathways of thyroxine degradation were identifiable. Finally, we show the capability\
+    \ of automated data process- ing for the matching of different stressing conditions,\
+    \ in order to extract information about mechanistic similarities. As a result,\
+    \ degradation kinetics is influenced by factors like availability of oxygen, stressing\
+    \ time, or stressing temperature, while the degradation mechanisms appear to be\
+    \ conserved.},\n author = {V. Neu and C. Bielow and K. Reinert and C. G. Huber},\n\
+    \ journal = {Journal of chromatography A},\n month = {December},\n pages = {196--203},\n\
+    \ title = {Ultrahigh-performance liquid chromatography-ultraviolet absorbance\
+    \ detection-high-resolution-mass spectrometry combined with automated data processing\
+    \ for studying the kinetics of oxidative thermal degradation of thyroxine in the\
+    \ solid state},\n url = {http://publications.imp.fu-berlin.de/1463/},\n volume\
+    \ = {1371},\n year = {2014}\n}\n\n"
+  creators:
+  - name:
+      family: Neu
+      given: V.
+      honourific: null
+      lineage: null
+  - name:
+      family: Bielow
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  - name:
+      family: Huber
+      given: C. G.
+      honourific: null
+      lineage: null
+  date: 2014-12
+  date_type: published
+  datestamp: '2014-11-19 15:15:57'
+  dir: disk0/00/00/14/63
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 1463
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications1463
+  lastmod: '2016-11-15 14:03:10'
+  metadata_visibility: show
+  official_url: http://linkinghub.elsevier.com/retrieve/pii/S0021967314016823
+  pagerange: 196-203
+  publication: Journal of chromatography A
+  refereed: 'TRUE'
+  rev_number: 12
+  status_changed: '2016-11-15 14:03:10'
+  subjects:
+  - C710
+  title: Ultrahigh-performance liquid chromatography-ultraviolet absorbance detection-high-resolution-mass
+    spectrometry combined with automated data processing for studying the kinetics
+    of oxidative thermal degradation of thyroxine in the solid state
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1463
+  userid: 29
+  volume: 1371
+- abstract: The increasing scale and complexity of quantitative proteomics studies
+    complicate subsequent analysis of the acquired data. Untargeted label-free quantification,
+    based either on feature intensities or on spectral counting, is a method that
+    scales particularly well with respect to the number of samples. It is thus an
+    excellent alternative to labeling techniques. In order to profit from this scalability,
+    however, data analysis has to cope with large amounts of data, process them automatically,
+    and do a thorough statistical analysis in order to achieve reliable results. We
+    review the state of the art with respect to computational tools for label-free
+    quantification in untargeted proteomics. The two fundamental approaches are feature-based
+    quantification, relying on the summed-up mass spectrometric intensity of peptides,
+    and spectral counting, which relies on the number of MS/MS spectra acquired for
+    a certain protein. We review the current algorithmic approaches underlying some
+    widely used software packages and briefly discuss the statistical strategies for
+    analyzing the data.
+  bibtex: "@article{fu_mi_publications1473,\n abstract = {The increasing scale and\
+    \ complexity of quantitative proteomics studies complicate subsequent analysis\
+    \ of the acquired data. Untargeted label-free quantification, based either on\
+    \ feature intensities or on spectral counting, is a method that scales particularly\
+    \ well with respect to the number of samples. It is thus an excellent alternative\
+    \ to labeling techniques. In order to profit from this scalability, however, data\
+    \ analysis has to cope with large amounts of data, process them automatically,\
+    \ and do a thorough statistical analysis in order to achieve reliable results.\
+    \ We review the state of the art with respect to computational tools for label-free\
+    \ quantification in untargeted proteomics. The two fundamental approaches are\
+    \ feature-based quantification, relying on the summed-up mass spectrometric intensity\
+    \ of peptides, and spectral counting, which relies on the number of MS/MS spectra\
+    \ acquired for a certain protein. We review the current algorithmic approaches\
+    \ underlying some widely used software packages and briefly discuss the statistical\
+    \ strategies for analyzing the data.},\n author = {S. Nahnsen and C. Bielow and\
+    \ K. Reinert and O. Kohlbacher},\n journal = {Molecular \\& Cellular Proteomics},\n\
+    \ month = {March},\n number = {3},\n pages = {549--556},\n title = {Tools for\
+    \ Label-free Peptide Quantification},\n url = {http://publications.imp.fu-berlin.de/1473/},\n\
+    \ volume = {12},\n year = {2013}\n}\n\n"
+  creators:
+  - name:
+      family: Nahnsen
+      given: S.
+      honourific: null
+      lineage: null
+  - name:
+      family: Bielow
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  - name:
+      family: Kohlbacher
+      given: O.
+      honourific: null
+      lineage: null
+  date: '2013-03-01'
+  date_type: published
+  datestamp: '2014-12-09 12:32:07'
+  dir: disk0/00/00/14/73
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 1473
+  full_text_status: none
+  id_number: doi:10.1074/mcp.R112.025163
+  ispublished: pub
+  issn: 1535-9476
+  item_issues_count: 0
+  key: fu_mi_publications1473
+  lastmod: '2014-12-09 12:32:07'
+  metadata_visibility: show
+  number: 3
+  official_url: http://dx.doi.org/10.1074/mcp.R112.025163
+  pagerange: 549-556
+  publication: Molecular & Cellular Proteomics
+  refereed: 'TRUE'
+  rev_number: 7
+  status_changed: '2014-12-09 12:32:07'
+  subjects:
+  - G400
+  title: Tools for Label-free Peptide Quantification
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1473
+  userid: 132
+  volume: 12
+- abstract: "Cisplatin is one of the most widely used chemotherapeutic agents for\
+    \ the treatment of solid tumours. The major dose-limiting factor is nephrotoxicity,\
+    \ in particular in the proximal tubule. Here, we use an integrated omics approach,\
+    \ including transcriptomics, proteomics and metabolomics coupled to biokinetics\
+    \ to identify cell stress response pathways induced by cisplatin. The human renal\
+    \ proximal tubular cell line RPTEC/TERT1 was treated with sub-cytotoxic concentrations\
+    \ of cisplatin (0.5 and 2\u03BCM) in a daily repeat dose treating regime for up\
+    \ to 14days. Biokinetic analysis showed that cisplatin was taken up from the basolateral\
+    \ compartment, transported to the apical compartment, and accumulated in cells\
+    \ over time. This is in line with basolateral uptake of cisplatin via organic\
+    \ cation transporter 2 and bioactivation via gamma-glutamyl transpeptidase located\
+    \ on the apical side of proximal tubular cells. Cisplatin affected several pathways\
+    \ including, p53 signalling, Nrf2 mediated oxidative stress response, mitochondrial\
+    \ processes, mTOR and AMPK signalling. In addition, we identified novel pathways\
+    \ changed by cisplatin, including eIF2 signalling, actin nucleation via the ARP/WASP\
+    \ complex and regulation of cell polarization. In conclusion, using an integrated\
+    \ omic approach together with biokinetics we have identified both novel and established\
+    \ mechanisms of cisplatin toxicity."
+  bibtex: "@article{fu_mi_publications1488,\n abstract = {Cisplatin is one of the\
+    \ most widely used chemotherapeutic agents for the treatment of solid tumours.\
+    \ The major dose-limiting factor is nephrotoxicity, in particular in the proximal\
+    \ tubule. Here, we use an integrated omics approach, including transcriptomics,\
+    \ proteomics and metabolomics coupled to biokinetics to identify cell stress response\
+    \ pathways induced by cisplatin. The human renal proximal tubular cell line RPTEC/TERT1\
+    \ was treated with sub-cytotoxic concentrations of cisplatin (0.5 and 2{\\ensuremath{\\\
+    mu}}M) in a daily repeat dose treating regime for up to 14days. Biokinetic analysis\
+    \ showed that cisplatin was taken up from the basolateral compartment, transported\
+    \ to the apical compartment, and accumulated in cells over time. This is in line\
+    \ with basolateral uptake of cisplatin via organic cation transporter 2 and bioactivation\
+    \ via gamma-glutamyl transpeptidase located on the apical side of proximal tubular\
+    \ cells. Cisplatin affected several pathways including, p53 signalling, Nrf2 mediated\
+    \ oxidative stress response, mitochondrial processes, mTOR and AMPK signalling.\
+    \ In addition, we identified novel pathways changed by cisplatin, including eIF2\
+    \ signalling, actin nucleation via the ARP/WASP complex and regulation of cell\
+    \ polarization. In conclusion, using an integrated omic approach together with\
+    \ biokinetics we have identified both novel and established mechanisms of cisplatin\
+    \ toxicity.},\n author = {Anja Wilmes and Chris Bielow and Christina Ranninger\
+    \ and Patricia Bellwon and Lydia Aschauer and Alice Limonciel and Hubert Chassaigne\
+    \ and Theresa Kristl and Stephan Aiche and Christian G. Huber and Claude Guillou\
+    \ and Philipp Hewitt and Martin O. Leonard and Wolfgang Dekant and Frederic Bois\
+    \ and Paul Jennings},\n journal = {Toxicology in Vitro},\n month = {December},\n\
+    \ number = {1, Part A},\n pages = {117--127},\n publisher = {Elsevier B.V.},\n\
+    \ title = {Mechanism of cisplatin proximal tubule toxicity revealed by integrating\
+    \ transcriptomics, proteomics, metabolomics and biokinetics},\n url = {http://publications.imp.fu-berlin.de/1488/},\n\
+    \ volume = {30},\n year = {2015}\n}\n\n"
+  creators:
+  - name:
+      family: Wilmes
+      given: Anja
+      honourific: null
+      lineage: null
+  - name:
+      family: Bielow
+      given: Chris
+      honourific: null
+      lineage: null
+  - name:
+      family: Ranninger
+      given: Christina
+      honourific: null
+      lineage: null
+  - name:
+      family: Bellwon
+      given: Patricia
+      honourific: null
+      lineage: null
+  - name:
+      family: Aschauer
+      given: Lydia
+      honourific: null
+      lineage: null
+  - name:
+      family: Limonciel
+      given: Alice
+      honourific: null
+      lineage: null
+  - name:
+      family: Chassaigne
+      given: Hubert
+      honourific: null
+      lineage: null
+  - name:
+      family: Kristl
+      given: Theresa
+      honourific: null
+      lineage: null
+  - name:
+      family: Aiche
+      given: Stephan
+      honourific: null
+      lineage: null
+  - name:
+      family: Huber
+      given: Christian G.
+      honourific: null
+      lineage: null
+  - name:
+      family: Guillou
+      given: Claude
+      honourific: null
+      lineage: null
+  - name:
+      family: Hewitt
+      given: Philipp
+      honourific: null
+      lineage: null
+  - name:
+      family: Leonard
+      given: Martin O.
+      honourific: null
+      lineage: null
+  - name:
+      family: Dekant
+      given: Wolfgang
+      honourific: null
+      lineage: null
+  - name:
+      family: Bois
+      given: Frederic
+      honourific: null
+      lineage: null
+  - name:
+      family: Jennings
+      given: Paul
+      honourific: null
+      lineage: null
+  date: '2015-12-25'
+  date_type: published
+  datestamp: '2015-01-21 12:15:51'
+  dir: disk0/00/00/14/88
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 1488
+  full_text_status: none
+  id_number: doi:10.1016/j.tiv.2014.10.006
+  ispublished: pub
+  issn: 8872333
+  item_issues_count: 0
+  key: fu_mi_publications1488
+  lastmod: '2016-02-23 16:10:47'
+  metadata_visibility: show
+  number: 1, Part A
+  official_url: http://dx.doi.org/10.1016/j.tiv.2014.10.006
+  pagerange: 117-127
+  publication: Toxicology in Vitro
+  publisher: Elsevier B.V.
+  refereed: 'TRUE'
+  rev_number: 13
+  status_changed: '2016-02-23 16:10:47'
+  subjects:
+  - G400
+  title: Mechanism of cisplatin proximal tubule toxicity revealed by integrating transcriptomics,
+    proteomics, metabolomics and biokinetics
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1488
+  userid: 132
+  volume: 30
+- abstract: 'MS-based proteomics and metabolomics are rapidly evolving research fields
+    driven by the development of novel instruments, experimental approaches, and analysis
+    methods. Monolithic analysis tools perform well on single tasks but lack the flexibility
+    to cope with the constantly changing requirements and experimental setups. Workflow
+    systems, which combine small processing tools into complex analysis pipelines,
+    allow custom-tailored and flexible data-processing workflows that can be published
+    or shared with collaborators. In this article, we present the integration of established
+    tools for computational MS from the open-source software framework OpenMS into
+    the workflow engine Konstanz Information Miner (KNIME) for the analysis of large
+    datasets and production of high-quality visualizations. We provide example workflows
+    to demonstrate combined data processing and visualization for three diverse tasks
+    in computational MS: isobaric mass tag based quantitation in complex experimental
+    setups, label-free quantitation and identification of metabolites, and quality
+    control for proteomics experiments.'
+  bibtex: "@article{fu_mi_publications1505,\n abstract = {MS-based proteomics and\
+    \ metabolomics are rapidly evolving research fields driven by the development\
+    \ of novel instruments, experimental approaches, and analysis methods. Monolithic\
+    \ analysis tools perform well on single tasks but lack the flexibility to cope\
+    \ with the constantly changing requirements and experimental setups. Workflow\
+    \ systems, which combine small processing tools into complex analysis pipelines,\
+    \ allow custom-tailored and flexible data-processing workflows that can be published\
+    \ or shared with collaborators. In this article, we present the integration of\
+    \ established tools for computational MS from the open-source software framework\
+    \ OpenMS into the workflow engine Konstanz Information Miner (KNIME) for the analysis\
+    \ of large datasets and production of high-quality visualizations. We provide\
+    \ example workflows to demonstrate combined data processing and visualization\
+    \ for three diverse tasks in computational MS: isobaric mass tag based quantitation\
+    \ in complex experimental setups, label-free quantitation and identification of\
+    \ metabolites, and quality control for proteomics experiments.},\n author = {S.\
+    \ Aiche and T. Sachsenberg and E. Kenar and M. Walzer and B. Wiswedel and T. Kristl\
+    \ and M. Boyles and A. Duschl and C. G. Huber and M. R. Berthold and K. Reinert\
+    \ and O. Kohlbacher},\n journal = {PROTEOMICS},\n month = {April},\n number =\
+    \ {8},\n pages = {1443--1447},\n publisher = {Wiley VCH},\n title = {Workflows\
+    \ for automated downstream data analysis and visualization in large-scale computational\
+    \ mass spectrometry},\n url = {http://publications.imp.fu-berlin.de/1505/},\n\
+    \ volume = {15},\n year = {2015}\n}\n\n"
+  creators:
+  - id: null
+    name:
+      family: Aiche
+      given: S.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Sachsenberg
+      given: T.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Kenar
+      given: E.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Walzer
+      given: M.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Wiswedel
+      given: B.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Kristl
+      given: T.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Boyles
+      given: M.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Duschl
+      given: A.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Huber
+      given: C. G.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Berthold
+      given: M. R.
+      honourific: null
+      lineage: null
+  - id: knut.reinert@fu-berlin.de
+    name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Kohlbacher
+      given: O.
+      honourific: null
+      lineage: null
+  date: 2015-04
+  date_type: published
+  datestamp: '2015-02-12 12:07:57'
+  dir: disk0/00/00/15/05
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 1505
+  full_text_status: none
+  id_number: doi:10.1002/pmic.201400391
+  ispublished: pub
+  issn: 16159853
+  item_issues_count: 0
+  key: fu_mi_publications1505
+  lastmod: '2016-11-15 14:01:31'
+  metadata_visibility: show
+  number: 8
+  official_url: http://dx.doi.org/10.1002/pmic.201400391
+  pagerange: 1443-1447
+  publication: PROTEOMICS
+  publisher: Wiley VCH
+  refereed: 'TRUE'
+  rev_number: 13
+  status_changed: '2016-11-15 14:01:31'
+  subjects:
+  - G400
+  title: Workflows for automated downstream data analysis and visualization in large-scale
+    computational mass spectrometry
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1505
+  userid: 132
+  volume: 15
+- abstract: "Motivation: \r\nLarge insertions of novel sequence are an important type\
+    \ of structural variants. Previous studies used traditional de novo assemblers\
+    \ for assembling non-mapping high-throughput sequencing (HTS) or capillary reads\
+    \ and then tried to anchor them in the reference using paired read information.\r\
+    \n\r\nResults: \r\nWe present approaches for detecting insertion breakpoints and\
+    \ targeted assembly of large insertions from HTS paired data: BASIL and ANISE.\
+    \ On near identity repeats that are hard for assemblers, ANISE employs a repeat\
+    \ resolution step. This results in far better reconstructions than obtained by\
+    \ the compared methods. On simulated data, we found our insert assembler to be\
+    \ competitive with the de novo assemblers ABYSS and SGA while yielding already\
+    \ anchored inserted sequence as opposed to unanchored contigs as from ABYSS/SGA.\
+    \ On real-world data, we detected novel sequence in a human individual and thoroughly\
+    \ validated the assembled sequence. ANISE was found to be superior to the competing\
+    \ tool MindTheGap on both simulated and real-world data.\r\n\r\nAvailability and\
+    \ implementation: ANISE and BASIL are available for download at http://www.seqan.de/projects/herbarium\
+    \ under a permissive open source license. \r\n\r\nContact: manuel.holtgrewe@fu-berlin.de\
+    \ or knut.reinert@fu-berlin.de"
+  bibtex: "@article{fu_mi_publications1506,\n abstract = {Motivation: \nLarge insertions\
+    \ of novel sequence are an important type of structural variants. Previous studies\
+    \ used traditional de novo assemblers for assembling non-mapping high-throughput\
+    \ sequencing (HTS) or capillary reads and then tried to anchor them in the reference\
+    \ using paired read information.\n\nResults: \nWe present approaches for detecting\
+    \ insertion breakpoints and targeted assembly of large insertions from HTS paired\
+    \ data: BASIL and ANISE. On near identity repeats that are hard for assemblers,\
+    \ ANISE employs a repeat resolution step. This results in far better reconstructions\
+    \ than obtained by the compared methods. On simulated data, we found our insert\
+    \ assembler to be competitive with the de novo assemblers ABYSS and SGA while\
+    \ yielding already anchored inserted sequence as opposed to unanchored contigs\
+    \ as from ABYSS/SGA. On real-world data, we detected novel sequence in a human\
+    \ individual and thoroughly validated the assembled sequence. ANISE was found\
+    \ to be superior to the competing tool MindTheGap on both simulated and real-world\
+    \ data.\n\nAvailability and implementation: ANISE and BASIL are available for\
+    \ download at http://www.seqan.de/projects/herbarium under a permissive open source\
+    \ license. \n\nContact: manuel.holtgrewe@fu-berlin.de or knut.reinert@fu-berlin.de},\n\
+    \ author = {M. Holtgrewe and L. Kuchenbecker and K. Reinert},\n journal = {Bioinformatics},\n\
+    \ number = {12},\n pages = {1904--1912},\n title = {Methods for the Detection\
+    \ and Assembly of Novel Sequence in High-Throughput Sequencing Data},\n url =\
+    \ {http://publications.imp.fu-berlin.de/1506/},\n volume = {31},\n year = {2015}\n\
+    }\n\n"
+  creators:
+  - name:
+      family: Holtgrewe
+      given: M.
+      honourific: null
+      lineage: null
+  - name:
+      family: Kuchenbecker
+      given: L.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: 2015
+  date_type: published
+  datestamp: '2015-02-16 13:41:21'
+  dir: disk0/00/00/15/06
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 1506
+  full_text_status: none
+  id_number: doi:10.1093/bioinformatics/btv051
+  ispublished: pub
+  issn: 1367-4803
+  item_issues_count: 0
+  key: fu_mi_publications1506
+  lastmod: '2016-02-25 11:13:53'
+  metadata_visibility: show
+  number: 12
+  official_url: http://dx.doi.org/10.1093/bioinformatics/btv051
+  pagerange: 1904-1912
+  publication: Bioinformatics
+  refereed: 'TRUE'
+  rev_number: 14
+  status_changed: '2016-02-25 11:13:53'
+  subjects:
+  - G400
+  title: Methods for the Detection and Assembly of Novel Sequence in High-Throughput
+    Sequencing Data
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1506
+  userid: 132
+  volume: 31
+- abstract: "High-throughput DNA sequencing has considerably changed the possibilities\
+    \ for conducting biomedical research by measuring billions of short DNA or RNA\
+    \ fragments. A central computational problem, and for many applications a first\
+    \ step, consists of determining where the fragments came from\r\nin the original\
+    \ genome. In this article, we review the main techniques for generating the fragments,\
+    \ the main applications, and the main algorithmic ideas for computing a solution\
+    \ to the read alignment problem. In addition, we describe pitfalls and difficulties\
+    \ connected to determining the correct positions of reads."
+  bibtex: "@article{fu_mi_publications1544,\n abstract = {High-throughput DNA sequencing\
+    \ has considerably changed the possibilities for conducting biomedical research\
+    \ by measuring billions of short DNA or RNA fragments. A central computational\
+    \ problem, and for many applications a first step, consists of determining where\
+    \ the fragments came from\nin the original genome. In this article, we review\
+    \ the main techniques for generating the fragments, the main applications, and\
+    \ the main algorithmic ideas for computing a solution to the read alignment problem.\
+    \ In addition, we describe pitfalls and difficulties connected to determining\
+    \ the correct positions of reads.},\n author = {K. Reinert and B. Langmead and\
+    \ D. Weese and D.J. Evers},\n journal = {Annual Review of Genomics and Human Genetics},\n\
+    \ month = {May},\n number = {1},\n pages = {133--151},\n title = {Alignment of\
+    \ Next-Generation Sequencing Reads},\n url = {http://publications.imp.fu-berlin.de/1544/},\n\
+    \ volume = {16},\n year = {2015}\n}\n\n"
+  creators:
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  - name:
+      family: Langmead
+      given: B.
+      honourific: null
+      lineage: null
+  - name:
+      family: Weese
+      given: D.
+      honourific: null
+      lineage: null
+  - name:
+      family: Evers
+      given: D.J.
+      honourific: null
+      lineage: null
+  date: '2015-05-04'
+  date_type: published
+  datestamp: '2015-05-07 12:25:03'
+  dir: disk0/00/00/15/44
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 1544
+  full_text_status: none
+  id_number: doi:10.1146/annurev-genom-090413-025358
+  ispublished: pub
+  issn: 1527-8204
+  item_issues_count: 0
+  key: fu_mi_publications1544
+  lastmod: '2016-02-25 13:11:02'
+  metadata_visibility: show
+  number: 1
+  official_url: http://dx.doi.org/10.1146/annurev-genom-090413-025358
+  pagerange: 133-151
+  publication: Annual Review of Genomics and Human Genetics
+  refereed: 'TRUE'
+  rev_number: 13
+  status_changed: '2016-02-25 13:11:02'
+  subjects:
+  - G400
+  title: Alignment of Next-Generation Sequencing Reads
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1544
+  userid: 132
+  volume: 16
+- abstract: "Motivation: Recombined T and B cell receptor repertoires are increasingly\
+    \ being studied using next generation sequencing (NGS) in order to interrogate\
+    \ the repertoire composition as well as changes in the distribution of receptor\
+    \ clones under different physiological and disease states. This type of analysis\
+    \ requires efficient and unambiguous clonotype assignment to a large number of\
+    \ NGS read sequences, including the identification of the incorporated V and J\
+    \ gene segments and the CDR3 sequence. Current tools have deficits with respect\
+    \ to performance, accuracy and documentation of their underlying algorithms and\
+    \ usage.\r\n\r\nResults: We present IMSEQ, a method to derive clonotype repertoires\
+    \ from next generation sequencing data with sophisticated routines for handling\
+    \ errors stemming from PCR and sequencing artefacts. The application can handle\
+    \ different kinds of input data originating from single- or paired-end sequencing\
+    \ in different configurations and is generic regarding the species and gene of\
+    \ interest. We have carefully evaluated our method with simulated and real world\
+    \ data and show that IMSEQ is superior to other tools with respect to its clonotyping\
+    \ as well as standalone error correction and runtime performance.\r\n\r\nAvailability:\
+    \ IMSEQ was implemented in C++ using the SeqAn library for efficient sequence\
+    \ analysis. It is freely available under the GPLv2 open source license and can\
+    \ be downloaded at www.imtools.org. "
+  bibtex: "@article{fu_mi_publications1551,\n abstract = {Motivation: Recombined T\
+    \ and B cell receptor repertoires are increasingly being studied using next generation\
+    \ sequencing (NGS) in order to interrogate the repertoire composition as well\
+    \ as changes in the distribution of receptor clones under different physiological\
+    \ and disease states. This type of analysis requires efficient and unambiguous\
+    \ clonotype assignment to a large number of NGS read sequences, including the\
+    \ identification of the incorporated V and J gene segments and the CDR3 sequence.\
+    \ Current tools have deficits with respect to performance, accuracy and documentation\
+    \ of their underlying algorithms and usage.\n\nResults: We present IMSEQ, a method\
+    \ to derive clonotype repertoires from next generation sequencing data with sophisticated\
+    \ routines for handling errors stemming from PCR and sequencing artefacts. The\
+    \ application can handle different kinds of input data originating from single-\
+    \ or paired-end sequencing in different configurations and is generic regarding\
+    \ the species and gene of interest. We have carefully evaluated our method with\
+    \ simulated and real world data and show that IMSEQ is superior to other tools\
+    \ with respect to its clonotyping as well as standalone error correction and runtime\
+    \ performance.\n\nAvailability: IMSEQ was implemented in C++ using the SeqAn library\
+    \ for efficient sequence analysis. It is freely available under the GPLv2 open\
+    \ source license and can be downloaded at www.imtools.org. },\n author = {L. Kuchenbecker\
+    \ and M. Nienen and J. Hecht and A. U. Neumann and N. Babel and K. Reinert and\
+    \ P. N. Robinson},\n journal = {Bioinformatics},\n number = {18},\n pages = {2963--2971},\n\
+    \ publisher = {Oxford University Press (online advanced access)},\n title = {IMSEQ\
+    \ - a fast and error aware approach to immunogenetic sequence analysis},\n url\
+    \ = {http://publications.imp.fu-berlin.de/1551/},\n volume = {31},\n year = {2015}\n\
+    }\n\n"
+  creators:
+  - name:
+      family: Kuchenbecker
+      given: L.
+      honourific: null
+      lineage: null
+  - name:
+      family: Nienen
+      given: M.
+      honourific: null
+      lineage: null
+  - name:
+      family: Hecht
+      given: J.
+      honourific: null
+      lineage: null
+  - name:
+      family: Neumann
+      given: A. U.
+      honourific: null
+      lineage: null
+  - name:
+      family: Babel
+      given: N.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  - name:
+      family: Robinson
+      given: P. N.
+      honourific: null
+      lineage: null
+  date: 2015
+  date_type: published
+  datestamp: '2015-06-02 12:53:46'
+  dir: disk0/00/00/15/51
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 1551
+  full_text_status: none
+  id_number: doi:10.1093/bioinformatics/btv309
+  ispublished: pub
+  issn: 1367-4803
+  item_issues_count: 0
+  key: fu_mi_publications1551
+  lastmod: '2016-02-25 11:24:07'
+  metadata_visibility: show
+  number: 18
+  official_url: http://dx.doi.org/10.1093/bioinformatics/btv309
+  pagerange: 2963-2971
+  publication: Bioinformatics
+  publisher: Oxford University Press (online advanced access)
+  refereed: 'TRUE'
+  rev_number: 11
+  status_changed: '2016-02-25 11:24:07'
+  subjects:
+  - G400
+  title: IMSEQ - a fast and error aware approach to immunogenetic sequence analysis
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1551
+  userid: 132
+  volume: 31
+- abstract: "The present study was performed in an attempt to develop an in vitro\
+    \ integrated testing strategy (ITS) to evaluate drug-induced neurotoxicity. A\
+    \ number of endpoints were analyzed using two complementary brain cell culture\
+    \ models and an in vitro blood\u2013brain barrier (BBB) model after single and\
+    \ repeated exposure treatments with selected drugs that covered the major biological,\
+    \ pharmacological and neuro-toxicological responses. Furthermore, four drugs (diazepam,\
+    \ cyclosporine A, chlorpromazine and amiodarone) were tested more in depth as\
+    \ representatives of different classes of neurotoxicants, inducing toxicity through\
+    \ different pathways of toxicity.\r\n\r\nThe developed in vitro BBB model allowed\
+    \ detection of toxic effects at the level of BBB and evaluation of drug transport\
+    \ through the barrier for predicting free brain concentrations of the studied\
+    \ drugs. The measurement of neuronal electrical activity was found to be a sensitive\
+    \ tool to predict the neuroactivity and neurotoxicity of drugs after acute exposure.\
+    \ The histotypic 3D re-aggregating brain cell cultures, containing all brain cell\
+    \ types, were found to be well suited for OMICs analyses after both acute and\
+    \ long term treatment.\r\n\r\nThe obtained data suggest that an in vitro ITS based\
+    \ on the information obtained from BBB studies and combined with metabolomics,\
+    \ proteomics and neuronal electrical activity measurements performed in stable\
+    \ in vitro neuronal cell culture systems, has high potential to improve current\
+    \ in vitro drug-induced neurotoxicity evaluation.\r\n\r\nAbbreviations:\r\nBBB,\
+    \ blood brain barrier; DMSO, dimethylsulfoxide; EC, endothelial cells; DIV, day\
+    \ in vitro; IPA, Ingenuity Pathway Analysis; ITS, integrated testing strategy;\
+    \ LY, Lucifer Yellow; MEA, micro-electrode array; RH, Ringer HEPES medium; SPSS,\
+    \ Statistical Package for the Social Sciences\r\n"
+  bibtex: "@article{fu_mi_publications1736,\n abstract = {The present study was performed\
+    \ in an attempt to develop an in vitro integrated testing strategy (ITS) to evaluate\
+    \ drug-induced neurotoxicity. A number of endpoints were analyzed using two complementary\
+    \ brain cell culture models and an in vitro blood?brain barrier (BBB) model after\
+    \ single and repeated exposure treatments with selected drugs that covered the\
+    \ major biological, pharmacological and neuro-toxicological responses. Furthermore,\
+    \ four drugs (diazepam, cyclosporine A, chlorpromazine and amiodarone) were tested\
+    \ more in depth as representatives of different classes of neurotoxicants, inducing\
+    \ toxicity through different pathways of toxicity.\n\nThe developed in vitro BBB\
+    \ model allowed detection of toxic effects at the level of BBB and evaluation\
+    \ of drug transport through the barrier for predicting free brain concentrations\
+    \ of the studied drugs. The measurement of neuronal electrical activity was found\
+    \ to be a sensitive tool to predict the neuroactivity and neurotoxicity of drugs\
+    \ after acute exposure. The histotypic 3D re-aggregating brain cell cultures,\
+    \ containing all brain cell types, were found to be well suited for OMICs analyses\
+    \ after both acute and long term treatment.\n\nThe obtained data suggest that\
+    \ an in vitro ITS based on the information obtained from BBB studies and combined\
+    \ with metabolomics, proteomics and neuronal electrical activity measurements\
+    \ performed in stable in vitro neuronal cell culture systems, has high potential\
+    \ to improve current in vitro drug-induced neurotoxicity evaluation.\n\nAbbreviations:\n\
+    BBB, blood brain barrier; DMSO, dimethylsulfoxide; EC, endothelial cells; DIV,\
+    \ day in vitro; IPA, Ingenuity Pathway Analysis; ITS, integrated testing strategy;\
+    \ LY, Lucifer Yellow; MEA, micro-electrode array; RH, Ringer HEPES medium; SPSS,\
+    \ Statistical Package for the Social Sciences},\n author = {L. Schultz and M.-G.\
+    \ Zurich and M. Culot and A. da Costa and C. Landry and P. Bellwon and T. Kristl\
+    \ and K. H{\\\"o}rmann and S. Ruzek and S. Aiche and K. Reinert and C. Bielow\
+    \ and F. Gosselet and R. Cecchelli and C. G. Huber and O. H.-U. Schroeder and\
+    \ A. Gramowski-Voss and D. G. Weiss and A. Bal-Price},\n journal = {Toxicology\
+    \ in Vitro},\n keywords = {In vitro blood brain barrier; MEA; Neuronal network\
+    \ culture; OMICs; Drug development; 3D brain culture},\n month = {December},\n\
+    \ note = {Online publication: May 2015},\n number = {1},\n pages = {138--165},\n\
+    \ publisher = {Elsevier B.V.},\n title = {Evaluation of drug-induced neurotoxicity\
+    \ based on metabolomics, proteomics and electrical activity measurements in complementary\
+    \ CNS in vitro models},\n url = {http://publications.imp.fu-berlin.de/1736/},\n\
+    \ volume = {30},\n year = {2015}\n}\n\n"
+  creators:
+  - id: null
+    name:
+      family: Schultz
+      given: L.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Zurich
+      given: M.-G.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Culot
+      given: M.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: da Costa
+      given: A.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Landry
+      given: C.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Bellwon
+      given: P.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Kristl
+      given: T.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: "H\xF6rmann"
+      given: K.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Ruzek
+      given: S.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Aiche
+      given: S.
+      honourific: null
+      lineage: null
+  - id: knut.reinert@fu-berlin.de
+    name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Bielow
+      given: C.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Gosselet
+      given: F.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Cecchelli
+      given: R.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Huber
+      given: C. G.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Schroeder
+      given: O. H.-U.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Gramowski-Voss
+      given: A.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Weiss
+      given: D. G.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Bal-Price
+      given: A.
+      honourific: null
+      lineage: null
+  date: '2015-12-25'
+  date_type: published
+  datestamp: '2015-10-01 08:35:15'
+  dir: disk0/00/00/17/36
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 1736
+  full_text_status: none
+  id_number: doi:10.1016/j.tiv.2015.05.016
+  ispublished: pub
+  issn: 8872333
+  item_issues_count: 0
+  key: fu_mi_publications1736
+  keywords: In vitro blood brain barrier; MEA; Neuronal network culture; OMICs; Drug
+    development; 3D brain culture
+  lastmod: '2016-11-15 13:58:51'
+  metadata_visibility: show
+  note: 'Online publication: May 2015'
+  number: 1
+  official_url: http://dx.doi.org/10.1016/j.tiv.2015.05.016
+  pagerange: 138-165
+  publication: Toxicology in Vitro
+  publisher: Elsevier B.V.
+  refereed: 'TRUE'
+  rev_number: 15
+  status_changed: '2016-11-15 13:58:51'
+  subjects:
+  - G400
+  title: Evaluation of drug-induced neurotoxicity based on metabolomics, proteomics
+    and electrical activity measurements in complementary CNS in vitro models
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1736
+  userid: 132
+  volume: 30
+- abstract: "We present CIDANE, a novel framework for genome-based transcript reconstruction\
+    \ and quantification from RNA-seq reads. CIDANE assembles transcripts efficiently\
+    \ with significantly higher sensitivity and precision than existing tools. Its\
+    \ algorithmic core not only reconstructs transcripts ab initio, but also allows\
+    \ the use of the growing annotation of known splice sites, transcription start\
+    \ and end sites, or full-length transcripts, which are available for most model\
+    \ organisms. CIDANE supports the integrated analysis of RNA-seq and additional\
+    \ gene-boundary data and recovers splice junctions that are invisible to other\
+    \ methods. CIDANE is available at http://\u200Bccb.\u200Bjhu.\u200Bedu/\u200B\
+    software/\u200Bcidane/\u200B."
+  bibtex: "@article{fu_mi_publications1830,\n abstract = {We present CIDANE, a novel\
+    \ framework for genome-based transcript reconstruction and quantification from\
+    \ RNA-seq reads. CIDANE assembles transcripts efficiently with significantly higher\
+    \ sensitivity and precision than existing tools. Its algorithmic core not only\
+    \ reconstructs transcripts ab initio, but also allows the use of the growing annotation\
+    \ of known splice sites, transcription start and end sites, or full-length transcripts,\
+    \ which are available for most model organisms. CIDANE supports the integrated\
+    \ analysis of RNA-seq and additional gene-boundary data and recovers splice junctions\
+    \ that are invisible to other methods. CIDANE is available at http://?ccb.?jhu.?edu/?software/?cidane/?.},\n\
+    \ author = {S. Canzar and S. Andreotti and D. Weese and K. Reinert and G. W. Klau},\n\
+    \ journal = {Genome Biology},\n month = {January},\n number = {1},\n publisher\
+    \ = {BioMed Central, Springer Science+Business Media},\n title = {CIDANE: comprehensive\
+    \ isoform discovery and abundance estimation},\n url = {http://publications.imp.fu-berlin.de/1830/},\n\
+    \ volume = {17},\n year = {2016}\n}\n\n"
+  creators:
+  - id: null
+    name:
+      family: Canzar
+      given: S.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Andreotti
+      given: S.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Weese
+      given: D.
+      honourific: null
+      lineage: null
+  - id: knut.reinert@fu-berlin.de
+    name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Klau
+      given: G. W.
+      honourific: null
+      lineage: null
+  date: '2016-01-30'
+  date_type: published
+  datestamp: '2016-02-25 12:27:42'
+  dir: disk0/00/00/18/30
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 1830
+  full_text_status: none
+  id_number: doi:10.1186/s13059-015-0865-0
+  ispublished: pub
+  issn: 1474-760X
+  item_issues_count: 0
+  key: fu_mi_publications1830
+  lastmod: '2016-11-15 13:54:32'
+  metadata_visibility: show
+  number: 1
+  official_url: http://dx.doi.org/10.1186/s13059-015-0865-0
+  publication: Genome Biology
+  publisher: BioMed Central, Springer Science+Business Media
+  refereed: 'TRUE'
+  rev_number: 10
+  status_changed: '2016-11-15 13:54:32'
+  subjects:
+  - G400
+  title: 'CIDANE: comprehensive isoform discovery and abundance estimation'
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1830
+  userid: 132
+  volume: 17
+- abstract: 'In mass spectrometry-based shotgun proteomics, protein identifications
+    are usually the desired result. However, most of the analytical methods are based
+    on the identification of reliable peptides and not the direct identification of
+    intact proteins. Thus, assembling peptides identified from tandem mass spectra
+    into a list of proteins, referred to as protein inference, is a critical step
+    in proteomics research. Currently, different protein inference algorithms and
+    tools are available for the proteomics community. Here, we evaluated five software
+    tools for protein inference (PIA, ProteinProphet, Fido, ProteinLP, MSBayesPro)
+    using three popular database search engines: Mascot, X!Tandem, and MS-GF +. All
+    the algorithms were evaluated using a highly customizable KNIME workflow using
+    four different public datasets with varying complexities (different sample preparation,
+    species and analytical instruments). We defined a set of quality control metrics
+    to evaluate the performance of each combination of search engines, protein inference
+    algorithm, and parameters on each dataset. We show that the results for complex
+    samples vary not only regarding the actual numbers of reported protein groups
+    but also concerning the actual composition of groups. Furthermore, the robustness
+    of reported proteins when using databases of differing complexities is strongly
+    dependant on the applied inference algorithm. Finally, merging the identifications
+    of multiple search engines does not necessarily increase the number of reported
+    proteins, but does increase the number of peptides per protein and thus can generally
+    be recommended.'
+  bibtex: "@article{fu_mi_publications1939,\n abstract = {In mass spectrometry-based\
+    \ shotgun proteomics, protein identifications are usually the desired result.\
+    \ However, most of the analytical methods are based on the identification of reliable\
+    \ peptides and not the direct identification of intact proteins. Thus, assembling\
+    \ peptides identified from tandem mass spectra into a list of proteins, referred\
+    \ to as protein inference, is a critical step in proteomics research. Currently,\
+    \ different protein inference algorithms and tools are available for the proteomics\
+    \ community. Here, we evaluated five software tools for protein inference (PIA,\
+    \ ProteinProphet, Fido, ProteinLP, MSBayesPro) using three popular database search\
+    \ engines: Mascot, X!Tandem, and MS-GF +. All the algorithms were evaluated using\
+    \ a highly customizable KNIME workflow using four different public datasets with\
+    \ varying complexities (different sample preparation, species and analytical instruments).\
+    \ We defined a set of quality control metrics to evaluate the performance of each\
+    \ combination of search engines, protein inference algorithm, and parameters on\
+    \ each dataset. We show that the results for complex samples vary not only regarding\
+    \ the actual numbers of reported protein groups but also concerning the actual\
+    \ composition of groups. Furthermore, the robustness of reported proteins when\
+    \ using databases of differing complexities is strongly dependant on the applied\
+    \ inference algorithm. Finally, merging the identifications of multiple search\
+    \ engines does not necessarily increase the number of reported proteins, but does\
+    \ increase the number of peptides per protein and thus can generally be recommended.},\n\
+    \ author = {Enrique Audain and Julian Uszkoreit and Timo Sachsenberg and Julianus\
+    \ Pfeuffer and Xiao Liang and Henning Hermjakob and Aniel Sanchez and Martin Eisenacher\
+    \ and Knut Reinert and David L. Tabb and Oliver Kohlbacher and Yasset Perez-Riverol},\n\
+    \ journal = {Journal of Proteomics},\n month = {January},\n pages = {170--182},\n\
+    \ publisher = {Elsevier},\n title = {In-depth analysis of protein inference algorithms\
+    \ using multiple search engines and well-defined metrics},\n url = {http://publications.imp.fu-berlin.de/1939/},\n\
+    \ volume = {150},\n year = {2017}\n}\n\n"
+  creators:
+  - name:
+      family: Audain
+      given: Enrique
+      honourific: null
+      lineage: null
+  - name:
+      family: Uszkoreit
+      given: Julian
+      honourific: null
+      lineage: null
   - name:
       family: Sachsenberg
       given: Timo
-      honourific:
-      lineage:
+      honourific: null
+      lineage: null
+  - name:
+      family: Pfeuffer
+      given: Julianus
+      honourific: null
+      lineage: null
+  - name:
+      family: Liang
+      given: Xiao
+      honourific: null
+      lineage: null
+  - name:
+      family: Hermjakob
+      given: Henning
+      honourific: null
+      lineage: null
+  - name:
+      family: Sanchez
+      given: Aniel
+      honourific: null
+      lineage: null
+  - name:
+      family: Eisenacher
+      given: Martin
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: Knut
+      honourific: null
+      lineage: null
+  - name:
+      family: Tabb
+      given: David L.
+      honourific: null
+      lineage: null
+  - name:
+      family: Kohlbacher
+      given: Oliver
+      honourific: null
+      lineage: null
+  - name:
+      family: Perez-Riverol
+      given: Yasset
+      honourific: null
+      lineage: null
+  date: '2017-01-06'
+  date_type: published
+  datestamp: '2016-08-31 09:06:41'
+  dir: disk0/00/00/19/39
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 1939
+  full_text_status: none
+  id_number: doi:10.1016/j.jprot.2016.08.002
+  ispublished: pub
+  issn: 18743919
+  item_issues_count: 0
+  key: fu_mi_publications1939
+  lastmod: '2017-01-12 10:08:32'
+  metadata_visibility: show
+  official_url: http://dx.doi.org/10.1016/j.jprot.2016.08.002
+  pagerange: 170-182
+  publication: Journal of Proteomics
+  publisher: Elsevier
+  refereed: 'TRUE'
+  rev_number: 13
+  status_changed: '2017-01-12 10:08:32'
+  subjects:
+  - G400
+  title: In-depth analysis of protein inference algorithms using multiple search engines
+    and well-defined metrics
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1939
+  userid: 132
+  volume: 150
+- abstract: "We sometimes see manufactured bakery products on the market which are\
+    \ labelled as being gluten free. Why is the content of such gluten proteins of\
+    \ importance for the fabrication of bakery industry and for the products? The\
+    \ gluten proteins represent up to 80 % of wheat proteins, and they are conventionally\
+    \ subdivided into gliadins and glutenins. Gliadins belong to the proline and glutamine-rich\
+    \ prolamin family. Its role in human gluten intolerance, as a consequence of its\
+    \ harmful effects, is well documented in the scientific literature. The only known\
+    \ therapy so far is a gluten-free diet, and hence, it is important to develop\
+    \ robust and reliable analytical methods to quantitatively assess the presence\
+    \ of the identified peptides causing the so-called coeliac disease. This work\
+    \ describes the development of a new, fast and robust micro ion pair-LC-MS analytical\
+    \ method for the qualitative and quantitative determination of 30-mer toxic gliadin\
+    \ peptides in wheat flour. The use of RapiGest\u2122 SF as a denaturation reagent\
+    \ prior to the enzymatic digestion showed to shorten the measuring time. During\
+    \ the optimisation of the enzymatic digestion step, the best 30-mer toxic peptide\
+    \ was identified from the maximum recovery after 3 h of digestion time. The lower\
+    \ limit of quantification was determined to be 0.25 ng/\u03BCL. The method has\
+    \ shown to be linear for the selected concentration range of 0.25\u20133.0 ng/\u03BC\
+    L. The uncertainty related to reproducibility of measurement procedure, excluding\
+    \ the extraction step, has shown to be 5.0 % (N\u2009=\u200912). Finally, this\
+    \ method was successfully applied to the quantification of 30-mer toxic peptides\
+    \ from commercial wheat flour with an overall uncertainty under reproducibility\
+    \ conditions of 6.4 % including the extraction of the gliadin fraction. The results\
+    \ were always expressed as the average of the values from all standard concentrations.\
+    \ Subsequently, the final concentration of the 30-mer toxic peptide in the flour\
+    \ was calculated and expressed in milligrams per gram unit. The determined, calculated\
+    \ concentration of the 30-mer toxic peptide in the flour was found to be 1.29\u2009\
+    \xB1\u20090.37 \u03BCg/g in flour (N\u2009=\u200925, sy\u2009=\u2009545,075, f\u2009\
+    =\u200925\u2009\u2212\u20092 (t\u2009=\u20092.069), P\u2009=\u200995 %, two-sided)."
+  bibtex: "@article{fu_mi_publications1976,\n abstract = {We sometimes see manufactured\
+    \ bakery products on the market which are labelled as being gluten free. Why is\
+    \ the content of such gluten proteins of importance for the fabrication of bakery\
+    \ industry and for the products? The gluten proteins represent up to 80 \\% of\
+    \ wheat proteins, and they are conventionally subdivided into gliadins and glutenins.\
+    \ Gliadins belong to the proline and glutamine-rich prolamin family. Its role\
+    \ in human gluten intolerance, as a consequence of its harmful effects, is well\
+    \ documented in the scientific literature. The only known therapy so far is a\
+    \ gluten-free diet, and hence, it is important to develop robust and reliable\
+    \ analytical methods to quantitatively assess the presence of the identified peptides\
+    \ causing the so-called coeliac disease. This work describes the development of\
+    \ a new, fast and robust micro ion pair-LC-MS analytical method for the qualitative\
+    \ and quantitative determination of 30-mer toxic gliadin peptides in wheat flour.\
+    \ The use of RapiGest? SF as a denaturation reagent prior to the enzymatic digestion\
+    \ showed to shorten the measuring time. During the optimisation of the enzymatic\
+    \ digestion step, the best 30-mer toxic peptide was identified from the maximum\
+    \ recovery after 3 h of digestion time. The lower limit of quantification was\
+    \ determined to be 0.25 ng/{\\ensuremath{\\mu}}L. The method has shown to be linear\
+    \ for the selected concentration range of 0.25?3.0 ng/{\\ensuremath{\\mu}}L. The\
+    \ uncertainty related to reproducibility of measurement procedure, excluding the\
+    \ extraction step, has shown to be 5.0 \\% (N\xE2\u20AC\u2030=\xE2\u20AC\u2030\
+    12). Finally, this method was successfully applied to the quantification of 30-mer\
+    \ toxic peptides from commercial wheat flour with an overall uncertainty under\
+    \ reproducibility conditions of 6.4 \\% including the extraction of the gliadin\
+    \ fraction. The results were always expressed as the average of the values from\
+    \ all standard concentrations. Subsequently, the final concentration of the 30-mer\
+    \ toxic peptide in the flour was calculated and expressed in milligrams per gram\
+    \ unit. The determined, calculated concentration of the 30-mer toxic peptide in\
+    \ the flour was found to be 1.29\xE2\u20AC\u2030{$\\pm$}\xE2\u20AC\u20300.37 {\\\
+    ensuremath{\\mu}}g/g in flour (N\xE2\u20AC\u2030=\xE2\u20AC\u203025, sy\xE2\u20AC\
+    \u2030=\xE2\u20AC\u2030545,075, f\xE2\u20AC\u2030=\xE2\u20AC\u203025\xE2\u20AC\
+    \u2030?\xE2\u20AC\u20302 (t\xE2\u20AC\u2030=\xE2\u20AC\u20302.069), P\xE2\u20AC\
+    \u2030=\xE2\u20AC\u203095 \\%, two-sided).},\n author = {B. Vatansever and A.\
+    \ Mu{\\~n}oz and C. L. Klein and K. Reinert},\n journal = {Analytical and Bioanalytical\
+    \ Chemistry},\n month = {February},\n number = {4},\n pages = {989--997},\n publisher\
+    \ = {Springer Berlin Heidelberg},\n title = {Development and optimisation of a\
+    \ generic micro LC-ESI-MS method for the qualitative and quantitative determination\
+    \ of 30-mer toxic gliadin peptides in wheat flour for food analysis},\n url =\
+    \ {http://publications.imp.fu-berlin.de/1976/},\n volume = {409},\n year = {2017}\n\
+    }\n\n"
+  creators:
+  - name:
+      family: Vatansever
+      given: B.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Mu\xF1oz"
+      given: A.
+      honourific: null
+      lineage: null
+  - name:
+      family: Klein
+      given: C. L.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: 2017-02
+  date_type: published
+  datestamp: '2016-11-03 11:34:05'
+  dir: disk0/00/00/19/76
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 1976
+  full_text_status: none
+  id_number: doi:10.1007/s00216-016-0013-z
+  ispublished: pub
+  issn: 1618-2642
+  item_issues_count: 0
+  key: fu_mi_publications1976
+  lastmod: '2017-09-12 13:35:25'
+  metadata_visibility: show
+  number: 4
+  official_url: http://dx.doi.org/10.1007/s00216-016-0013-z
+  pagerange: 989-997
+  publication: Analytical and Bioanalytical Chemistry
+  publisher: Springer Berlin Heidelberg
+  refereed: 'TRUE'
+  rev_number: 13
+  status_changed: '2017-09-12 13:35:25'
+  subjects:
+  - G400
+  title: Development and optimisation of a generic micro LC-ESI-MS method for the
+    qualitative and quantitative determination of 30-mer toxic gliadin peptides in
+    wheat flour for food analysis
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1976
+  userid: 132
+  volume: 409
+- abstract: Many disciplines, from human genetics and oncology to plant breeding,
+    microbiology and virology, commonly face the challenge of analyzing rapidly increasing
+    numbers of genomes. In case of Homo sapiens, the number of sequenced genomes will
+    approach hundreds of thousands in the next few years. Simply scaling up established
+    bioinformatics pipelines will not be sufficient for leveraging the full potential
+    of such rich genomic data sets. Instead, novel, qualitatively different computational
+    methods and paradigms are needed. We will witness the rapid extension of computational
+    pan-genomics, a new sub-area of research in computational biology. In this article,
+    we generalize existing definitions and understand a pan-genome as any collection
+    of genomic sequences to be analyzed jointly or to be used as a reference. We examine
+    already available approaches to construct and use pan-genomes, discuss the potential
+    benefits of future technologies and methodologies and review open challenges from
+    the vantage point of the above-mentioned biological disciplines. As a prominent
+    example for a computational paradigm shift, we particularly highlight the transition
+    from the representation of reference genomes as strings to representations as
+    graphs. We outline how this and other challenges from different application domains
+    translate into common computational problems, point out relevant bioinformatics
+    techniques and identify open problems in computer science. With this review, we
+    aim to increase awareness that a joint approach to computational pan-genomics
+    can help address many of the problems currently faced in various domains.
+  bibtex: "@article{fu_mi_publications1981,\n abstract = {Many disciplines, from human\
+    \ genetics and oncology to plant breeding, microbiology and virology, commonly\
+    \ face the challenge of analyzing rapidly increasing numbers of genomes. In case\
+    \ of Homo sapiens, the number of sequenced genomes will approach hundreds of thousands\
+    \ in the next few years. Simply scaling up established bioinformatics pipelines\
+    \ will not be sufficient for leveraging the full potential of such rich genomic\
+    \ data sets. Instead, novel, qualitatively different computational methods and\
+    \ paradigms are needed. We will witness the rapid extension of computational pan-genomics,\
+    \ a new sub-area of research in computational biology. In this article, we generalize\
+    \ existing definitions and understand a pan-genome as any collection of genomic\
+    \ sequences to be analyzed jointly or to be used as a reference. We examine already\
+    \ available approaches to construct and use pan-genomes, discuss the potential\
+    \ benefits of future technologies and methodologies and review open challenges\
+    \ from the vantage point of the above-mentioned biological disciplines. As a prominent\
+    \ example for a computational paradigm shift, we particularly highlight the transition\
+    \ from the representation of reference genomes as strings to representations as\
+    \ graphs. We outline how this and other challenges from different application\
+    \ domains translate into common computational problems, point out relevant bioinformatics\
+    \ techniques and identify open problems in computer science. With this review,\
+    \ we aim to increase awareness that a joint approach to computational pan-genomics\
+    \ can help address many of the problems currently faced in various domains.},\n\
+    \ author = {T. Marschall and K. Reinert and (59 authors in total) others},\n journal\
+    \ = {Briefings in Bioinformatics},\n month = {January},\n number = {1},\n pages\
+    \ = {118--135},\n publisher = {Oxford University Press},\n title = {Computational\
+    \ pan-genomics: status, promises and challenges},\n url = {http://publications.imp.fu-berlin.de/1981/},\n\
+    \ volume = {19},\n year = {2018}\n}\n\n"
+  creators:
+  - id: null
+    name:
+      family: Marschall
+      given: T.
+      honourific: null
+      lineage: null
+  - id: knut.reinert@fu-berlin.de
+    name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: others
+      given: (59 authors in total)
+      honourific: null
+      lineage: null
+  date: '2018-01-01'
+  date_type: published
+  datestamp: '2016-11-17 12:32:39'
+  dir: disk0/00/00/19/81
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 1981
+  full_text_status: none
+  id_number: doi:10.1093/bib/bbw089
+  ispublished: pub
+  issn: 1467-5463 (Print), 1477-4054 (Online)
+  item_issues_count: 0
+  key: fu_mi_publications1981
+  lastmod: '2018-11-08 12:31:04'
+  metadata_visibility: show
+  number: 1
+  official_url: http://dx.doi.org/10.1093/bib/bbw089
+  pagerange: 118-135
+  publication: Briefings in Bioinformatics
+  publisher: Oxford University Press
+  refereed: 'TRUE'
+  rev_number: 17
+  status_changed: '2018-11-08 12:31:04'
+  subjects:
+  - G400
+  title: 'Computational pan-genomics: status, promises and challenges'
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/1981
+  userid: 132
+  volume: 19
+- abstract: "\r\nBackground\r\n\r\nThe last two human genome assemblies have extended\
+    \ the previous linear golden-path paradigm of the human genome to a graph-like\
+    \ model to better represent regions with a high degree of structural variability.\
+    \ The new model offers opportunities to improve the technical validity of variant\
+    \ calling in whole-genome sequencing (WGS).\r\nMethods\r\n\r\nWe developed an\
+    \ algorithm that analyzes the patterns of variant calls in the 178 structurally\
+    \ variable regions of the GRCh38 genome assembly, and infers whether a given sample\
+    \ is most likely to contain sequences from the primary assembly, an alternate\
+    \ locus, or their heterozygous combination at each of these 178 regions. We investigate\
+    \ 121 in-house WGS datasets that have been aligned to the GRCh37 and GRCh38 assemblies.\r\
+    \n\r\nResults\r\n\r\nWe show that stretches of sequences that are largely but\
+    \ not entirely identical between the primary assembly and an alternate locus can\
+    \ result in multiple variant calls against regions of the primary assembly. In\
+    \ WGS analysis, this results in characteristic and recognizable patterns of variant\
+    \ calls at positions that we term alignable scaffold-discrepant positions (ASDPs).\
+    \ In 121 in-house genomes, on average 51.8\xB13.8 of the 178 regions were found\
+    \ to correspond best to an alternate locus rather than the primary assembly sequence,\
+    \ and filtering these genomes with our algorithm led to the identification of\
+    \ 7863 variant calls per genome that colocalized with ASDPs. Additionally, we\
+    \ found that 437 of 791 genome-wide association study hits located within one\
+    \ of the regions corresponded to ASDPs.\r\n\r\nConclusions\r\n\r\nOur algorithm\
+    \ uses the information contained in the 178 structurally variable regions of the\
+    \ GRCh38 genome assembly to avoid spurious variant calls in cases where samples\
+    \ contain an alternate locus rather than the corresponding segment of the primary\
+    \ assembly. These results suggest the great potential of fully incorporating the\
+    \ resources of graph-like genome assemblies into variant calling, but also underscore\
+    \ the importance of developing computational resources that will allow a full\
+    \ reconstruction of the genotype in personal genomes. Our algorithm is freely\
+    \ available at https://github.com/charite/asdpex."
+  bibtex: "@article{fu_mi_publications2004,\n abstract = {\nBackground\n\nThe last\
+    \ two human genome assemblies have extended the previous linear golden-path paradigm\
+    \ of the human genome to a graph-like model to better represent regions with a\
+    \ high degree of structural variability. The new model offers opportunities to\
+    \ improve the technical validity of variant calling in whole-genome sequencing\
+    \ (WGS).\nMethods\n\nWe developed an algorithm that analyzes the patterns of variant\
+    \ calls in the 178 structurally variable regions of the GRCh38 genome assembly,\
+    \ and infers whether a given sample is most likely to contain sequences from the\
+    \ primary assembly, an alternate locus, or their heterozygous combination at each\
+    \ of these 178 regions. We investigate 121 in-house WGS datasets that have been\
+    \ aligned to the GRCh37 and GRCh38 assemblies.\n\nResults\n\nWe show that stretches\
+    \ of sequences that are largely but not entirely identical between the primary\
+    \ assembly and an alternate locus can result in multiple variant calls against\
+    \ regions of the primary assembly. In WGS analysis, this results in characteristic\
+    \ and recognizable patterns of variant calls at positions that we term alignable\
+    \ scaffold-discrepant positions (ASDPs). In 121 in-house genomes, on average 51.8{$\\\
+    pm$}3.8 of the 178 regions were found to correspond best to an alternate locus\
+    \ rather than the primary assembly sequence, and filtering these genomes with\
+    \ our algorithm led to the identification of 7863 variant calls per genome that\
+    \ colocalized with ASDPs. Additionally, we found that 437 of 791 genome-wide association\
+    \ study hits located within one of the regions corresponded to ASDPs.\n\nConclusions\n\
+    \nOur algorithm uses the information contained in the 178 structurally variable\
+    \ regions of the GRCh38 genome assembly to avoid spurious variant calls in cases\
+    \ where samples contain an alternate locus rather than the corresponding segment\
+    \ of the primary assembly. These results suggest the great potential of fully\
+    \ incorporating the resources of graph-like genome assemblies into variant calling,\
+    \ but also underscore the importance of developing computational resources that\
+    \ will allow a full reconstruction of the genotype in personal genomes. Our algorithm\
+    \ is freely available at https://github.com/charite/asdpex.},\n author = {Marten\
+    \ J{\\\"a}ger and Max Schubach and Tomasz Zemojtel and Knut Reinert and Deanna\
+    \ M. Church and Peter N. Robinson},\n journal = {Genome Medicine},\n month = {December},\n\
+    \ number = {1},\n publisher = {BioMed Central (Springer Nature)},\n title = {Alternate-locus\
+    \ aware variant calling in whole genome sequencing},\n url = {http://publications.imp.fu-berlin.de/2004/},\n\
+    \ volume = {8},\n year = {2016}\n}\n\n"
+  creators:
+  - name:
+      family: "J\xE4ger"
+      given: Marten
+      honourific: null
+      lineage: null
+  - name:
+      family: Schubach
+      given: Max
+      honourific: null
+      lineage: null
+  - name:
+      family: Zemojtel
+      given: Tomasz
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: Knut
+      honourific: null
+      lineage: null
+  - name:
+      family: Church
+      given: Deanna M.
+      honourific: null
+      lineage: null
+  - name:
+      family: Robinson
+      given: Peter N.
+      honourific: null
+      lineage: null
+  date: '2016-12-13'
+  date_type: published
+  datestamp: '2017-01-12 09:36:57'
+  dir: disk0/00/00/20/04
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 2004
+  full_text_status: none
+  id_number: doi:10.1186/s13073-016-0383-z
+  ispublished: pub
+  issn: 1756-994X
+  item_issues_count: 0
+  key: fu_mi_publications2004
+  lastmod: '2017-01-12 09:36:57'
+  metadata_visibility: show
+  number: 1
+  official_url: http://dx.doi.org/10.1186/s13073-016-0383-z
+  publication: Genome Medicine
+  publisher: BioMed Central (Springer Nature)
+  refereed: 'TRUE'
+  rev_number: 7
+  status_changed: '2017-01-12 09:36:57'
+  subjects:
+  - G400
+  title: Alternate-locus aware variant calling in whole genome sequencing
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2004
+  userid: 132
+  volume: 8
+- abstract: "Background\r\n\r\nThe use of novel algorithmic techniques is pivotal\
+    \ to many important problems in life science. For example the sequencing of the\
+    \ human genome (Venter et al., 2001) would not have been possible without advanced\
+    \ assembly algorithms and the development of practical BWT based read mappers\
+    \ have been instrumental for NGS analysis. However, owing to the high speed of\
+    \ technological progress and the urgent need for bioinformatics tools, there was\
+    \ a widening gap between state-of-the-art algorithmic techniques and the actual\
+    \ algorithmic components of tools that are in widespread use. We previously addressed\
+    \ this by introducing the SeqAn library of efficient data types and algorithms\
+    \ in 2008 (D\xF6ring et al., 2008).\r\n\r\nResults\r\n\r\nThe SeqAn library has\
+    \ matured considerably since its first publication 9 years ago. In this article\
+    \ we review its status as an established resource for programmers in the field\
+    \ of sequence analysis and its contributions to many analysis tools.\r\n\r\nConclusions\r\
+    \n\r\nWe anticipate that SeqAn will continue to be a valuable resource, especially\
+    \ since it started to actively support various hardware acceleration techniques\
+    \ in a systematic manner.\r\n\r\nKeywords\r\n\r\nNGS analysis; Software libraries;\
+    \ C++; Data structures"
+  bibtex: "@article{fu_mi_publications2103,\n abstract = {Background\n\nThe use of\
+    \ novel algorithmic techniques is pivotal to many important problems in life science.\
+    \ For example the sequencing of the human genome (Venter et al., 2001) would not\
+    \ have been possible without advanced assembly algorithms and the development\
+    \ of practical BWT based read mappers have been instrumental for NGS analysis.\
+    \ However, owing to the high speed of technological progress and the urgent need\
+    \ for bioinformatics tools, there was a widening gap between state-of-the-art\
+    \ algorithmic techniques and the actual algorithmic components of tools that are\
+    \ in widespread use. We previously addressed this by introducing the SeqAn library\
+    \ of efficient data types and algorithms in 2008 (D{\\\"o}ring et al., 2008).\n\
+    \nResults\n\nThe SeqAn library has matured considerably since its first publication\
+    \ 9 years ago. In this article we review its status as an established resource\
+    \ for programmers in the field of sequence analysis and its contributions to many\
+    \ analysis tools.\n\nConclusions\n\nWe anticipate that SeqAn will continue to\
+    \ be a valuable resource, especially since it started to actively support various\
+    \ hardware acceleration techniques in a systematic manner.\n\nKeywords\n\nNGS\
+    \ analysis; Software libraries; C++; Data structures},\n author = {Knut Reinert\
+    \ and Temesgen Hailemariam Dadi and Marcel Ehrhardt and Hannes Hauswedell and\
+    \ Svenja Mehringer and Ren{\\'e} Rahn and Jongkyu Kim and Christopher Pockrandt\
+    \ and J{\\\"o}rg Winkler and Enrico Siragusa and Gianvito Urgese and David Weese},\n\
+    \ journal = {Journal of Biotechnology},\n keywords = {NGS analysis; Software libraries;\
+    \ C++; Data structures},\n month = {November},\n pages = {157--168},\n publisher\
+    \ = {ELSEVIER},\n title = {The SeqAn C++ template library for efficient sequence\
+    \ analysis: A resource for programmers},\n url = {http://publications.imp.fu-berlin.de/2103/},\n\
+    \ volume = {261},\n year = {2017}\n}\n\n"
+  creators:
+  - name:
+      family: Reinert
+      given: Knut
+      honourific: null
+      lineage: null
+  - name:
+      family: Dadi
+      given: Temesgen Hailemariam
+      honourific: null
+      lineage: null
+  - name:
+      family: Ehrhardt
+      given: Marcel
+      honourific: null
+      lineage: null
+  - name:
+      family: Hauswedell
+      given: Hannes
+      honourific: null
+      lineage: null
+  - name:
+      family: Mehringer
+      given: Svenja
+      honourific: null
+      lineage: null
+  - name:
+      family: Rahn
+      given: "Ren\xE9"
+      honourific: null
+      lineage: null
+  - name:
+      family: Kim
+      given: Jongkyu
+      honourific: null
+      lineage: null
+  - name:
+      family: Pockrandt
+      given: Christopher
+      honourific: null
+      lineage: null
+  - name:
+      family: Winkler
+      given: "J\xF6rg"
+      honourific: null
+      lineage: null
+  - name:
+      family: Siragusa
+      given: Enrico
+      honourific: null
+      lineage: null
+  - name:
+      family: Urgese
+      given: Gianvito
+      honourific: null
+      lineage: null
+  - name:
+      family: Weese
+      given: David
+      honourific: null
+      lineage: null
+  date: '2017-11-10'
+  date_type: published
+  datestamp: '2017-09-12 14:16:48'
+  dir: disk0/00/00/21/03
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 2103
+  full_text_status: none
+  id_number: doi:10.1016/j.jbiotec.2017.07.017
+  ispublished: pub
+  issn: 1681656
+  key: fu_mi_publications2103
+  keywords: NGS analysis; Software libraries; C++; Data structures
+  lastmod: '2017-10-12 11:37:39'
+  metadata_visibility: show
+  official_url: http://doi.org/10.1016/j.jbiotec.2017.07.017
+  pagerange: 157-168
+  publication: Journal of Biotechnology
+  publisher: ELSEVIER
+  refereed: 'TRUE'
+  rev_number: 6
+  status_changed: '2017-09-12 14:16:48'
+  subjects:
+  - G400
+  title: 'The SeqAn C++ template library for efficient sequence analysis: A resource
+    for programmers'
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2103
+  userid: 132
+  volume: 261
+- abstract: "Background\r\n\r\nIn recent years, several mass spectrometry-based omics\
+    \ technologies emerged to investigate qualitative and quantitative changes within\
+    \ thousands of biologically active components such as proteins, lipids and metabolites.\
+    \ The research enabled through these methods potentially contributes to the diagnosis\
+    \ and pathophysiology of human diseases as well as to the clarification of structures\
+    \ and interactions between biomolecules. Simultaneously, technological advances\
+    \ in the field of mass spectrometry leading to an ever increasing amount of data,\
+    \ demand high standards in efficiency, accuracy and reproducibility of potential\
+    \ analysis software.\r\n\r\nResults\r\n\r\nThis article presents the current state\
+    \ and ongoing developments in OpenMS, a versatile open-source framework aimed\
+    \ at enabling reproducible analyses of high-throughput mass spectrometry data.\
+    \ It provides implementations of frequently occurring processing operations on\
+    \ MS data through a clean application programming interface in C++ and Python.\
+    \ A collection of 185 tools and ready-made workflows for typical MS-based experiments\
+    \ enable convenient analyses for non-developers and facilitate reproducible research\
+    \ without losing flexibility.\r\n\r\nConclusions\r\n\r\nOpenMS will continue to\
+    \ increase its ease of use for developers as well as users with improved continuous\
+    \ integration/deployment strategies, regular trainings with updated training materials\
+    \ and multiple sources of support. The active developer community ensures the\
+    \ incorporation of new features to support state of the art research."
+  bibtex: "@article{fu_mi_publications2116,\n abstract = {Background\n\nIn recent\
+    \ years, several mass spectrometry-based omics technologies emerged to investigate\
+    \ qualitative and quantitative changes within thousands of biologically active\
+    \ components such as proteins, lipids and metabolites. The research enabled through\
+    \ these methods potentially contributes to the diagnosis and pathophysiology of\
+    \ human diseases as well as to the clarification of structures and interactions\
+    \ between biomolecules. Simultaneously, technological advances in the field of\
+    \ mass spectrometry leading to an ever increasing amount of data, demand high\
+    \ standards in efficiency, accuracy and reproducibility of potential analysis\
+    \ software.\n\nResults\n\nThis article presents the current state and ongoing\
+    \ developments in OpenMS, a versatile open-source framework aimed at enabling\
+    \ reproducible analyses of high-throughput mass spectrometry data. It provides\
+    \ implementations of frequently occurring processing operations on MS data through\
+    \ a clean application programming interface in C++ and Python. A collection of\
+    \ 185 tools and ready-made workflows for typical MS-based experiments enable convenient\
+    \ analyses for non-developers and facilitate reproducible research without losing\
+    \ flexibility.\n\nConclusions\n\nOpenMS will continue to increase its ease of\
+    \ use for developers as well as users with improved continuous integration/deployment\
+    \ strategies, regular trainings with updated training materials and multiple sources\
+    \ of support. The active developer community ensures the incorporation of new\
+    \ features to support state of the art research.},\n author = {Julianus Pfeuffer\
+    \ and Timo Sachsenberg and Oliver Alka and Mathias Walzer and Alexander Fillbrunn\
+    \ and Lars Nilse and Oliver Schilling and Knut Reinert and Oliver Kohlbacher},\n\
+    \ journal = {Journal of Biotechnology},\n month = {November},\n pages = {142--148},\n\
+    \ publisher = {ELSEVIER},\n title = {OpenMS ? A platform for reproducible analysis\
+    \ of mass spectrometry data},\n url = {http://publications.imp.fu-berlin.de/2116/},\n\
+    \ volume = {261},\n year = {2017}\n}\n\n"
+  creators:
+  - name:
+      family: Pfeuffer
+      given: Julianus
+      honourific: null
+      lineage: null
+  - name:
+      family: Sachsenberg
+      given: Timo
+      honourific: null
+      lineage: null
   - name:
       family: Alka
-      honourific:
       given: Oliver
-      lineage:
+      honourific: null
+      lineage: null
   - name:
-      lineage:
-      given: Mathias
-      honourific:
       family: Walzer
+      given: Mathias
+      honourific: null
+      lineage: null
   - name:
-      given: Alexander
-      honourific:
       family: Fillbrunn
-      lineage:
+      given: Alexander
+      honourific: null
+      lineage: null
   - name:
-      lineage:
       family: Nilse
       given: Lars
-      honourific:
+      honourific: null
+      lineage: null
   - name:
-      given: Oliver
-      honourific:
       family: Schilling
-      lineage:
+      given: Oliver
+      honourific: null
+      lineage: null
   - name:
-      given: Knut
-      honourific:
       family: Reinert
-      lineage:
+      given: Knut
+      honourific: null
+      lineage: null
   - name:
-      lineage:
       family: Kohlbacher
       given: Oliver
-      honourific:
-- number: 3
-  refereed: 'TRUE'
-  eprintid: 2429
+      honourific: null
+      lineage: null
+  date: '2017-11-10'
   date_type: published
-  full_text_status: none
-  id_number: doi:10.1021/acs.jproteome.9b00566
-  metadata_visibility: show
-  eprint_status: archive
-  issn: 1535-3893
-  dir: disk0/00/00/24/29
-  date: '2020-01-24'
-  pagerange: 1060-1072
-  volume: 19
+  datestamp: '2017-10-12 12:05:59'
+  dir: disk0/00/00/21/16
   divisions:
   - group_algbioinf
+  eprint_status: archive
+  eprintid: 2116
+  full_text_status: none
+  id_number: doi:10.1016/j.jbiotec.2017.05.016
+  ispublished: pub
+  issn: 1681656
+  key: fu_mi_publications2116
+  lastmod: '2017-10-12 12:05:59'
+  metadata_visibility: show
+  official_url: http://doi.org/10.1016/j.jbiotec.2017.05.016
+  pagerange: 142-148
+  publication: Journal of Biotechnology
+  publisher: ELSEVIER
+  refereed: 'TRUE'
+  rev_number: 5
+  status_changed: '2017-10-12 12:05:59'
   subjects:
   - G400
-  official_url: http://doi.org/10.1021/acs.jproteome.9b00566
-  keywords: bottom-up proteomics, protein inference, Bayesian networks, convolution
-    trees, loopy belief propagation, iPRG2016
-  lastmod: '2020-04-02 10:05:57'
-  ispublished: pub
-  uri: http://publications.imp.fu-berlin.de/id/eprint/2429
+  title: "OpenMS \u2013 A platform for reproducible analysis of mass spectrometry\
+    \ data"
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2116
+  userid: 132
+  volume: 261
+- abstract: "Motivation: \r\nHigh-throughput sequencing machines can process many\
+    \ samples in a single run. For Illumina systems, sequencing reads are barcoded\
+    \ with an additional DNA tag that is contained in the respective sequencing adapters.\
+    \ The recognition of barcode and adapter sequences is hence commonly needed for\
+    \ the analysis of next-generation sequencing data. Flexbar performs demultiplexing\
+    \ based on barcodes and adapter trimming for such data. The massive amounts of\
+    \ data generated on modern sequencing machines demand that this preprocessing\
+    \ is done as efficiently as possible.\r\n\r\nResults: \r\nWe present Flexbar 3.0,\
+    \ the successor of the popular program Flexbar. It employs now twofold parallelism:\
+    \ multi-threading and additionally SIMD vectorization. Both types of parallelism\
+    \ are used to speed-up the computation of pair-wise sequence alignments, which\
+    \ are used for the detection of barcodes and adapters. Furthermore, new features\
+    \ were included to cover a wide range of applications. We evaluated the performance\
+    \ of Flexbar based on a simulated sequencing dataset. Our program outcompetes\
+    \ other tools in terms of speed and is among the best tools in the presented quality\
+    \ benchmark.\r\n\r\nAvailability and implementation:\r\nhttps://github.com/seqan/flexbar\r\
+    \n\r\nContact:\r\njohannes.roehr@fu-berlin.de or knut.reinert@fu-berlin.de"
+  bibtex: "@article{fu_mi_publications2117,\n abstract = {Motivation: \nHigh-throughput\
+    \ sequencing machines can process many samples in a single run. For Illumina systems,\
+    \ sequencing reads are barcoded with an additional DNA tag that is contained in\
+    \ the respective sequencing adapters. The recognition of barcode and adapter sequences\
+    \ is hence commonly needed for the analysis of next-generation sequencing data.\
+    \ Flexbar performs demultiplexing based on barcodes and adapter trimming for such\
+    \ data. The massive amounts of data generated on modern sequencing machines demand\
+    \ that this preprocessing is done as efficiently as possible.\n\nResults: \nWe\
+    \ present Flexbar 3.0, the successor of the popular program Flexbar. It employs\
+    \ now twofold parallelism: multi-threading and additionally SIMD vectorization.\
+    \ Both types of parallelism are used to speed-up the computation of pair-wise\
+    \ sequence alignments, which are used for the detection of barcodes and adapters.\
+    \ Furthermore, new features were included to cover a wide range of applications.\
+    \ We evaluated the performance of Flexbar based on a simulated sequencing dataset.\
+    \ Our program outcompetes other tools in terms of speed and is among the best\
+    \ tools in the presented quality benchmark.\n\nAvailability and implementation:\n\
+    https://github.com/seqan/flexbar\n\nContact:\njohannes.roehr@fu-berlin.de or knut.reinert@fu-berlin.de},\n\
+    \ author = {Johannes T. Roehr and Christoph Dieterich and Knut Reinert},\n journal\
+    \ = {Bioinformatics},\n month = {September},\n number = {18},\n pages = {2941--2942},\n\
+    \ title = {Flexbar 3.0 ? SIMD and multicore parallelization},\n url = {http://publications.imp.fu-berlin.de/2117/},\n\
+    \ volume = {33},\n year = {2017}\n}\n\n"
   creators:
   - name:
-      lineage:
-      given: Julianus
-      honourific:
-      family: Pfeuffer
+      family: Roehr
+      given: Johannes T.
+      honourific: null
+      lineage: null
   - name:
-      lineage:
+      family: Dieterich
+      given: Christoph
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: Knut
+      honourific: null
+      lineage: null
+  date: '2017-09-15'
+  date_type: published
+  datestamp: '2017-10-12 12:16:48'
+  dir: disk0/00/00/21/17
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 2117
+  full_text_status: none
+  id_number: doi:10.1093/bioinformatics/btx330
+  ispublished: pub
+  issn: 1367-4803
+  key: fu_mi_publications2117
+  lastmod: '2017-10-12 12:16:48'
+  metadata_visibility: show
+  number: 18
+  official_url: http://doi.org/10.1093/bioinformatics/btx330
+  pagerange: 2941-2942
+  publication: Bioinformatics
+  refereed: 'TRUE'
+  rev_number: 5
+  status_changed: '2017-10-12 12:16:48'
+  subjects:
+  - G400
+  title: "Flexbar 3.0 \u2013 SIMD and multicore parallelization"
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2117
+  userid: 132
+  volume: 33
+- abstract: "The unidirectional FM index was introduced by Ferragina and Manzini in\
+    \ 2000 and allows to search a pattern in the index in one direction. The bidirectional\
+    \ FM index (2FM) was introduced by Lam et al. in 2009. It allows to search for\
+    \ a pattern by extending an infix of the pattern arbitrarily to the left or right.\
+    \ If \u03C3 is the size of the alphabet then the method of Lam et al. can conduct\
+    \ one step in time O(\u03C3) while needing space O(\u03C3\u22C5n) using constant\
+    \ time rank queries on bit vectors. Schnattinger and colleagues improved this\
+    \ time to O(log\u03C3) while using O(log\u03C3\u22C5n) bits of space for both,\
+    \ the FM and 2FM index. This is achieved by the use of binary wavelet trees.\r\
+    \n\r\nIn this paper we introduce a new, practical method for conducting an exact\
+    \ search in a uni- and bidirectional FM index in O(1) time per step while using\
+    \ O(log\u03C3\u22C5n)+o(log\u03C3\u22C5\u03C3\u22C5n) \r\nbits of space. This\
+    \ is done by replacing the binary wavelet tree by a new data structure, the Enhanced\
+    \ Prefixsum Rank dictionary (EPR-dictionary).\r\n\r\nWe implemented this method\
+    \ in the SeqAn C++ library and experimentally validated our theoretical results.\
+    \ In addition we compared our implementation with other freely available implementations\
+    \ of bidirectional indices and show that we are between \u22482.2\u22124.2 times\
+    \ faster. This will have a large impact for many bioinformatics applications that\
+    \ rely on practical implementations of (2)FM indices e.g. for read mapping. To\
+    \ our knowledge this is the first implementation of a constant time method for\
+    \ a search step in 2FM indices."
+  bibtex: "@incollection{fu_mi_publications2118,\n abstract = {The unidirectional\
+    \ FM index was introduced by Ferragina and Manzini in 2000 and allows to search\
+    \ a pattern in the index in one direction. The bidirectional FM index (2FM) was\
+    \ introduced by Lam et al. in 2009. It allows to search for a pattern by extending\
+    \ an infix of the pattern arbitrarily to the left or right. If {\\ensuremath{\\\
+    sigma}} is the size of the alphabet then the method of Lam et al. can conduct\
+    \ one step in time O({\\ensuremath{\\sigma}}) while needing space O({\\ensuremath{\\\
+    sigma}}{$\\cdot$}n) using constant time rank queries on bit vectors. Schnattinger\
+    \ and colleagues improved this time to O(log{\\ensuremath{\\sigma}}) while using\
+    \ O(log{\\ensuremath{\\sigma}}{$\\cdot$}n) bits of space for both, the FM and\
+    \ 2FM index. This is achieved by the use of binary wavelet trees.\n\nIn this paper\
+    \ we introduce a new, practical method for conducting an exact search in a uni-\
+    \ and bidirectional FM index in O(1) time per step while using O(log{\\ensuremath{\\\
+    sigma}}{$\\cdot$}n)+o(log{\\ensuremath{\\sigma}}{$\\cdot$}{\\ensuremath{\\sigma}}{$\\\
+    cdot$}n) \nbits of space. This is done by replacing the binary wavelet tree by\
+    \ a new data structure, the Enhanced Prefixsum Rank dictionary (EPR-dictionary).\n\
+    \nWe implemented this method in the SeqAn C++ library and experimentally validated\
+    \ our theoretical results. In addition we compared our implementation with other\
+    \ freely available implementations of bidirectional indices and show that we are\
+    \ between {$\\approx$}2.2?4.2 times faster. This will have a large impact for\
+    \ many bioinformatics applications that rely on practical implementations of (2)FM\
+    \ indices e.g. for read mapping. To our knowledge this is the first implementation\
+    \ of a constant time method for a search step in 2FM indices.},\n author = {Christopher\
+    \ Pockrandt and Marcel Ehrhardt and Knut Reinert},\n booktitle = {Research in\
+    \ Computational Molecular Biology. RECOMB 2017},\n editor = {S. Sahinalp},\n month\
+    \ = {April},\n pages = {190--206},\n publisher = {Springer, Cham},\n series =\
+    \ {Lecture Notes in Computer Science (LNCS)},\n title = {EPR-Dictionaries: A Practical\
+    \ and Fast Data Structure for Constant Time Searches in Unidirectional and Bidirectional\
+    \ FM Indices},\n url = {http://publications.imp.fu-berlin.de/2118/},\n volume\
+    \ = {10229},\n year = {2017}\n}\n\n"
+  book_title: Research in Computational Molecular Biology. RECOMB 2017
+  creators:
+  - name:
+      family: Pockrandt
+      given: Christopher
+      honourific: null
+      lineage: null
+  - name:
+      family: Ehrhardt
+      given: Marcel
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: Knut
+      honourific: null
+      lineage: null
+  date: '2017-04-12'
+  date_type: published
+  datestamp: '2017-10-12 12:37:21'
+  dir: disk0/00/00/21/18
+  divisions:
+  - group_algbioinf
+  editors:
+  - name:
+      family: Sahinalp
+      given: S.
+      honourific: null
+      lineage: null
+  eprint_status: archive
+  eprintid: 2118
+  full_text_status: none
+  id_number: doi:10.1007/978-3-319-56970-3_12
+  isbn: 978-3-319-56970-3 (elektronisch)
+  ispublished: pub
+  issn: 0302-9743
+  key: fu_mi_publications2118
+  lastmod: '2017-10-12 12:37:21'
+  metadata_visibility: show
+  official_url: http://doi.org/10.1007/978-3-319-56970-3_12
+  pagerange: 190-206
+  pages: 16
+  publisher: Springer, Cham
+  refereed: 'TRUE'
+  rev_number: 6
+  series: Lecture Notes in Computer Science (LNCS)
+  status_changed: '2017-10-12 12:37:21'
+  subjects:
+  - G400
+  title: 'EPR-Dictionaries: A Practical and Fast Data Structure for Constant Time
+    Searches in Unidirectional and Bidirectional FM Indices'
+  type: book_section
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2118
+  userid: 132
+  volume: 10229
+- abstract: Identification and quantification of microorganisms is a significant step
+    in studying the alpha and beta diversities within and between microbial communities
+    respectively. Both identification and quantification of a given microbial community
+    can be carried out using whole genome shotgun sequences with less bias than when
+    using 16S-rDNA sequences. However, shared regions of DNA among reference genomes
+    and taxonomic units pose a significant challenge in assigning reads correctly
+    to their true origins. The existing microbial community profiling tools commonly
+    deal with this problem by either preparing signature-based unique references or
+    assigning an ambiguous read to its least common ancestor in a taxonomic tree.
+    The former method is limited to making use of the reads which can be mapped to
+    the curated regions, while the latter suffer from the lack of uniquely mapped
+    reads at lower (more specific) taxonomic ranks. Moreover, even if the tools exhibited
+    good performance in calling the organisms present in a sample, there is still
+    room for improvement in determining the correct relative abundance of the organisms.
+    We present a new method Species Level Identification of Microorganisms from Metagenomes
+    (SLIMM) which addresses the above issues by using coverage information of reference
+    genomes to remove unlikely genomes from the analysis and subsequently gain more
+    uniquely mapped reads to assign at lower ranks of a taxonomic tree. SLIMM is based
+    on a few, seemingly easy steps which when combined create a tool that outperforms
+    state-of-the-art tools in run-time and memory usage while being on par or better
+    in computing quantitative and qualitative information at species-level.
+  bibtex: "@article{fu_mi_publications2119,\n abstract = {Identification and quantification\
+    \ of microorganisms is a significant step in studying the alpha and beta diversities\
+    \ within and between microbial communities respectively. Both identification and\
+    \ quantification of a given microbial community can be carried out using whole\
+    \ genome shotgun sequences with less bias than when using 16S-rDNA sequences.\
+    \ However, shared regions of DNA among reference genomes and taxonomic units pose\
+    \ a significant challenge in assigning reads correctly to their true origins.\
+    \ The existing microbial community profiling tools commonly deal with this problem\
+    \ by either preparing signature-based unique references or assigning an ambiguous\
+    \ read to its least common ancestor in a taxonomic tree. The former method is\
+    \ limited to making use of the reads which can be mapped to the curated regions,\
+    \ while the latter suffer from the lack of uniquely mapped reads at lower (more\
+    \ specific) taxonomic ranks. Moreover, even if the tools exhibited good performance\
+    \ in calling the organisms present in a sample, there is still room for improvement\
+    \ in determining the correct relative abundance of the organisms. We present a\
+    \ new method Species Level Identification of Microorganisms from Metagenomes (SLIMM)\
+    \ which addresses the above issues by using coverage information of reference\
+    \ genomes to remove unlikely genomes from the analysis and subsequently gain more\
+    \ uniquely mapped reads to assign at lower ranks of a taxonomic tree. SLIMM is\
+    \ based on a few, seemingly easy steps which when combined create a tool that\
+    \ outperforms state-of-the-art tools in run-time and memory usage while being\
+    \ on par or better in computing quantitative and qualitative information at species-level.},\n\
+    \ author = {Temesgen Hailemariam Dadi and Bernhard Y. Renard and Lothar H. Wieler\
+    \ and Torsten Semmler and Knut Reinert},\n journal = {PeerJ},\n month = {March},\n\
+    \ pages = {e3138},\n title = {SLIMM: species level identification of microorganisms\
+    \ from metagenomes},\n url = {http://publications.imp.fu-berlin.de/2119/},\n volume\
+    \ = {5},\n year = {2017}\n}\n\n"
+  creators:
+  - name:
+      family: Dadi
+      given: Temesgen Hailemariam
+      honourific: null
+      lineage: null
+  - name:
+      family: Renard
+      given: Bernhard Y.
+      honourific: null
+      lineage: null
+  - name:
+      family: Wieler
+      given: Lothar H.
+      honourific: null
+      lineage: null
+  - name:
+      family: Semmler
+      given: Torsten
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: Knut
+      honourific: null
+      lineage: null
+  date: '2017-03-28'
+  date_type: published
+  datestamp: '2017-10-12 13:01:44'
+  dir: disk0/00/00/21/19
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 2119
+  full_text_status: none
+  id_number: doi:10.7717/peerj.3138
+  ispublished: pub
+  issn: 2167-8359
+  key: fu_mi_publications2119
+  lastmod: '2017-10-12 13:01:44'
+  metadata_visibility: show
+  official_url: http://doi.org/10.7717/peerj.3138
+  pagerange: e3138
+  publication: PeerJ
+  refereed: 'TRUE'
+  rev_number: 5
+  status_changed: '2017-10-12 13:01:44'
+  subjects:
+  - G400
+  title: 'SLIMM: species level identification of microorganisms from metagenomes'
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2119
+  userid: 132
+  volume: 5
+- abstract: "The combination of high-performance liquid chromatography and electrospray\
+    \ ionization ion mobility spectrometry facilitates the two-dimensional separation\
+    \ of complex mixtures in the retention and drift time plane. The ion mobility\
+    \ spectrometer presented here was optimized for flow rates customarily used in\
+    \ high-performance liquid chromatography between 100 and 1500 \u03BCL/min. The\
+    \ characterization of the system with respect to such parameters as the peak capacity\
+    \ of each time dimension and of the 2D spectrum was carried out based on a separation\
+    \ of a pesticide mixture containing 24 substances. While the total ion current\
+    \ chromatogram is coarsely resolved, exhibiting coelutions for a number of compounds,\
+    \ all substances can be separately detected in the 2D plane due to the orthogonality\
+    \ of the separations in retention and drift dimensions. Another major advantage\
+    \ of the ion mobility detector is the identification of substances based on their\
+    \ characteristic mobilities. Electrospray ionization allows the detection of substances\
+    \ lacking a chromophore. As an example, the separation of a mixture of 18 amino\
+    \ acids is presented. A software built upon the free mass spectrometry package\
+    \ OpenMS was developed for processing the extensive 2D data. The different processing\
+    \ steps are implemented as separate modules which can be arranged in a graphic\
+    \ workflow facilitating automated processing of data."
+  bibtex: "@article{fu_mi_publications2128,\n abstract = {The combination of high-performance\
+    \ liquid chromatography and electrospray ionization ion mobility spectrometry\
+    \ facilitates the two-dimensional separation of complex mixtures in the retention\
+    \ and drift time plane. The ion mobility spectrometer presented here was optimized\
+    \ for flow rates customarily used in high-performance liquid chromatography between\
+    \ 100 and 1500 {\\ensuremath{\\mu}}L/min. The characterization of the system with\
+    \ respect to such parameters as the peak capacity of each time dimension and of\
+    \ the 2D spectrum was carried out based on a separation of a pesticide mixture\
+    \ containing 24 substances. While the total ion current chromatogram is coarsely\
+    \ resolved, exhibiting coelutions for a number of compounds, all substances can\
+    \ be separately detected in the 2D plane due to the orthogonality of the separations\
+    \ in retention and drift dimensions. Another major advantage of the ion mobility\
+    \ detector is the identification of substances based on their characteristic mobilities.\
+    \ Electrospray ionization allows the detection of substances lacking a chromophore.\
+    \ As an example, the separation of a mixture of 18 amino acids is presented. A\
+    \ software built upon the free mass spectrometry package OpenMS was developed\
+    \ for processing the extensive 2D data. The different processing steps are implemented\
+    \ as separate modules which can be arranged in a graphic workflow facilitating\
+    \ automated processing of data.},\n author = {Martin Z{\\\"u}hlke and Daniel Riebe\
+    \ and Toralf Beitz and Hans-Gerd L{\\\"o}hmannsr{\\\"o}ben and Sandro Andreotti\
+    \ and Knut Reinert and Karl Zenichowski and Marc Diener},\n journal = {Journal\
+    \ of Separation Science},\n month = {November},\n number = {24},\n pages = {4756--4764},\n\
+    \ publisher = {Wiley},\n title = {High-performance liquid chromatography with\
+    \ electrospray ionization ion mobility spectrometry: Characterization, data management,\
+    \ and applications},\n url = {http://publications.imp.fu-berlin.de/2128/},\n volume\
+    \ = {39},\n year = {2016}\n}\n\n"
+  creators:
+  - name:
+      family: "Z\xFChlke"
+      given: Martin
+      honourific: null
+      lineage: null
+  - name:
+      family: Riebe
+      given: Daniel
+      honourific: null
+      lineage: null
+  - name:
+      family: Beitz
+      given: Toralf
+      honourific: null
+      lineage: null
+  - name:
+      family: "L\xF6hmannsr\xF6ben"
+      given: Hans-Gerd
+      honourific: null
+      lineage: null
+  - name:
+      family: Andreotti
+      given: Sandro
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: Knut
+      honourific: null
+      lineage: null
+  - name:
+      family: Zenichowski
+      given: Karl
+      honourific: null
+      lineage: null
+  - name:
+      family: Diener
+      given: Marc
+      honourific: null
+      lineage: null
+  date: '2016-11-28'
+  date_type: published
+  datestamp: '2017-11-22 13:04:29'
+  dir: disk0/00/00/21/28
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 2128
+  full_text_status: none
+  id_number: doi:10.1002/jssc.201600749
+  ispublished: pub
+  issn: 16159306
+  key: fu_mi_publications2128
+  lastmod: '2017-11-22 13:19:29'
+  metadata_visibility: show
+  number: 24
+  official_url: http://doi.org/10.1002/jssc.201600749
+  pagerange: 4756-4764
+  publication: Journal of Separation Science
+  publisher: Wiley
+  refereed: 'TRUE'
+  rev_number: 6
+  status_changed: '2017-11-22 13:04:29'
+  subjects:
+  - G400
+  title: 'High-performance liquid chromatography with electrospray ionization ion
+    mobility spectrometry: Characterization, data management, and applications'
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2128
+  userid: 132
+  volume: 39
+- abstract: High-resolution mass spectrometry (MS) has become an important tool in
+    the life sciences, contributing to the diagnosis and understanding of human diseases,
+    elucidating biomolecular structural information and characterizing cellular signaling
+    networks. However, the rapid growth in the volume and complexity of MS data makes
+    transparent, accurate and reproducible analysis difficult. We present OpenMS 2.0
+    (http://www.openms.de), a robust, open-source, cross-platform software specifically
+    designed for the flexible and reproducible analysis of high-throughput MS data.
+    The extensible OpenMS software implements common mass spectrometric data processing
+    tasks through a well-defined application programming interface in C++ and Python
+    and through standardized open data formats. OpenMS additionally provides a set
+    of 185 tools and ready-made workflows for common mass spectrometric data processing
+    tasks, which enable users to perform complex quantitative mass spectrometric analyses
+    with ease.
+  bibtex: "@article{fu_mi_publications2129,\n abstract = {High-resolution mass spectrometry\
+    \ (MS) has become an important tool in the life sciences, contributing to the\
+    \ diagnosis and understanding of human diseases, elucidating biomolecular structural\
+    \ information and characterizing cellular signaling networks. However, the rapid\
+    \ growth in the volume and complexity of MS data makes transparent, accurate and\
+    \ reproducible analysis difficult. We present OpenMS 2.0 (http://www.openms.de),\
+    \ a robust, open-source, cross-platform software specifically designed for the\
+    \ flexible and reproducible analysis of high-throughput MS data. The extensible\
+    \ OpenMS software implements common mass spectrometric data processing tasks through\
+    \ a well-defined application programming interface in C++ and Python and through\
+    \ standardized open data formats. OpenMS additionally provides a set of 185 tools\
+    \ and ready-made workflows for common mass spectrometric data processing tasks,\
+    \ which enable users to perform complex quantitative mass spectrometric analyses\
+    \ with ease.},\n author = {Hannes L R{\\\"o}st and Timo Sachsenberg and Stephan\
+    \ Aiche and Chris Bielow and Hendrik Weisser and Fabian Aicheler and Sandro Andreotti\
+    \ and Hans-Christian Ehrlich and Petra Gutenbrunner and Erhan Kenar and Xiao Liang\
+    \ and Sven Nahnsen and Lars Nilse and Julianus Pfeuffer and George Rosenberger\
+    \ and Marc Rurik and Uwe Schmitt and Johannes Veit and Mathias Walzer and David\
+    \ Wojnar and Witold E Wolski and Oliver Schilling and Jyoti S Choudhary and Lars\
+    \ Malmstr{\\\"o}m and Ruedi Aebersold and Knut Reinert and Oliver Kohlbacher},\n\
+    \ journal = {Nature Methods},\n month = {August},\n number = {9},\n pages = {741--748},\n\
+    \ publisher = {Springer Nature/Macmillan Publishers Limited},\n title = {OpenMS:\
+    \ a flexible open-source software platform for mass spectrometry data analysis},\n\
+    \ url = {http://publications.imp.fu-berlin.de/2129/},\n volume = {13},\n year\
+    \ = {2016}\n}\n\n"
+  creators:
+  - name:
+      family: "R\xF6st"
+      given: Hannes L
+      honourific: null
+      lineage: null
+  - name:
       family: Sachsenberg
       given: Timo
-      honourific:
+      honourific: null
+      lineage: null
   - name:
-      lineage:
-      given: Tjeerd M. H.
-      honourific:
-      family: Dijkstra
+      family: Aiche
+      given: Stephan
+      honourific: null
+      lineage: null
   - name:
-      family: Serang
+      family: Bielow
+      given: Chris
+      honourific: null
+      lineage: null
+  - name:
+      family: Weisser
+      given: Hendrik
+      honourific: null
+      lineage: null
+  - name:
+      family: Aicheler
+      given: Fabian
+      honourific: null
+      lineage: null
+  - name:
+      family: Andreotti
+      given: Sandro
+      honourific: null
+      lineage: null
+  - name:
+      family: Ehrlich
+      given: Hans-Christian
+      honourific: null
+      lineage: null
+  - name:
+      family: Gutenbrunner
+      given: Petra
+      honourific: null
+      lineage: null
+  - name:
+      family: Kenar
+      given: Erhan
+      honourific: null
+      lineage: null
+  - name:
+      family: Liang
+      given: Xiao
+      honourific: null
+      lineage: null
+  - name:
+      family: Nahnsen
+      given: Sven
+      honourific: null
+      lineage: null
+  - name:
+      family: Nilse
+      given: Lars
+      honourific: null
+      lineage: null
+  - name:
+      family: Pfeuffer
+      given: Julianus
+      honourific: null
+      lineage: null
+  - name:
+      family: Rosenberger
+      given: George
+      honourific: null
+      lineage: null
+  - name:
+      family: Rurik
+      given: Marc
+      honourific: null
+      lineage: null
+  - name:
+      family: Schmitt
+      given: Uwe
+      honourific: null
+      lineage: null
+  - name:
+      family: Veit
+      given: Johannes
+      honourific: null
+      lineage: null
+  - name:
+      family: Walzer
+      given: Mathias
+      honourific: null
+      lineage: null
+  - name:
+      family: Wojnar
+      given: David
+      honourific: null
+      lineage: null
+  - name:
+      family: Wolski
+      given: Witold E
+      honourific: null
+      lineage: null
+  - name:
+      family: Schilling
       given: Oliver
-      honourific:
-      lineage:
+      honourific: null
+      lineage: null
   - name:
-      given: Knut
-      honourific:
+      family: Choudhary
+      given: Jyoti S
+      honourific: null
+      lineage: null
+  - name:
+      family: "Malmstr\xF6m"
+      given: Lars
+      honourific: null
+      lineage: null
+  - name:
+      family: Aebersold
+      given: Ruedi
+      honourific: null
+      lineage: null
+  - name:
       family: Reinert
-      lineage:
+      given: Knut
+      honourific: null
+      lineage: null
   - name:
       family: Kohlbacher
       given: Oliver
-      honourific:
-      lineage:
-  datestamp: '2020-04-02 10:05:57'
-  publication: Journal of Proteome Research
-  status_changed: '2020-04-02 10:05:57'
-  abstract: Accurate protein inference in the presence of shared peptides is still
+      honourific: null
+      lineage: null
+  date: '2016-08-30'
+  date_type: published
+  datestamp: '2017-11-22 13:17:53'
+  dir: disk0/00/00/21/29
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 2129
+  full_text_status: none
+  id_number: doi:10.1038/nmeth.3959
+  ispublished: pub
+  issn: 1548-7091
+  key: fu_mi_publications2129
+  lastmod: '2017-11-22 13:17:53'
+  metadata_visibility: show
+  number: 9
+  official_url: http://doi.org/10.1038/nmeth.3959
+  pagerange: 741-748
+  publication: Nature Methods
+  publisher: Springer Nature/Macmillan Publishers Limited
+  refereed: 'TRUE'
+  rev_number: 5
+  status_changed: '2017-11-22 13:17:53'
+  subjects:
+  - G400
+  title: 'OpenMS: a flexible open-source software platform for mass spectrometry data
+    analysis'
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2129
+  userid: 132
+  volume: 13
+- abstract: "Background\r\n\r\nReproducibility is one of the tenets of the scientific\
+    \ method. Scientific experiments often comprise complex data flows, selection\
+    \ of adequate parameters, and analysis and visualization of intermediate and end\
+    \ results. Breaking down the complexity of such experiments into the joint collaboration\
+    \ of small, repeatable, well defined tasks, each with well defined inputs, parameters,\
+    \ and outputs, offers the immediate benefit of identifying bottlenecks, pinpoint\
+    \ sections which could benefit from parallelization, among others. Workflows rest\
+    \ upon the notion of splitting complex work into the joint effort of several manageable\
+    \ tasks.\r\n\r\nThere are several engines that give users the ability to design\
+    \ and execute workflows. Each engine was created to address certain problems of\
+    \ a specific community, therefore each one has its advantages and shortcomings.\
+    \ Furthermore, not all features of all workflow engines are royalty-free \u2014\
+    an aspect that could potentially drive away members of the scientific community.\r\
+    \n\r\nResults\r\n\r\nWe have developed a set of tools that enables the scientific\
+    \ community to benefit from workflow interoperability. We developed a platform-free\
+    \ structured representation of parameters, inputs, outputs of command-line tools\
+    \ in so-called Common Tool Descriptor documents. We have also overcome the shortcomings\
+    \ and combined the features of two royalty-free workflow engines with a substantial\
+    \ user community: the Konstanz Information Miner, an engine which we see as a\
+    \ formidable workflow editor, and the Grid and User Support Environment, a web-based\
+    \ framework able to interact with several high-performance computing resources.\
+    \ We have thus created a free and highly accessible way to design workflows on\
+    \ a desktop computer and execute them on high-performance computing resources.\r\
+    \n\r\nConclusions\r\n\r\nOur work will not only reduce time spent on designing\
+    \ scientific workflows, but also make executing workflows on remote high-performance\
+    \ computing resources more accessible to technically inexperienced users. We strongly\
+    \ believe that our efforts not only decrease the turnaround time to obtain scientific\
+    \ results but also have a positive impact on reproducibility, thus elevating the\
+    \ quality of obtained scientific results."
+  bibtex: "@article{fu_mi_publications2130,\n abstract = {Background\n\nReproducibility\
+    \ is one of the tenets of the scientific method. Scientific experiments often\
+    \ comprise complex data flows, selection of adequate parameters, and analysis\
+    \ and visualization of intermediate and end results. Breaking down the complexity\
+    \ of such experiments into the joint collaboration of small, repeatable, well\
+    \ defined tasks, each with well defined inputs, parameters, and outputs, offers\
+    \ the immediate benefit of identifying bottlenecks, pinpoint sections which could\
+    \ benefit from parallelization, among others. Workflows rest upon the notion of\
+    \ splitting complex work into the joint effort of several manageable tasks.\n\n\
+    There are several engines that give users the ability to design and execute workflows.\
+    \ Each engine was created to address certain problems of a specific community,\
+    \ therefore each one has its advantages and shortcomings. Furthermore, not all\
+    \ features of all workflow engines are royalty-free {--}an aspect that could potentially\
+    \ drive away members of the scientific community.\n\nResults\n\nWe have developed\
+    \ a set of tools that enables the scientific community to benefit from workflow\
+    \ interoperability. We developed a platform-free structured representation of\
+    \ parameters, inputs, outputs of command-line tools in so-called Common Tool Descriptor\
+    \ documents. We have also overcome the shortcomings and combined the features\
+    \ of two royalty-free workflow engines with a substantial user community: the\
+    \ Konstanz Information Miner, an engine which we see as a formidable workflow\
+    \ editor, and the Grid and User Support Environment, a web-based framework able\
+    \ to interact with several high-performance computing resources. We have thus\
+    \ created a free and highly accessible way to design workflows on a desktop computer\
+    \ and execute them on high-performance computing resources.\n\nConclusions\n\n\
+    Our work will not only reduce time spent on designing scientific workflows, but\
+    \ also make executing workflows on remote high-performance computing resources\
+    \ more accessible to technically inexperienced users. We strongly believe that\
+    \ our efforts not only decrease the turnaround time to obtain scientific results\
+    \ but also have a positive impact on reproducibility, thus elevating the quality\
+    \ of obtained scientific results.},\n author = {Luis de la Garza and Johannes\
+    \ Veit and Andras Szolek and Marc R{\\\"o}ttig and Stephan Aiche and Sandra Gesing\
+    \ and Knut Reinert and Oliver Kohlbacher},\n journal = {BMC Bioinformatics},\n\
+    \ month = {March},\n number = {1},\n publisher = {Springer Nature},\n title =\
+    \ {From the desktop to the grid: scalable bioinformatics via workflow conversion},\n\
+    \ url = {http://publications.imp.fu-berlin.de/2130/},\n volume = {17},\n year\
+    \ = {2016}\n}\n\n"
+  creators:
+  - name:
+      family: de la Garza
+      given: Luis
+      honourific: null
+      lineage: null
+  - name:
+      family: Veit
+      given: Johannes
+      honourific: null
+      lineage: null
+  - name:
+      family: Szolek
+      given: Andras
+      honourific: null
+      lineage: null
+  - name:
+      family: "R\xF6ttig"
+      given: Marc
+      honourific: null
+      lineage: null
+  - name:
+      family: Aiche
+      given: Stephan
+      honourific: null
+      lineage: null
+  - name:
+      family: Gesing
+      given: Sandra
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: Knut
+      honourific: null
+      lineage: null
+  - name:
+      family: Kohlbacher
+      given: Oliver
+      honourific: null
+      lineage: null
+  date: '2016-03-12'
+  date_type: published
+  datestamp: '2017-11-22 13:42:20'
+  dir: disk0/00/00/21/30
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 2130
+  full_text_status: none
+  id_number: doi:10.1186/s12859-016-0978-9
+  ispublished: pub
+  issn: 1471-2105
+  key: fu_mi_publications2130
+  lastmod: '2017-11-22 13:42:20'
+  metadata_visibility: show
+  number: 1
+  official_url: http://doi.org/10.1186/s12859-016-0978-9
+  publication: BMC Bioinformatics
+  publisher: Springer Nature
+  refereed: 'TRUE'
+  rev_number: 5
+  status_changed: '2017-11-22 13:42:20'
+  subjects:
+  - G400
+  title: 'From the desktop to the grid: scalable bioinformatics via workflow conversion'
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2130
+  userid: 132
+  volume: 17
+- abstract: "This proceedings volume contains papers presented at the 17th Workshop\
+    \ on Algorithms in Bioinformatics (WABI 2017), which was held in Boston, MA, USA\
+    \ in conjunction with the 8th ACM Conference on Bioinformatics, Computational\
+    \ Biology, and Health Informatics (ACM BCB) from August 21\u201323, 2017.\r\n\
+    The Workshop on Algorithms in Bioinformatics is an annual conference established\
+    \ in 2001 to cover all aspects of algorithmic work in bioinformatics, computational\
+    \ biology, and systems biology. The workshop is intended as a forum for discrete\
+    \ algorithms and machine-learning methods that address important problems in molecular\
+    \ biology, that are founded on sound models, that are computationally efficient,\
+    \ and that have been implemented and tested in simulations and on real datasets.\
+    \ The meeting\u2019s focus is on recent research results, including significant\
+    \ work-in-progress, as well as identifying and explore directions of future research.\r\
+    \nWABI 2017 is grateful for the support of ACM-BCB in allowing us to cohost the\
+    \ meetings, as well as to ACM-BCB\u2019s sponsors: the Association for Computing\
+    \ Machinery (ACM) and ACM\u2019s SIGBIO.\r\nIn 2017, a total of 55 manuscripts\
+    \ were submitted to WABI from which 27 were selected for presentation at the conference.\
+    \ This year, WABI is adopting a new proceedings form, publishing the conference\
+    \ proceedings through the LIPIcs (Leibniz International Proceedings in Informatics)\
+    \ proceedings series. Extended versions of selected papers will be invited for\
+    \ publication in a thematic series in the journal Algorithms for Molecular Biology\
+    \ (AMB), published by BioMed Central.\r\nThe 27 papers were selected based on\
+    \ a thorough peer review, involving at least three independent reviewers per submitted\
+    \ paper, followed by discussions among the WABI Program Committee members. The\
+    \ selected papers cover a wide range of topics, including statistical inference,\
+    \ phylogenetic studies, sequence and genome analysis, comparative genomics, and\
+    \ mass spectrometry data analysis.\r\nWe thank all the authors of submitted papers\
+    \ and the members of the WABI Program Committee and their reviewers for their\
+    \ efforts that made this conference possible. We are also grateful to the WABI\
+    \ Steering Committee for their help and advice. We also thank all the conference\
+    \ participants and speakers who contribute to a great scientific program. In\r\
+    \nparticular, we are indebted to the keynote speaker of the conference, Tandy\
+    \ Warnow, for her presentation. We also thank Christopher Pockrandt for setting\
+    \ up the WABI webpage\r\nand Umit Acar for his help with coordinating the WABI\
+    \ and ACM-BCB pages. Finally, we thank the ACM-BCB Organizing Committee, especially\
+    \ Nurit Haspel and Lenore Cowen,\r\nfor their hard work in making all of the local\
+    \ arrangements and working closely with us to ensure a successful and exciting\
+    \ WABI and ACM-BCB."
+  bibtex: "@book{fu_mi_publications2132,\n abstract = {This proceedings volume contains\
+    \ papers presented at the 17th Workshop on Algorithms in Bioinformatics (WABI\
+    \ 2017), which was held in Boston, MA, USA in conjunction with the 8th ACM Conference\
+    \ on Bioinformatics, Computational Biology, and Health Informatics (ACM BCB) from\
+    \ August 21?23, 2017.\nThe Workshop on Algorithms in Bioinformatics is an annual\
+    \ conference established in 2001 to cover all aspects of algorithmic work in bioinformatics,\
+    \ computational biology, and systems biology. The workshop is intended as a forum\
+    \ for discrete algorithms and machine-learning methods that address important\
+    \ problems in molecular biology, that are founded on sound models, that are computationally\
+    \ efficient, and that have been implemented and tested in simulations and on real\
+    \ datasets. The meeting?s focus is on recent research results, including significant\
+    \ work-in-progress, as well as identifying and explore directions of future research.\n\
+    WABI 2017 is grateful for the support of ACM-BCB in allowing us to cohost the\
+    \ meetings, as well as to ACM-BCB?s sponsors: the Association for Computing Machinery\
+    \ (ACM) and ACM?s SIGBIO.\nIn 2017, a total of 55 manuscripts were submitted to\
+    \ WABI from which 27 were selected for presentation at the conference. This year,\
+    \ WABI is adopting a new proceedings form, publishing the conference proceedings\
+    \ through the LIPIcs (Leibniz International Proceedings in Informatics) proceedings\
+    \ series. Extended versions of selected papers will be invited for publication\
+    \ in a thematic series in the journal Algorithms for Molecular Biology (AMB),\
+    \ published by BioMed Central.\nThe 27 papers were selected based on a thorough\
+    \ peer review, involving at least three independent reviewers per submitted paper,\
+    \ followed by discussions among the WABI Program Committee members. The selected\
+    \ papers cover a wide range of topics, including statistical inference, phylogenetic\
+    \ studies, sequence and genome analysis, comparative genomics, and mass spectrometry\
+    \ data analysis.\nWe thank all the authors of submitted papers and the members\
+    \ of the WABI Program Committee and their reviewers for their efforts that made\
+    \ this conference possible. We are also grateful to the WABI Steering Committee\
+    \ for their help and advice. We also thank all the conference participants and\
+    \ speakers who contribute to a great scientific program. In\nparticular, we are\
+    \ indebted to the keynote speaker of the conference, Tandy Warnow, for her presentation.\
+    \ We also thank Christopher Pockrandt for setting up the WABI webpage\nand Umit\
+    \ Acar for his help with coordinating the WABI and ACM-BCB pages. Finally, we\
+    \ thank the ACM-BCB Organizing Committee, especially Nurit Haspel and Lenore Cowen,\n\
+    for their hard work in making all of the local arrangements and working closely\
+    \ with us to ensure a successful and exciting WABI and ACM-BCB.},\n address =\
+    \ {Saarbr{\\\"u}cken/Wadern},\n editor = {Russell Schwartz and Knut Reinert},\n\
+    \ month = {August},\n publisher = {Dagstuhl LIPIcs},\n series = {LIPICS},\n title\
+    \ = {17th International Workshop on Algorithms in Bioinformatics (WABI 2017)},\n\
+    \ url = {http://publications.imp.fu-berlin.de/2132/},\n volume = {88},\n year\
+    \ = {2017}\n}\n\n"
+  date: 2017-08
+  date_type: published
+  datestamp: '2017-11-23 11:10:39'
+  dir: disk0/00/00/21/32
+  divisions:
+  - group_algbioinf
+  editors:
+  - id: null
+    name:
+      family: Schwartz
+      given: Russell
+      honourific: null
+      lineage: null
+  - id: knut.reinert@fu-berlin.de
+    name:
+      family: Reinert
+      given: Knut
+      honourific: null
+      lineage: null
+  eprint_status: archive
+  eprintid: 2132
+  full_text_status: none
+  isbn: 978-3-95977-050-7
+  ispublished: pub
+  key: fu_mi_publications2132
+  lastmod: '2017-11-23 11:10:39'
+  metadata_visibility: show
+  official_url: http://www.dagstuhl.de/dagpub/978-3-95977-050-7
+  pages: 394
+  place_of_pub: "Saarbr\xFCcken/Wadern"
+  publisher: Dagstuhl LIPIcs
+  refereed: 'TRUE'
+  related_url:
+  - url: http://nbn-resolving.de/urn:nbn:de:0030-drops-78120
+  rev_number: 7
+  series: LIPICS
+  status_changed: '2017-11-23 11:10:39'
+  subjects:
+  - G400
+  title: 17th International Workshop on Algorithms in Bioinformatics (WABI 2017)
+  type: book
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2132
+  userid: 132
+  volume: 88
+- abstract: "Motivation: \r\nComprehensive identification of structural variations\
+    \ (SVs) is a crucial task for studying genetic diversity and diseases. However,\
+    \ it remains challenging. There is only a marginal consensus between different\
+    \ methods, and our understanding of SVs is substantially limited.In general, integration\
+    \ of multiple pieces of evidence including split-read, read-pair, soft-clip, and\
+    \ read-depth yields the best result regarding accuracy. However, doing this step\
+    \ by step is usually cumbersome and computationally expensive. \r\nResult: \r\n\
+    We present Vaquita, an accurate and fast tool for the identification of structural\
+    \ variations, which leverages all four types of evidence in a single program.\
+    \ After merging SVs from split-reads and discordant read-pairs, Vaquita realigns\
+    \ the soft-clipped reads to the selected regions using a fast bit-vector algorithm.\
+    \ Furthermore, it also considers the discrepancy of depth distribution around\
+    \ breakpoints using Kullback-Leibler divergence. Finally, Vaquita provides an\
+    \ additional metric for candidate selection based on voting, and also provides\
+    \ robust prioritization based on rank aggregation. We show that Vaquita is robust\
+    \ in terms of sequencing coverage, insertion size of the library, and read length,\
+    \ and is comparable or even better for the identification of deletions, inversions,\
+    \ duplications, and translocations than state-of-the-art tools, using both simulated\
+    \ and real datasets. In addition, Vaquita is more than eight times faster than\
+    \ any other tools in comparison. \r\nAvailability: \r\nVaquita is implemented\
+    \ in C++ using the SeqAn library. The source code is distributed under the BSD\
+    \ license and can be downloaded at http://github.com/seqan/vaquita"
+  bibtex: "@incollection{fu_mi_publications2133,\n abstract = {Motivation: \nComprehensive\
+    \ identification of structural variations (SVs) is a crucial task for studying\
+    \ genetic diversity and diseases. However, it remains challenging. There is only\
+    \ a marginal consensus between different methods, and our understanding of SVs\
+    \ is substantially limited.In general, integration of multiple pieces of evidence\
+    \ including split-read, read-pair, soft-clip, and read-depth yields the best result\
+    \ regarding accuracy. However, doing this step by step is usually cumbersome and\
+    \ computationally expensive. \nResult: \nWe present Vaquita, an accurate and fast\
+    \ tool for the identification of structural variations, which leverages all four\
+    \ types of evidence in a single program. After merging SVs from split-reads and\
+    \ discordant read-pairs, Vaquita realigns the soft-clipped reads to the selected\
+    \ regions using a fast bit-vector algorithm. Furthermore, it also considers the\
+    \ discrepancy of depth distribution around breakpoints using Kullback-Leibler\
+    \ divergence. Finally, Vaquita provides an additional metric for candidate selection\
+    \ based on voting, and also provides robust prioritization based on rank aggregation.\
+    \ We show that Vaquita is robust in terms of sequencing coverage, insertion size\
+    \ of the library, and read length, and is comparable or even better for the identification\
+    \ of deletions, inversions, duplications, and translocations than state-of-the-art\
+    \ tools, using both simulated and real datasets. In addition, Vaquita is more\
+    \ than eight times faster than any other tools in comparison. \nAvailability:\
+    \ \nVaquita is implemented in C++ using the SeqAn library. The source code is\
+    \ distributed under the BSD license and can be downloaded at http://github.com/seqan/vaquita},\n\
+    \ address = {Saarbr{\\\"u}cken/Wadern},\n author = {Jongkyu Kim and Knut Reinert},\n\
+    \ booktitle = {17th International Workshop on Algorithms in Bioinformatics (WABI\
+    \ 2017)},\n editor = {Russell Schwartz and Knut Reinert},\n month = {August},\n\
+    \ number = {88},\n pages = {185(13:1)--198(13:14)},\n publisher = {Dagstuhl LIPIcs},\n\
+    \ series = {LIPICS},\n title = {Vaquita: Fast and Accurate Identification of Structural\
+    \ Variation Using Combined Evidence},\n url = {http://publications.imp.fu-berlin.de/2133/},\n\
+    \ year = {2017}\n}\n\n"
+  book_title: 17th International Workshop on Algorithms in Bioinformatics (WABI 2017)
+  creators:
+  - name:
+      family: Kim
+      given: Jongkyu
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: Knut
+      honourific: null
+      lineage: null
+  date: 2017-08
+  date_type: published
+  datestamp: '2017-11-23 12:21:14'
+  dir: disk0/00/00/21/33
+  divisions:
+  - group_algbioinf
+  editors:
+  - name:
+      family: Schwartz
+      given: Russell
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: Knut
+      honourific: null
+      lineage: null
+  eprint_status: archive
+  eprintid: 2133
+  full_text_status: none
+  id_number: 'DOI: 10.4230/LIPIcs.WABI.2017.13'
+  isbn: 978-3-95977-050-7
+  ispublished: pub
+  key: fu_mi_publications2133
+  lastmod: '2017-11-23 12:21:14'
+  metadata_visibility: show
+  number: 88
+  official_url: http://drops.dagstuhl.de/opus/volltexte/2017/7635/
+  pagerange: 185(13:1)-198(13:14)
+  pages: 14
+  place_of_pub: "Saarbr\xFCcken/Wadern"
+  publisher: Dagstuhl LIPIcs
+  refereed: 'TRUE'
+  related_url:
+  - url: http://www.dagstuhl.de/dagpub/978-3-95977-050-7
+  rev_number: 8
+  series: LIPICS
+  status_changed: '2017-11-23 12:21:14'
+  subjects:
+  - G400
+  title: 'Vaquita: Fast and Accurate Identification of Structural Variation Using
+    Combined Evidence'
+  type: book_section
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2133
+  userid: 132
+- abstract: Next Generation Sequencing (NGS) data have begun to appear in many applications
+    that are clinically relevant, such as resequencing of cancer patients, disease-gene
+    discovery and diagnostics for rare diseases, microbiome analyses, and gene expression
+    profiling. The analysis of sequencing data is demanding because of the enormous
+    data volume and the need for fast turnaround time, accuracy, reproducibility,
+    and data security. This Dagstuhl Seminar aimed at a free and deep exchange of
+    ideas and needs between the communities of algorithmicists and theoreticians and
+    practitioners from the biomedical field. It identified several relevant fields
+    such as data structures and algorithms for large data sets, hardware acceleration,
+    new problems in the upcoming age of genomes, etc. which were discussed in breakout
+    groups.
+  bibtex: "@manual{fu_mi_publications2134,\n abstract = {Next Generation Sequencing\
+    \ (NGS) data have begun to appear in many applications that are clinically relevant,\
+    \ such as resequencing of cancer patients, disease-gene discovery and diagnostics\
+    \ for rare diseases, microbiome analyses, and gene expression profiling. The analysis\
+    \ of sequencing data is demanding because of the enormous data volume and the\
+    \ need for fast turnaround time, accuracy, reproducibility, and data security.\
+    \ This Dagstuhl Seminar aimed at a free and deep exchange of ideas and needs between\
+    \ the communities of algorithmicists and theoreticians and practitioners from\
+    \ the biomedical field. It identified several relevant fields such as data structures\
+    \ and algorithms for large data sets, hardware acceleration, new problems in the\
+    \ upcoming age of genomes, etc. which were discussed in breakout groups.},\n address\
+    \ = {Dagstuhl, Germany},\n author = {Gene Meyers and Mihai Pop and Knut Reinert\
+    \ and Tandy Warnow},\n number = {DOI: 10.4230/DagRep.6.8.91},\n publisher = {Schloss\
+    \ Dagstuhl--Leibniz-Zentrum fuer Informatik},\n title = {Dagstuhl Reports, Vol.\
+    \ 6, No. 8, pp. 91-130: Next Generation Sequencing (Dagstuhl Seminar 16351)},\n\
+    \ type = {Documentation},\n url = {http://publications.imp.fu-berlin.de/2134/},\n\
+    \ year = {2017}\n}\n\n"
+  creators:
+  - name:
+      family: Meyers
+      given: Gene
+      honourific: null
+      lineage: null
+  - name:
+      family: Pop
+      given: Mihai
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: Knut
+      honourific: null
+      lineage: null
+  - name:
+      family: Warnow
+      given: Tandy
+      honourific: null
+      lineage: null
+  date: 2017
+  date_type: published
+  datestamp: '2017-11-23 13:19:47'
+  dir: disk0/00/00/21/34
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 2134
+  full_text_status: none
+  id_number: 'DOI: 10.4230/DagRep.6.8.91'
+  ispublished: pub
+  key: fu_mi_publications2134
+  lastmod: '2017-11-23 13:19:47'
+  metadata_visibility: show
+  monograph_type: documentation
+  official_url: http://drops.dagstuhl.de/opus/volltexte/2017/6839
+  pages: 40
+  place_of_pub: Dagstuhl, Germany
+  publisher: Schloss Dagstuhl--Leibniz-Zentrum fuer Informatik
+  rev_number: 6
+  status_changed: '2017-11-23 13:19:47'
+  subjects:
+  - G400
+  title: 'Dagstuhl Reports, Vol. 6, No. 8, pp. 91-130: Next Generation Sequencing
+    (Dagstuhl Seminar 16351)'
+  type: monograph
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2134
+  userid: 132
+- abstract: "Motivation\r\n\r\nPairwise sequence alignment is undoubtedly a central\
+    \ tool in many bioinformatics analyses. In this paper, we present a generically\
+    \ accelerated module for pairwise sequence lignments applicable for a broad range\
+    \ of applications. In our module, we unified the standard dynamic programming\
+    \ kernel used for pairwise sequence alignments and extended it with a generalized\
+    \ inter-sequence vectorization layout, such that many alignments can be computed\
+    \ simultaneously by exploiting SIMD (Single Instruction Multiple Data) instructions\
+    \ of modern processors. We then extended the module by adding two layers of thread-level\
+    \ parallelization, where we a) distribute many independent alignments on multiple\
+    \ threads and b) inherently parallelize a single alignment computation using a\
+    \ work stealing approach producing a dynamic wavefront progressing along the minor\
+    \ diagonal.\r\n\r\nResults\r\n\r\nWe evaluated our alignment vectorization and\
+    \ parallelization on different processors, including the newest Intel\xAE Xeon\xAE\
+    \ (Skylake) and Intel\xAE Xeon Phi\u2122 (KNL) processors, and use cases. The\
+    \ instruction set AVX512-BW (Byte and Word), available on Skylake processors,\
+    \ can genuinely improve the performance of vectorized alignments. We could run\
+    \ single alignments 1600 times faster on the Xeon Phi\u2122 and 1400 times faster\
+    \ on the Xeon\xAE than executing them with our previous sequential alignment module.\r\
+    \n\r\nAvailability\r\n\r\nThe module is programmed in C++ using the SeqAn (Reinert\
+    \ et al., 2017) library and distributed with version 2.4. under the BSD license.\
+    \ We support SSE4, AVX2, AVX512 instructions and included UME::SIMD, a SIMD-instruction\
+    \ wrapper library, to extend our module for further instruction sets. We thoroughly\
+    \ test all alignment components with all major C++ compilers on various platforms."
+  bibtex: "@article{fu_mi_publications2253,\n abstract = {Motivation\n\nPairwise sequence\
+    \ alignment is undoubtedly a central tool in many bioinformatics analyses. In\
+    \ this paper, we present a generically accelerated module for pairwise sequence\
+    \ lignments applicable for a broad range of applications. In our module, we unified\
+    \ the standard dynamic programming kernel used for pairwise sequence alignments\
+    \ and extended it with a generalized inter-sequence vectorization layout, such\
+    \ that many alignments can be computed simultaneously by exploiting SIMD (Single\
+    \ Instruction Multiple Data) instructions of modern processors. We then extended\
+    \ the module by adding two layers of thread-level parallelization, where we a)\
+    \ distribute many independent alignments on multiple threads and b) inherently\
+    \ parallelize a single alignment computation using a work stealing approach producing\
+    \ a dynamic wavefront progressing along the minor diagonal.\n\nResults\n\nWe evaluated\
+    \ our alignment vectorization and parallelization on different processors, including\
+    \ the newest Intel? Xeon? (Skylake) and Intel? Xeon Phi? (KNL) processors, and\
+    \ use cases. The instruction set AVX512-BW (Byte and Word), available on Skylake\
+    \ processors, can genuinely improve the performance of vectorized alignments.\
+    \ We could run single alignments 1600 times faster on the Xeon Phi? and 1400 times\
+    \ faster on the Xeon? than executing them with our previous sequential alignment\
+    \ module.\n\nAvailability\n\nThe module is programmed in C++ using the SeqAn (Reinert\
+    \ et al., 2017) library and distributed with version 2.4. under the BSD license.\
+    \ We support SSE4, AVX2, AVX512 instructions and included UME::SIMD, a SIMD-instruction\
+    \ wrapper library, to extend our module for further instruction sets. We thoroughly\
+    \ test all alignment components with all major C++ compilers on various platforms.},\n\
+    \ author = {Ren{\\'e} Rahn and Stefan Budach and Pascal Costanza and Marcel Ehrhardt\
+    \ and Jonny Hancox and Knut Reinert},\n journal = {Bioinformatics},\n month =\
+    \ {October},\n number = {20},\n pages = {3437--3445},\n publisher = {Oxford Academic\
+    \ (OUP)},\n title = {Generic accelerated sequence alignment in SeqAn using vectorization\
+    \ and multi-threading},\n url = {http://publications.imp.fu-berlin.de/2253/},\n\
+    \ volume = {34},\n year = {2018}\n}\n\n"
+  creators:
+  - name:
+      family: Rahn
+      given: "Ren\xE9"
+      honourific: null
+      lineage: null
+  - name:
+      family: Budach
+      given: Stefan
+      honourific: null
+      lineage: null
+  - name:
+      family: Costanza
+      given: Pascal
+      honourific: null
+      lineage: null
+  - name:
+      family: Ehrhardt
+      given: Marcel
+      honourific: null
+      lineage: null
+  - name:
+      family: Hancox
+      given: Jonny
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: Knut
+      honourific: null
+      lineage: null
+  date: '2018-10-15'
+  date_type: published
+  datestamp: '2018-05-31 11:28:35'
+  dir: disk0/00/00/22/53
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 2253
+  full_text_status: none
+  id_number: doi:10.1093/bioinformatics/bty380
+  ispublished: pub
+  issn: 1367-4803
+  key: fu_mi_publications2253
+  lastmod: '2018-11-13 13:43:57'
+  metadata_visibility: show
+  number: 20
+  official_url: http://doi.org/10.1093/bioinformatics/bty380
+  pagerange: 3437-3445
+  publication: Bioinformatics
+  publisher: Oxford Academic (OUP)
+  refereed: 'TRUE'
+  rev_number: 8
+  status_changed: '2018-11-13 13:43:57'
+  subjects:
+  - G400
+  title: Generic accelerated sequence alignment in SeqAn using vectorization and multi-threading
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2253
+  userid: 132
+  volume: 34
+- abstract: "Motivation\r\n\r\nMapping-based approaches have become limited in their\
+    \ application to very large sets of references since computing an FM-index for\
+    \ very large databases (e.g. >10 GB) has become a bottleneck. This affects many\
+    \ analyses that need such index as an essential step for approximate matching\
+    \ of the NGS reads to reference databases. For instance, in typical metagenomics\
+    \ analysis, the size of the reference sequences has become prohibitive to compute\
+    \ a single full-text index on standard machines. Even on large memory machines,\
+    \ computing such index takes about 1 day of computing time. As a result, updates\
+    \ of indices are rarely performed. Hence, it is desirable to create an alternative\
+    \ way of indexing while preserving fast search times.\r\n\r\nResults\r\n\r\nTo\
+    \ solve the index construction and update problem we propose the DREAM (Dynamic\
+    \ seaRchablE pArallel coMpressed index) framework and provide an implementation.\
+    \ The main contributions are the introduction of an approximate search distributor\
+    \ via a novel use of Bloom filters. We combine several Bloom filters to form an\
+    \ interleaved Bloom filter and use this new data structure to quickly exclude\
+    \ reads for parts of the databases where they cannot match. This allows us to\
+    \ keep the databases in several indices which can be easily rebuilt if parts are\
+    \ updated while maintaining a fast search time. The second main contribution is\
+    \ an implementation of DREAM-Yara a distributed version of a fully sensitive read\
+    \ mapper under the DREAM framework.\r\n\r\nAvailability and implementation: \r\
+    \nhttps://gitlab.com/pirovc/dream_yara/"
+  bibtex: "@article{fu_mi_publications2282,\n abstract = {Motivation\n\nMapping-based\
+    \ approaches have become limited in their application to very large sets of references\
+    \ since computing an FM-index for very large databases (e.g. {\\ensuremath{>}}10\
+    \ GB) has become a bottleneck. This affects many analyses that need such index\
+    \ as an essential step for approximate matching of the NGS reads to reference\
+    \ databases. For instance, in typical metagenomics analysis, the size of the reference\
+    \ sequences has become prohibitive to compute a single full-text index on standard\
+    \ machines. Even on large memory machines, computing such index takes about 1\
+    \ day of computing time. As a result, updates of indices are rarely performed.\
+    \ Hence, it is desirable to create an alternative way of indexing while preserving\
+    \ fast search times.\n\nResults\n\nTo solve the index construction and update\
+    \ problem we propose the DREAM (Dynamic seaRchablE pArallel coMpressed index)\
+    \ framework and provide an implementation. The main contributions are the introduction\
+    \ of an approximate search distributor via a novel use of Bloom filters. We combine\
+    \ several Bloom filters to form an interleaved Bloom filter and use this new data\
+    \ structure to quickly exclude reads for parts of the databases where they cannot\
+    \ match. This allows us to keep the databases in several indices which can be\
+    \ easily rebuilt if parts are updated while maintaining a fast search time. The\
+    \ second main contribution is an implementation of DREAM-Yara a distributed version\
+    \ of a fully sensitive read mapper under the DREAM framework.\n\nAvailability\
+    \ and implementation: \nhttps://gitlab.com/pirovc/dream\\_yara/},\n author = {Temesgen\
+    \ Hailemariam Dadi and Enrico Siragusa and Vitor C Piro and Andreas Andrusch and\
+    \ Enrico Seiler and Bernhard Y Renard and Knut Reinert},\n journal = {Bioinformatics},\n\
+    \ month = {September},\n number = {17},\n pages = {i766--i772},\n title = {DREAM-Yara:\
+    \ an exact read mapper for very large databases with short update time},\n url\
+    \ = {http://publications.imp.fu-berlin.de/2282/},\n volume = {34},\n year = {2018}\n\
+    }\n\n"
+  creators:
+  - name:
+      family: Dadi
+      given: Temesgen Hailemariam
+      honourific: null
+      lineage: null
+  - name:
+      family: Siragusa
+      given: Enrico
+      honourific: null
+      lineage: null
+  - name:
+      family: Piro
+      given: Vitor C
+      honourific: null
+      lineage: null
+  - name:
+      family: Andrusch
+      given: Andreas
+      honourific: null
+      lineage: null
+  - name:
+      family: Seiler
+      given: Enrico
+      honourific: null
+      lineage: null
+  - name:
+      family: Renard
+      given: Bernhard Y
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: Knut
+      honourific: null
+      lineage: null
+  date: '2018-09-08'
+  date_type: published
+  datestamp: '2018-11-08 11:49:07'
+  dir: disk0/00/00/22/82
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 2282
+  full_text_status: none
+  id_number: doi:10.1093/bioinformatics/bty567
+  ispublished: pub
+  issn: 1367-4803
+  key: fu_mi_publications2282
+  lastmod: '2018-11-08 11:49:07'
+  metadata_visibility: show
+  number: 17
+  official_url: http://doi.org/10.1093/bioinformatics/bty567
+  pagerange: i766-i772
+  publication: Bioinformatics
+  refereed: 'TRUE'
+  rev_number: 5
+  status_changed: '2018-11-08 11:49:07'
+  subjects:
+  - G400
+  title: 'DREAM-Yara: an exact read mapper for very large databases with short update
+    time'
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2282
+  userid: 132
+  volume: 34
+- abstract: "Spontaneous outbreaks of Clostridium difficile infection (CDI) occur\
+    \ in neonatal piglets, but the predisposing factors are largely not known. To\
+    \ study the conditions for C. difficile colonization and CDI development, 48 neonatal\
+    \ piglets were moved into isolators, fed bovine milk\u2013based formula, and infected\
+    \ with C. difficile 078. Analyses included clinical scoring; measurement of the\
+    \ fecal C. difficile burden, toxin B level, and calprotectin level; and postmortem\
+    \ histopathological analysis of colon specimens. Controls were noninfected suckling\
+    \ piglets. Fecal specimens from suckling piglets, formula-fed piglets, and formula-fed,\
+    \ C. difficile\u2013infected piglets were used for metagenomics analysis. High\
+    \ background levels of C. difficile and toxin were detected in formula-fed piglets\
+    \ prior to infection, while suckling piglets carried about 3-fold less C. difficile,\
+    \ and toxin was not detected. Toxin level in C. difficile\u2013challenged animals\
+    \ correlated positively with C. difficile and calprotectin levels. Postmortem\
+    \ signs of CDI were absent in suckling piglets, whereas mesocolonic edema and\
+    \ gas-filled distal small intestines and ceca, cellular damage, and reduced expression\
+    \ of claudins were associated with animals from the challenge trials. Microbiota\
+    \ in formula-fed piglets was enriched with Escherichia, Shigella, Streptococcus,\
+    \ Enterococcus, and Ruminococcus species. Formula-fed piglets were predisposed\
+    \ to C. difficile colonization earlier as compared to suckling piglets. Infection\
+    \ with a hypervirulent C. difficile ribotype did not aggravate the symptoms of\
+    \ infection. Sow-offspring association and consumption of porcine milk during\
+    \ early life may be crucial for the control of C. difficile expansion in piglets."
+  bibtex: "@article{fu_mi_publications2283,\n abstract = {Spontaneous outbreaks of\
+    \ Clostridium difficile infection (CDI) occur in neonatal piglets, but the predisposing\
+    \ factors are largely not known. To study the conditions for C. difficile colonization\
+    \ and CDI development, 48 neonatal piglets were moved into isolators, fed bovine\
+    \ milk?based formula, and infected with C. difficile 078. Analyses included clinical\
+    \ scoring; measurement of the fecal C. difficile burden, toxin B level, and calprotectin\
+    \ level; and postmortem histopathological analysis of colon specimens. Controls\
+    \ were noninfected suckling piglets. Fecal specimens from suckling piglets, formula-fed\
+    \ piglets, and formula-fed, C. difficile?infected piglets were used for metagenomics\
+    \ analysis. High background levels of C. difficile and toxin were detected in\
+    \ formula-fed piglets prior to infection, while suckling piglets carried about\
+    \ 3-fold less C. difficile, and toxin was not detected. Toxin level in C. difficile?challenged\
+    \ animals correlated positively with C. difficile and calprotectin levels. Postmortem\
+    \ signs of CDI were absent in suckling piglets, whereas mesocolonic edema and\
+    \ gas-filled distal small intestines and ceca, cellular damage, and reduced expression\
+    \ of claudins were associated with animals from the challenge trials. Microbiota\
+    \ in formula-fed piglets was enriched with Escherichia, Shigella, Streptococcus,\
+    \ Enterococcus, and Ruminococcus species. Formula-fed piglets were predisposed\
+    \ to C. difficile colonization earlier as compared to suckling piglets. Infection\
+    \ with a hypervirulent C. difficile ribotype did not aggravate the symptoms of\
+    \ infection. Sow-offspring association and consumption of porcine milk during\
+    \ early life may be crucial for the control of C. difficile expansion in piglets.},\n\
+    \ author = {{\\L}ukasz Grze{\\'s}kowiak and Beatriz Mart{\\'i}nez-Vallesp{\\'i}n\
+    \ and Temesgen H Dadi and Judith Radloff and Salah Amasheh and Femke-Anouska Heinsen\
+    \ and Andre Franke and Knut Reinert and Wilfried Vahjen and J{\\\"u}rgen Zentek\
+    \ and Robert Pieper},\n journal = {The Journal of Infectious Diseases},\n month\
+    \ = {May},\n number = {9},\n pages = {1442--1452},\n title = {Formula Feeding\
+    \ Predisposes Neonatal Piglets to Clostridium difficile Gut Infection},\n url\
+    \ = {http://publications.imp.fu-berlin.de/2283/},\n volume = {217},\n year = {2018}\n\
+    }\n\n"
+  creators:
+  - name:
+      family: "Grze\u015Bkowiak"
+      given: "\u0141ukasz"
+      honourific: null
+      lineage: null
+  - name:
+      family: "Mart\xEDnez-Vallesp\xEDn"
+      given: Beatriz
+      honourific: null
+      lineage: null
+  - name:
+      family: Dadi
+      given: Temesgen H
+      honourific: null
+      lineage: null
+  - name:
+      family: Radloff
+      given: Judith
+      honourific: null
+      lineage: null
+  - name:
+      family: Amasheh
+      given: Salah
+      honourific: null
+      lineage: null
+  - name:
+      family: Heinsen
+      given: Femke-Anouska
+      honourific: null
+      lineage: null
+  - name:
+      family: Franke
+      given: Andre
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: Knut
+      honourific: null
+      lineage: null
+  - name:
+      family: Vahjen
+      given: Wilfried
+      honourific: null
+      lineage: null
+  - name:
+      family: Zentek
+      given: "J\xFCrgen"
+      honourific: null
+      lineage: null
+  - name:
+      family: Pieper
+      given: Robert
+      honourific: null
+      lineage: null
+  date: '2018-05-01'
+  date_type: published
+  datestamp: '2018-11-08 11:52:57'
+  dir: disk0/00/00/22/83
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 2283
+  full_text_status: none
+  id_number: doi:10.1093/infdis/jix567
+  ispublished: pub
+  issn: 0022-1899
+  key: fu_mi_publications2283
+  lastmod: '2018-11-08 11:52:57'
+  metadata_visibility: show
+  number: 9
+  official_url: http://doi.org/10.1093/infdis/jix567
+  pagerange: 1442-1452
+  publication: The Journal of Infectious Diseases
+  refereed: 'TRUE'
+  rev_number: 5
+  status_changed: '2018-11-08 11:52:57'
+  subjects:
+  - G400
+  title: Formula Feeding Predisposes Neonatal Piglets to Clostridium difficile Gut
+    Infection
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2283
+  userid: 132
+  volume: 217
+- abstract: Finding approximate occurrences of a pattern in a text using a full-text
+    index is a central problem in bioinformatics and has been extensively researched.
+    Bidirectional indices have opened new possibilities in this regard allowing the
+    search to start from anywhere within the pattern and extend in both directions.
+    In particular, use of search schemes (partitioning the pattern and searching the
+    pieces in certain orders with given bounds on errors) can yield significant speed-ups.
+    However, finding optimal search schemes is a difficult combinatorial optimization
+    problem. Here for the first time, we propose a mixed integer program (MIP) capable
+    to solve this optimization problem for Hamming distance with given number of pieces.
+    Our experiments show that the optimal search schemes found by our MIP significantly
+    improve the performance of search in bidirectional FM-index upon previous ad-hoc
+    solutions. For example, approximate matching of 101-bp Illumina reads (with two
+    errors) becomes 35 times faster than standard backtracking. Moreover, despite
+    being performed purely in the index, the running time of search using our optimal
+    schemes (for up to two errors) is comparable to the best state-of-the-art aligners,
+    which benefit from combining search in index with in-text verification using dynamic
+    programming. As a result, we anticipate a full-fledged aligner that employs an
+    intelligent combination of search in the bidirectional FM-index using our optimal
+    search schemes and in-text verification using dynamic programming outperforms
+    today's best aligners. The development of such an aligner, called FAMOUS (Fast
+    Approximate string Matching using OptimUm search Schemes), is ongoing as our future
+    work.
+  bibtex: "@article{fu_mi_publications2284,\n abstract = {Finding approximate occurrences\
+    \ of a pattern in a text using a full-text index is a central problem in bioinformatics\
+    \ and has been extensively researched. Bidirectional indices have opened new possibilities\
+    \ in this regard allowing the search to start from anywhere within the pattern\
+    \ and extend in both directions. In particular, use of search schemes (partitioning\
+    \ the pattern and searching the pieces in certain orders with given bounds on\
+    \ errors) can yield significant speed-ups. However, finding optimal search schemes\
+    \ is a difficult combinatorial optimization problem. Here for the first time,\
+    \ we propose a mixed integer program (MIP) capable to solve this optimization\
+    \ problem for Hamming distance with given number of pieces. Our experiments show\
+    \ that the optimal search schemes found by our MIP significantly improve the performance\
+    \ of search in bidirectional FM-index upon previous ad-hoc solutions. For example,\
+    \ approximate matching of 101-bp Illumina reads (with two errors) becomes 35 times\
+    \ faster than standard backtracking. Moreover, despite being performed purely\
+    \ in the index, the running time of search using our optimal schemes (for up to\
+    \ two errors) is comparable to the best state-of-the-art aligners, which benefit\
+    \ from combining search in index with in-text verification using dynamic programming.\
+    \ As a result, we anticipate a full-fledged aligner that employs an intelligent\
+    \ combination of search in the bidirectional FM-index using our optimal search\
+    \ schemes and in-text verification using dynamic programming outperforms today's\
+    \ best aligners. The development of such an aligner, called FAMOUS (Fast Approximate\
+    \ string Matching using OptimUm search Schemes), is ongoing as our future work.},\n\
+    \ author = {Kiavash Kianfar and Christopher Pockrandt and Bahman Torkamandi and\
+    \ Haochen Luo and Knut Reinert},\n booktitle = {Optimum Search Schemes for Approximate\
+    \ String Matching Using Bidirectional FM-Index},\n journal = {bioRxiv, The Preprint\
+    \ Server for Biology},\n month = {April},\n title = {Optimum Search Schemes for\
+    \ Approximate String Matching Using Bidirectional FM-Index},\n url = {http://publications.imp.fu-berlin.de/2284/},\n\
+    \ year = {2018}\n}\n\n"
+  book_title: Optimum Search Schemes for Approximate String Matching Using Bidirectional
+    FM-Index
+  creators:
+  - name:
+      family: Kianfar
+      given: Kiavash
+      honourific: null
+      lineage: null
+  - name:
+      family: Pockrandt
+      given: Christopher
+      honourific: null
+      lineage: null
+  - name:
+      family: Torkamandi
+      given: Bahman
+      honourific: null
+      lineage: null
+  - name:
+      family: Luo
+      given: Haochen
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: Knut
+      honourific: null
+      lineage: null
+  date: '2018-04-14'
+  date_type: published
+  datestamp: '2018-11-12 14:25:35'
+  dir: disk0/00/00/22/84
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 2284
+  full_text_status: none
+  id_number: doi:10.1101/301085
+  ispublished: pub
+  key: fu_mi_publications2284
+  lastmod: '2018-11-12 14:25:35'
+  metadata_visibility: show
+  official_url: http://doi.org/10.1101/301085
+  publication: bioRxiv, The Preprint Server for Biology
+  refereed: 'FALSE'
+  related_url:
+  - url: https://www.biorxiv.org/content/early/2018/04/14/301085
+  rev_number: 5
+  status_changed: '2018-11-12 14:25:35'
+  subjects:
+  - G400
+  title: Optimum Search Schemes for Approximate String Matching Using Bidirectional
+    FM-Index
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2284
+  userid: 132
+- abstract: "Francisella (F.) tularensis is a highly virulent, Gram-negative bacterial\
+    \ pathogen and the causative agent of the zoonotic disease tularemia. Here, we\
+    \ generated, analyzed and characterized a high quality circular genome sequence\
+    \ of the F. tularensis subsp. holarctica strain 12T0050 that caused fatal tularemia\
+    \ in a hare. Besides the genomic structure, we focused on the analysis of oriC,\
+    \ unique to the Francisella genus and regulating replication in and outside hosts\
+    \ and the first report on genomic DNA methylation of a Francisella strain. The\
+    \ high quality genome was used to establish and evaluate a diagnostic whole genome\
+    \ sequencing pipeline. A genotyping strategy for F. tularensis was developed using\
+    \ various bioinformatics tools for genotyping. Additionally, whole genome sequences\
+    \ of F. tularensis subsp. holarctica isolates isolated in the years 2008\u2013\
+    2015 in Germany were generated. A phylogenetic analysis allowed to determine the\
+    \ genetic relatedness of these isolates and confirmed the highly conserved nature\
+    \ of F. tularensis subsp. holarctica."
+  bibtex: "@article{fu_mi_publications2374,\n abstract = {Francisella (F.) tularensis\
+    \ is a highly virulent, Gram-negative bacterial pathogen and the causative agent\
+    \ of the zoonotic disease tularemia. Here, we generated, analyzed and characterized\
+    \ a high quality circular genome sequence of the F. tularensis subsp. holarctica\
+    \ strain 12T0050 that caused fatal tularemia in a hare. Besides the genomic structure,\
+    \ we focused on the analysis of oriC, unique to the Francisella genus and regulating\
+    \ replication in and outside hosts and the first report on genomic DNA methylation\
+    \ of a Francisella strain. The high quality genome was used to establish and evaluate\
+    \ a diagnostic whole genome sequencing pipeline. A genotyping strategy for F.\
+    \ tularensis was developed using various bioinformatics tools for genotyping.\
+    \ Additionally, whole genome sequences of F. tularensis subsp. holarctica isolates\
+    \ isolated in the years 2008?2015 in Germany were generated. A phylogenetic analysis\
+    \ allowed to determine the genetic relatedness of these isolates and confirmed\
+    \ the highly conserved nature of F. tularensis subsp. holarctica.},\n author =\
+    \ {Anne Busch and Prasad Thomas and Eric Zuchantke and Holger Brendebach and Kerstin\
+    \ Neubert and Josephine Gruetzke and Sascha Al Dahouk and Martin Peters and Helmut\
+    \ Hotzel and Heinrich Neubauer and Herbert Tomaso},\n journal = {Frontiers in\
+    \ Microbiology},\n month = {March},\n title = {Revisiting Francisella tularensis\
+    \ subsp. holarctica, Causative Agent of Tularemia in Germany With Bioinformatics:\
+    \ New Insights in Genome Structure, DNA Methylation and Comparative Phylogenetic\
+    \ Analysis},\n url = {http://publications.imp.fu-berlin.de/2374/},\n volume =\
+    \ {9},\n year = {2018}\n}\n\n"
+  creators:
+  - name:
+      family: Busch
+      given: Anne
+      honourific: null
+      lineage: null
+  - name:
+      family: Thomas
+      given: Prasad
+      honourific: null
+      lineage: null
+  - name:
+      family: Zuchantke
+      given: Eric
+      honourific: null
+      lineage: null
+  - name:
+      family: Brendebach
+      given: Holger
+      honourific: null
+      lineage: null
+  - name:
+      family: Neubert
+      given: Kerstin
+      honourific: null
+      lineage: null
+  - name:
+      family: Gruetzke
+      given: Josephine
+      honourific: null
+      lineage: null
+  - name:
+      family: Al Dahouk
+      given: Sascha
+      honourific: null
+      lineage: null
+  - name:
+      family: Peters
+      given: Martin
+      honourific: null
+      lineage: null
+  - name:
+      family: Hotzel
+      given: Helmut
+      honourific: null
+      lineage: null
+  - name:
+      family: Neubauer
+      given: Heinrich
+      honourific: null
+      lineage: null
+  - name:
+      family: Tomaso
+      given: Herbert
+      honourific: null
+      lineage: null
+  date: '2018-03-13'
+  date_type: published
+  datestamp: '2019-08-29 10:32:18'
+  dir: disk0/00/00/23/74
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 2374
+  full_text_status: none
+  id_number: doi:10.3389/fmicb.2018.00344
+  ispublished: pub
+  issn: 1664-302X
+  key: fu_mi_publications2374
+  lastmod: '2019-08-29 10:32:18'
+  metadata_visibility: show
+  official_url: http://doi.org/10.3389/fmicb.2018.00344
+  publication: Frontiers in Microbiology
+  refereed: 'TRUE'
+  rev_number: 5
+  status_changed: '2019-08-29 10:32:18'
+  subjects:
+  - G400
+  title: 'Revisiting Francisella tularensis subsp. holarctica, Causative Agent of
+    Tularemia in Germany With Bioinformatics: New Insights in Genome Structure, DNA
+    Methylation and Comparative Phylogenetic Analysis'
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2374
+  userid: 132
+  volume: 9
+- abstract: Accurate protein inference in the presence of shared peptides is still
     one of the key problems in bottom-up proteomics. Most protein inference tools
     employing simple heuristic inference strategies are efficient but exhibit reduced
     accuracy. More advanced probabilistic methods often exhibit better inference quality
@@ -7092,523 +7034,4465 @@
     in better protein inference results and thus increased robustness of the biological
     hypotheses generated. EPIFANY is available as open-source software for all major
     platforms at https://OpenMS.de/epifany.
-  title: 'EPIFANY: A Method for Efficient High-Confidence Protein Inference'
+  bibtex: "@article{fu_mi_publications2429,\n abstract = {Accurate protein inference\
+    \ in the presence of shared peptides is still one of the key problems in bottom-up\
+    \ proteomics. Most protein inference tools employing simple heuristic inference\
+    \ strategies are efficient but exhibit reduced accuracy. More advanced probabilistic\
+    \ methods often exhibit better inference quality but tend to be too slow for large\
+    \ data sets. Here, we present a novel protein inference method, EPIFANY, combining\
+    \ a loopy belief propagation algorithm with convolution trees for efficient processing\
+    \ of Bayesian networks. We demonstrate that EPIFANY combines the reliable protein\
+    \ inference of Bayesian methods with significantly shorter runtimes. On the 2016\
+    \ iPRG protein inference benchmark data, EPIFANY is the only tested method that\
+    \ finds all true-positive proteins at a 5\\% protein false discovery rate (FDR)\
+    \ without strict prefiltering on the peptide-spectrum match (PSM) level, yielding\
+    \ an increase in identification performance (+10\\% in the number of true positives\
+    \ and +14\\% in partial AUC) compared to previous approaches. Even very large\
+    \ data sets with hundreds of thousands of spectra (which are intractable with\
+    \ other Bayesian and some non-Bayesian tools) can be processed with EPIFANY within\
+    \ minutes. The increased inference quality including shared peptides results in\
+    \ better protein inference results and thus increased robustness of the biological\
+    \ hypotheses generated. EPIFANY is available as open-source software for all major\
+    \ platforms at https://OpenMS.de/epifany.},\n author = {Julianus Pfeuffer and\
+    \ Timo Sachsenberg and Tjeerd M. H. Dijkstra and Oliver Serang and Knut Reinert\
+    \ and Oliver Kohlbacher},\n journal = {Journal of Proteome Research},\n keywords\
+    \ = {bottom-up proteomics, protein inference, Bayesian networks, convolution trees,\
+    \ loopy belief propagation, iPRG2016},\n month = {January},\n number = {3},\n\
+    \ pages = {1060--1072},\n publisher = {ACS Publications},\n title = {EPIFANY:\
+    \ A Method for Efficient High-Confidence Protein Inference},\n url = {http://publications.imp.fu-berlin.de/2429/},\n\
+    \ volume = {19},\n year = {2020}\n}\n\n"
+  creators:
+  - name:
+      family: Pfeuffer
+      given: Julianus
+      honourific: null
+      lineage: null
+  - name:
+      family: Sachsenberg
+      given: Timo
+      honourific: null
+      lineage: null
+  - name:
+      family: Dijkstra
+      given: Tjeerd M. H.
+      honourific: null
+      lineage: null
+  - name:
+      family: Serang
+      given: Oliver
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: Knut
+      honourific: null
+      lineage: null
+  - name:
+      family: Kohlbacher
+      given: Oliver
+      honourific: null
+      lineage: null
+  date: '2020-01-24'
+  date_type: published
+  datestamp: '2020-04-02 10:05:57'
+  dir: disk0/00/00/24/29
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 2429
+  full_text_status: none
+  id_number: doi:10.1021/acs.jproteome.9b00566
+  ispublished: pub
+  issn: 1535-3893
+  key: fu_mi_publications2429
+  keywords: bottom-up proteomics, protein inference, Bayesian networks, convolution
+    trees, loopy belief propagation, iPRG2016
+  lastmod: '2020-04-02 10:05:57'
+  metadata_visibility: show
+  number: 3
+  official_url: http://doi.org/10.1021/acs.jproteome.9b00566
+  pagerange: 1060-1072
+  publication: Journal of Proteome Research
   publisher: ACS Publications
+  refereed: 'TRUE'
   rev_number: 5
-  type: article
-  userid: 132
-- divisions:
-  - group_algbioinf
-  volume: 10229
-  pagerange: 190-206
-  dir: disk0/00/00/21/18
-  issn: 0302-9743
-  eprint_status: archive
-  metadata_visibility: show
-  id_number: doi:10.1007/978-3-319-56970-3_12
-  date_type: published
-  rev_number: 6
-  publisher: Springer, Cham
-  status_changed: '2017-10-12 12:37:21'
-  editors:
-  - name:
-      lineage:
-      family: Sahinalp
-      honourific:
-      given: S.
-  uri: http://publications.imp.fu-berlin.de/id/eprint/2118
-  pages: 16
-  ispublished: pub
-  lastmod: '2017-10-12 12:37:21'
-  official_url: http://doi.org/10.1007/978-3-319-56970-3_12
+  status_changed: '2020-04-02 10:05:57'
   subjects:
   - G400
-  date: '2017-04-12'
-  full_text_status: none
-  series: Lecture Notes in Computer Science (LNCS)
-  refereed: 'TRUE'
-  eprintid: 2118
+  title: 'EPIFANY: A Method for Efficient High-Confidence Protein Inference'
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2429
   userid: 132
-  type: book_section
-  title: 'EPR-Dictionaries: A Practical and Fast Data Structure for Constant Time
-    Searches in Unidirectional and Bidirectional FM Indices'
-  abstract: "The unidirectional FM index was introduced by Ferragina and Manzini in
-    2000 and allows to search a pattern in the index in one direction. The bidirectional
-    FM index (2FM) was introduced by Lam et al. in 2009. It allows to search for a
-    pattern by extending an infix of the pattern arbitrarily to the left or right.
-    If σ is the size of the alphabet then the method of Lam et al. can conduct one
-    step in time O(σ) while needing space O(σ⋅n) using constant time rank queries
-    on bit vectors. Schnattinger and colleagues improved this time to O(logσ) while
-    using O(logσ⋅n) bits of space for both, the FM and 2FM index. This is achieved
-    by the use of binary wavelet trees.In this paper we introduce a new, practical
-    method for conducting an exact search in a uni- and bidirectional FM index in
-    O(1) time per step while using O(logσ⋅n)+o(logσ⋅σ⋅n) bits of space. This is
-    done by replacing the binary wavelet tree by a new data structure, the Enhanced
-    Prefixsum Rank dictionary (EPR-dictionary).We implemented this method
-    in the SeqAn C++ library and experimentally validated our theoretical results.
-    In addition we compared our implementation with other freely available implementations
-    of bidirectional indices and show that we are between ≈2.2−4.2 times faster. This
-    will have a large impact for many bioinformatics applications that rely on practical
-    implementations of (2)FM indices e.g. for read mapping. To our knowledge this
-    is the first implementation of a constant time method for a search step in 2FM
-    indices."
-  datestamp: '2017-10-12 12:37:21'
+  volume: 19
+- abstract: "Background\r\n\r\nNatural variations in a genome can drastically alter\
+    \ the CRISPR-Cas9 off-target landscape by creating or removing sites. Despite\
+    \ the resulting potential side-effects from such unaccounted for sites, current\
+    \ off-target detection pipelines are not equipped to include variant information.\
+    \ To address this, we developed VARiant-aware detection and SCoring of Off-Targets\
+    \ (VARSCOT).\r\n\r\nResults\r\n\r\nVARSCOT identifies only 0.6% of off-targets\
+    \ to be common between 4 individual genomes and the reference, with an average\
+    \ of 82% of off-targets unique to an individual. VARSCOT is the most sensitive\
+    \ detection method for off-targets, finding 40 to 70% more experimentally verified\
+    \ off-targets compared to other popular software tools and its machine learning\
+    \ model allows for CRISPR-Cas9 concentration aware off-target activity scoring.\r\
+    \n\r\nConclusions\r\n\r\nVARSCOT allows researchers to take genomic variation\
+    \ into account when designing individual or population-wide targeting strategies.\
+    \ VARSCOT is available from https://github.com/BauerLab/VARSCOT."
+  bibtex: "@article{fu_mi_publications2430,\n abstract = {Background\n\nNatural variations\
+    \ in a genome can drastically alter the CRISPR-Cas9 off-target landscape by creating\
+    \ or removing sites. Despite the resulting potential side-effects from such unaccounted\
+    \ for sites, current off-target detection pipelines are not equipped to include\
+    \ variant information. To address this, we developed VARiant-aware detection and\
+    \ SCoring of Off-Targets (VARSCOT).\n\nResults\n\nVARSCOT identifies only 0.6\\\
+    % of off-targets to be common between 4 individual genomes and the reference,\
+    \ with an average of 82\\% of off-targets unique to an individual. VARSCOT is\
+    \ the most sensitive detection method for off-targets, finding 40 to 70\\% more\
+    \ experimentally verified off-targets compared to other popular software tools\
+    \ and its machine learning model allows for CRISPR-Cas9 concentration aware off-target\
+    \ activity scoring.\n\nConclusions\n\nVARSCOT allows researchers to take genomic\
+    \ variation into account when designing individual or population-wide targeting\
+    \ strategies. VARSCOT is available from https://github.com/BauerLab/VARSCOT.},\n\
+    \ author = {Laurence O. W. Wilson and Sara Hetzel and Christopher Pockrandt and\
+    \ Knut Reinert and Denis C. Bauer},\n journal = {BMC Biotechnology},\n keywords\
+    \ = {CRISPR-Cas9, Off-target detection, Variants, Genome editing},\n month = {June},\n\
+    \ number = {1},\n title = {VARSCOT: variant-aware detection and scoring enables\
+    \ sensitive and personalized off-target detection for CRISPR-Cas9},\n url = {http://publications.imp.fu-berlin.de/2430/},\n\
+    \ volume = {19},\n year = {2019}\n}\n\n"
   creators:
   - name:
-      given: Christopher
-      honourific:
+      family: Wilson
+      given: Laurence O. W.
+      honourific: null
+      lineage: null
+  - name:
+      family: Hetzel
+      given: Sara
+      honourific: null
+      lineage: null
+  - name:
       family: Pockrandt
-      lineage:
+      given: Christopher
+      honourific: null
+      lineage: null
   - name:
-      given: Marcel
-      honourific:
-      family: Ehrhardt
-      lineage:
-  - name:
-      lineage:
-      honourific:
+      family: Reinert
       given: Knut
-      family: Reinert
-  isbn: 978-3-319-56970-3 (elektronisch)
-  book_title: Research in Computational Molecular Biology. RECOMB 2017
-- datestamp: '2014-08-25 18:46:21'
-  publication: Bioinformatics
-  creators:
+      honourific: null
+      lineage: null
   - name:
-      honourific:
-      given: R.
-      family: Rahn
-      lineage:
-  - name:
-      given: D.
-      honourific:
-      family: Weese
-      lineage:
-  - name:
-      given: K.
-      honourific:
-      family: Reinert
-      lineage:
-  type: article
-  rev_number: 8
-  userid: 132
-  abstract: "Motivation: Next-generation sequencing (NGS) has revolutionized biomedical
-    research in the past decade and led to a continuous stream of developments in
-    bioinformatics, addressing the need for fast and space-efficient solutions for
-    analyzing NGS data. Often researchers need to analyze a set of genomic sequences
-    that stem from closely related species or are indeed individuals of the same species.
-    Hence, the analyzed sequences are similar. For analyses where local changes in
-    the examined sequence induce only local changes in the results, it is obviously
-    desirable to examine identical or similar regions not repeatedly.Results:
-    In this work, we provide a datatype that exploits data parallelism inherent in
-    a set of similar sequences by analyzing shared regions only once. In real-world
-    experiments, we show that algorithms that otherwise would scan each reference
-    sequentially can be speeded up by a factor of 115.Availability: The data
-    structure and associated tools are publicly available at http://www.seqan.de/projects/jst
-    and are part of SeqAn, the C++ template library for sequence analysis.Contact:
-    rene.rahn@fu-berlin.de"
-  status_changed: '2014-08-25 18:46:21'
-  title: Journaled string tree--a scalable data structure for analyzing thousands
-    of similar genomes on your laptop
-  official_url: http://dx.doi.org/10.1093/bioinformatics/btu438
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1448
-  ispublished: pub
-  lastmod: '2014-08-25 18:46:21'
-  issn: Online ISSN 1460-2059 - Print ISSN 1367-4803
-  dir: disk0/00/00/14/48
-  eprint_status: archive
+      family: Bauer
+      given: Denis C.
+      honourific: null
+      lineage: null
+  date: '2019-06-27'
+  date_type: published
+  datestamp: '2020-04-02 11:57:40'
+  dir: disk0/00/00/24/30
   divisions:
   - group_algbioinf
+  eprint_status: archive
+  eprintid: 2430
+  full_text_status: none
+  id_number: doi:10.1186/s12896-019-0535-5
+  ispublished: pub
+  issn: 1472-6750
+  key: fu_mi_publications2430
+  keywords: CRISPR-Cas9, Off-target detection, Variants, Genome editing
+  lastmod: '2020-04-02 11:57:40'
+  metadata_visibility: show
+  number: 1
+  official_url: http://doi.org/10.1186/s12896-019-0535-5
+  publication: BMC Biotechnology
+  refereed: 'TRUE'
+  rev_number: 5
+  status_changed: '2020-04-02 11:57:40'
   subjects:
   - G400
-  date: '2014-07-15'
-  eprintid: 1448
-  refereed: 'TRUE'
+  title: 'VARSCOT: variant-aware detection and scoring enables sensitive and personalized
+    off-target detection for CRISPR-Cas9'
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2430
+  userid: 132
+  volume: 19
+- abstract: "Horizontal gene transfer (HGT) has changed the way we regard evolution.\
+    \ Instead of waiting for the next generation to establish new traits, especially\
+    \ bacteria are able to take a shortcut via HGT that enables them to pass on genes\
+    \ from one individual to another, even across species boundaries. The tool Daisy\
+    \ offers the first HGT detection approach based on read mapping that provides\
+    \ complementary evidence compared to existing methods. However, Daisy relies on\
+    \ the acceptor and donor organism involved in the HGT being known. We introduce\
+    \ DaisyGPS, a mapping-based pipeline that is able to identify acceptor and donor\
+    \ reference candidates of an HGT event based on sequencing reads. Acceptor and\
+    \ donor identification is akin to species identification in metagenomic samples\
+    \ based on sequencing reads, a problem addressed by metagenomic profiling tools.\
+    \ However, acceptor and donor references have certain properties such that these\
+    \ methods cannot be directly applied. DaisyGPS uses MicrobeGPS, a metagenomic\
+    \ profiling tool tailored towards estimating the genomic distance between organisms\
+    \ in the sample and the reference database. We enhance the underlying scoring\
+    \ system of MicrobeGPS to account for the sequence patterns in terms of mapping\
+    \ coverage of an acceptor and donor involved in an HGT event, and report a ranked\
+    \ list of reference candidates. These candidates can then be further evaluated\
+    \ by tools like Daisy to establish HGT regions. We successfully validated our\
+    \ approach on both simulated and real data, and show its benefits in an investigation\
+    \ of an outbreak involving Methicillin-resistant Staphylococcus aureus data.\r\
+    \n\r\nAuthor summary\r\n\r\nEvolution is traditionally viewed as a process where\
+    \ changes are only vertically inherited from parent to offspring across generations.\
+    \ Many principles such as phylogenetic trees and even the \u201Ctree of life\u201D\
+    \ are based on that doctrine. The concept of horizontal gene transfer changed\
+    \ the way we regard evolution completely. Horizontal gene transfer is the movement\
+    \ of genetic information between distantly related organisms of the same generation.\
+    \ Genome sequencing not only provided further evidence complementing experimental\
+    \ evidence but also shed light onto the frequency and prominence of this concept.\
+    \ Especially the rapid spread of antimicrobial resistance genes is a prominent\
+    \ example for the impact that horizontal gene transfer can have for public health.\
+    \ Next generation sequencing brought means for quick and relatively cheap analysis\
+    \ of even complex metagenomic samples where horizontal gene transfer is bound\
+    \ to happen frequently. Methods to directly detect and characterise horizontal\
+    \ gene transfer from such sequencing data, however, are still lacking. We here\
+    \ provide a method to identify organisms potentially involved in horizontal gene\
+    \ transfer events to be used in downstream analysis that enables a characterisation\
+    \ of a horizontal gene transfer event in terms of impact and prevalence."
+  bibtex: "@article{fu_mi_publications2434,\n abstract = {Horizontal gene transfer\
+    \ (HGT) has changed the way we regard evolution. Instead of waiting for the next\
+    \ generation to establish new traits, especially bacteria are able to take a shortcut\
+    \ via HGT that enables them to pass on genes from one individual to another, even\
+    \ across species boundaries. The tool Daisy offers the first HGT detection approach\
+    \ based on read mapping that provides complementary evidence compared to existing\
+    \ methods. However, Daisy relies on the acceptor and donor organism involved in\
+    \ the HGT being known. We introduce DaisyGPS, a mapping-based pipeline that is\
+    \ able to identify acceptor and donor reference candidates of an HGT event based\
+    \ on sequencing reads. Acceptor and donor identification is akin to species identification\
+    \ in metagenomic samples based on sequencing reads, a problem addressed by metagenomic\
+    \ profiling tools. However, acceptor and donor references have certain properties\
+    \ such that these methods cannot be directly applied. DaisyGPS uses MicrobeGPS,\
+    \ a metagenomic profiling tool tailored towards estimating the genomic distance\
+    \ between organisms in the sample and the reference database. We enhance the underlying\
+    \ scoring system of MicrobeGPS to account for the sequence patterns in terms of\
+    \ mapping coverage of an acceptor and donor involved in an HGT event, and report\
+    \ a ranked list of reference candidates. These candidates can then be further\
+    \ evaluated by tools like Daisy to establish HGT regions. We successfully validated\
+    \ our approach on both simulated and real data, and show its benefits in an investigation\
+    \ of an outbreak involving Methicillin-resistant Staphylococcus aureus data.\n\
+    \nAuthor summary\n\nEvolution is traditionally viewed as a process where changes\
+    \ are only vertically inherited from parent to offspring across generations. Many\
+    \ principles such as phylogenetic trees and even the ?tree of life? are based\
+    \ on that doctrine. The concept of horizontal gene transfer changed the way we\
+    \ regard evolution completely. Horizontal gene transfer is the movement of genetic\
+    \ information between distantly related organisms of the same generation. Genome\
+    \ sequencing not only provided further evidence complementing experimental evidence\
+    \ but also shed light onto the frequency and prominence of this concept. Especially\
+    \ the rapid spread of antimicrobial resistance genes is a prominent example for\
+    \ the impact that horizontal gene transfer can have for public health. Next generation\
+    \ sequencing brought means for quick and relatively cheap analysis of even complex\
+    \ metagenomic samples where horizontal gene transfer is bound to happen frequently.\
+    \ Methods to directly detect and characterise horizontal gene transfer from such\
+    \ sequencing data, however, are still lacking. We here provide a method to identify\
+    \ organisms potentially involved in horizontal gene transfer events to be used\
+    \ in downstream analysis that enables a characterisation of a horizontal gene\
+    \ transfer event in terms of impact and prevalence.},\n author = {Enrico Seiler\
+    \ and Kathrin Trappe and Bernhard Y. Renard},\n journal = {PLOS Computational\
+    \ Biology},\n month = {July},\n number = {7},\n pages = {e1007208},\n publisher\
+    \ = {Public Library of Science},\n title = {Where did you come from, where did\
+    \ you go: Refining metagenomic analysis tools for horizontal gene transfer characterisation},\n\
+    \ url = {http://publications.imp.fu-berlin.de/2434/},\n volume = {15},\n year\
+    \ = {2019}\n}\n\n"
+  creators:
+  - name:
+      family: Seiler
+      given: Enrico
+      honourific: null
+      lineage: null
+  - name:
+      family: Trappe
+      given: Kathrin
+      honourific: null
+      lineage: null
+  - name:
+      family: Renard
+      given: Bernhard Y.
+      honourific: null
+      lineage: null
+  date: '2019-07-23'
   date_type: published
+  datestamp: '2020-04-16 11:47:46'
+  dir: disk0/00/00/24/34
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 2434
   full_text_status: none
+  id_number: doi:10.1371/journal.pcbi.1007208
+  ispublished: pub
+  issn: 1553-7358
+  key: fu_mi_publications2434
+  lastmod: '2020-04-16 11:47:46'
   metadata_visibility: show
-  id_number: doi:10.1093/bioinformatics/btu438
+  number: 7
+  official_url: http://doi.org/10.1371/journal.pcbi.1007208
+  pagerange: e1007208
+  publication: PLOS Computational Biology
+  publisher: Public Library of Science
+  refereed: 'TRUE'
+  rev_number: 11
+  status_changed: '2020-04-16 11:47:46'
+  subjects:
+  - G400
+  title: 'Where did you come from, where did you go: Refining metagenomic analysis
+    tools for horizontal gene transfer characterisation'
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/2434
+  userid: 132
+  volume: 15
+- bibtex: "@article{fu_mi_publications324,\n journal = {Science},\n keywords = {ASSEMBLY},\n\
+    \ number = {5461},\n pages = {2185--2195},\n title = {The Genome Sequence of Drosophila\
+    \ melanogaster},\n url = {http://publications.imp.fu-berlin.de/324/},\n volume\
+    \ = {287},\n year = {2000}\n}\n\n"
+  date: 2000
+  datestamp: '2017-03-03 14:40:13'
+  dir: disk0/00/00/03/24
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 324
+  full_text_status: none
+  ispublished: pub
   item_issues_count: 0
-- official_url: http://doi.org/10.1093/bioinformatics/bty380
-  lastmod: '2018-11-13 13:43:57'
-  ispublished: pub
-  uri: http://publications.imp.fu-berlin.de/id/eprint/2253
-  creators:
-  - name:
-      family: Rahn
-      given: René
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      family: Budach
-      honourific:
-      given: Stefan
-  - name:
-      family: Costanza
-      honourific:
-      given: Pascal
-      lineage:
-  - name:
-      lineage:
-      given: Marcel
-      honourific:
-      family: Ehrhardt
-  - name:
-      lineage:
-      honourific:
-      given: Jonny
-      family: Hancox
-  - name:
-      lineage:
-      family: Reinert
-      given: Knut
-      honourific:
-  datestamp: '2018-05-31 11:28:35'
-  publication: Bioinformatics
-  title: Generic accelerated sequence alignment in SeqAn using vectorization and multi-threading
-  abstract: "MotivationPairwise sequence alignment is undoubtedly a central
-    tool in many bioinformatics analyses. In this paper, we present a generically
-    accelerated module for pairwise sequence lignments applicable for a broad range
-    of applications. In our module, we unified the standard dynamic programming kernel
-    used for pairwise sequence alignments and extended it with a generalized inter-sequence
-    vectorization layout, such that many alignments can be computed simultaneously
-    by exploiting SIMD (Single Instruction Multiple Data) instructions of modern processors.
-    We then extended the module by adding two layers of thread-level parallelization,
-    where we a) distribute many independent alignments on multiple threads and b)
-    inherently parallelize a single alignment computation using a work stealing approach
-    producing a dynamic wavefront progressing along the minor diagonal.ResultsWe
-    evaluated our alignment vectorization and parallelization on different processors,
-    including the newest Intel® Xeon® (Skylake) and Intel® Xeon Phi™ (KNL) processors,
-    and use cases. The instruction set AVX512-BW (Byte and Word), available on Skylake
-    processors, can genuinely improve the performance of vectorized alignments. We
-    could run single alignments 1600 times faster on the Xeon Phi™ and 1400 times
-    faster on the Xeon® than executing them with our previous sequential alignment
-    module.AvailabilityThe module is programmed in C++ using the SeqAn
-    (Reinert et al., 2017) library and distributed with version 2.4. under the BSD
-    license. We support SSE4, AVX2, AVX512 instructions and included UME::SIMD, a
-    SIMD-instruction wrapper library, to extend our module for further instruction
-    sets. We thoroughly test all alignment components with all major C++ compilers
-    on various platforms."
-  status_changed: '2018-11-13 13:43:57'
-  userid: 132
-  type: article
-  publisher: Oxford Academic (OUP)
-  rev_number: 8
-  refereed: 'TRUE'
-  eprintid: 2253
-  number: 20
-  id_number: doi:10.1093/bioinformatics/bty380
+  key: fu_mi_publications324
+  keywords: ASSEMBLY
+  lastmod: '2017-03-03 14:40:13'
   metadata_visibility: show
-  date_type: published
-  full_text_status: none
-  eprint_status: archive
-  dir: disk0/00/00/22/53
-  issn: 1367-4803
-  pagerange: 3437-3445
-  date: '2018-10-15'
+  number: 5461
+  pagerange: 2185-2195
+  publication: Science
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:26:43'
   subjects:
   - G400
-  divisions:
-  - group_algbioinf
-  volume: 34
-- userid: 1
+  title: The Genome Sequence of Drosophila melanogaster
   type: article
-  rev_number: 3
-  title: Robust consensus computation
-  status_changed: '2009-03-11 11:27:21'
-  publication: BMC Bioinformatics
-  datestamp: '2010-09-01 13:10:01'
+  uri: http://publications.imp.fu-berlin.de/id/eprint/324
+  userid: 1
+  volume: 287
+- bibtex: "@article{fu_mi_publications325,\n author = {E. Althaus and A. Caprara and\
+    \ H.-P. Lenhof and K. Reinert},\n journal = {Mathematical Programming},\n number\
+    \ = {105},\n pages = {387--425},\n title = {A Branch-and-Cut Algorithm for Multiple\
+    \ Sequence Alignment},\n url = {http://publications.imp.fu-berlin.de/325/},\n\
+    \ year = {2006}\n}\n\n"
   creators:
   - name:
-      lineage:
-      family: Rausch
-      honourific:
-      given: T.
+      family: Althaus
+      given: E.
+      honourific: null
+      lineage: null
   - name:
-      lineage:
+      family: Caprara
+      given: A.
+      honourific: null
+      lineage: null
+  - name:
+      family: Lenhof
+      given: H.-P.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: 2006
+  datestamp: '2017-03-03 14:40:13'
+  dir: disk0/00/00/03/25
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 325
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications325
+  lastmod: '2017-03-03 14:40:13'
+  metadata_visibility: show
+  number: 105
+  pagerange: 387-425
+  publication: Mathematical Programming
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:26:44'
+  subjects:
+  - G400
+  title: A Branch-and-Cut Algorithm for Multiple Sequence Alignment
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/325
+  userid: 1
+- bibtex: "@inproceedings{fu_mi_publications326,\n author = {E. Althaus and A. Caprara\
+    \ and H.-P. Lenhof and K. Reinert},\n booktitle = {Proceedings of the 1st European\
+    \ Conference on Computational Biology (ECCB 2002)},\n pages = {4--16},\n title\
+    \ = {Multiple Sequence alignment with arbitrary gap costs: Computing an  optimal\
+    \ solution using polyhedral combinatorics},\n url = {http://publications.imp.fu-berlin.de/326/},\n\
+    \ year = {2002}\n}\n\n"
+  creators:
+  - name:
+      family: Althaus
+      given: E.
+      honourific: null
+      lineage: null
+  - name:
+      family: Caprara
+      given: A.
+      honourific: null
+      lineage: null
+  - name:
+      family: Lenhof
+      given: H.-P.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: 2002
+  datestamp: '2017-03-03 14:40:13'
+  dir: disk0/00/00/03/26
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 326
+  event_title: "Proceedings of the 1st European Conference on Computational Biology\t\
+    (ECCB 2002)"
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications326
+  lastmod: '2017-03-03 14:40:13'
+  metadata_visibility: show
+  pagerange: 4-16
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:26:44'
+  subjects:
+  - G400
+  title: "Multiple Sequence alignment with arbitrary gap costs: Computing an\toptimal\
+    \ solution using polyhedral combinatorics"
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/326
+  userid: 1
+- bibtex: "@incollection{fu_mi_publications327,\n author = {V. Bafna and K. Reinert},\n\
+    \ booktitle = {Encyclopedia of Genetics, Genomics, Proteomics and Bioinformatics},\n\
+    \ publisher = {Wiley-Eastern},\n title = {Mass Spectrometry and Computational\
+    \ Proteomics},\n url = {http://publications.imp.fu-berlin.de/327/},\n year = {2005}\n\
+    }\n\n"
+  book_title: Encyclopedia of Genetics, Genomics, Proteomics and Bioinformatics
+  creators:
+  - name:
+      family: Bafna
+      given: V.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: 2005
+  datestamp: '2017-03-03 14:40:13'
+  dir: disk0/00/00/03/27
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 327
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications327
+  lastmod: '2017-03-03 14:40:13'
+  metadata_visibility: show
+  publisher: Wiley-Eastern
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:26:45'
+  subjects:
+  - G400
+  title: Mass Spectrometry and Computational Proteomics
+  type: book_section
+  uri: http://publications.imp.fu-berlin.de/id/eprint/327
+  userid: 1
+- bibtex: "@article{fu_mi_publications328,\n author = {J. A. Bailey and Z. Gu and\
+    \ R. A. Clark and K. Reinert and R. V. Samonte and S. S. Schwartz and M. D. Adams\
+    \ and E. W. Myers and P. Li and E. E. Eichler},\n journal = {Science},\n pages\
+    \ = {1003--1007},\n title = {Recent Segmental Duplications in the Human Genome},\n\
+    \ url = {http://publications.imp.fu-berlin.de/328/},\n volume = {297},\n year\
+    \ = {2002}\n}\n\n"
+  creators:
+  - name:
+      family: Bailey
+      given: J. A.
+      honourific: null
+      lineage: null
+  - name:
+      family: Gu
+      given: Z.
+      honourific: null
+      lineage: null
+  - name:
+      family: Clark
+      given: R. A.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  - name:
+      family: Samonte
+      given: R. V.
+      honourific: null
+      lineage: null
+  - name:
+      family: Schwartz
+      given: S. S.
+      honourific: null
+      lineage: null
+  - name:
+      family: Adams
+      given: M. D.
+      honourific: null
+      lineage: null
+  - name:
+      family: Myers
+      given: E. W.
+      honourific: null
+      lineage: null
+  - name:
+      family: Li
+      given: P.
+      honourific: null
+      lineage: null
+  - name:
+      family: Eichler
+      given: E. E.
+      honourific: null
+      lineage: null
+  date: 2002
+  datestamp: '2017-03-03 14:40:13'
+  dir: disk0/00/00/03/28
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 328
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications328
+  lastmod: '2017-03-03 14:40:13'
+  metadata_visibility: show
+  pagerange: 1003-1007
+  publication: Science
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:26:45'
+  subjects:
+  - G400
+  title: Recent Segmental Duplications in the Human Genome
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/328
+  userid: 1
+  volume: 297
+- bibtex: "@techreport{fu_mi_publications329,\n author = {G. Baudis and C. Gr{\\\"\
+    o}pl and S. Hougardy and T. Nierhoff and H.-J. Pr{\\\"o}mel},\n institution =\
+    \ {Humboldt-University Berlin},\n keywords = {Hypergraphs, set systems, and designs,\
+    \ Steiner trees, Approximation algorithms, Colouring, packing and covering, Combinatorial\
+    \ optimization,\nGraph algorithms},\n note = {This paper was already accepted\
+    \ for ICALP 2000 but we did not present       it since later we were informed\
+    \ that the main result had already\nbeen proven in a different way.},\n title\
+    \ = {Approximating Minimum Spanning Sets in Hypergraphs and Polymatroids},\n type\
+    \ = {Technical Report},\n url = {http://publications.imp.fu-berlin.de/329/},\n\
+    \ year = {2000}\n}\n\n"
+  creators:
+  - name:
+      family: Baudis
+      given: G.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: Hougardy
+      given: S.
+      honourific: null
+      lineage: null
+  - name:
+      family: Nierhoff
+      given: T.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Pr\xF6mel"
+      given: H.-J.
+      honourific: null
+      lineage: null
+  date: 2000
+  datestamp: '2009-04-14 14:41:05'
+  dir: disk0/00/00/03/29
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 329
+  full_text_status: none
+  institution: Humboldt-University Berlin
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications329
+  keywords: "Hypergraphs, set systems, and designs, Steiner trees, Approximation\t\
+    algorithms, Colouring, packing and covering, Combinatorial optimization,\r\n\t\
+    Graph algorithms"
+  lastmod: '2009-04-14 14:41:05'
+  metadata_visibility: show
+  monograph_type: technical_report
+  note: "This paper was already accepted for ICALP 2000 but we did not present\tit\
+    \ since later we were informed that the main result had already\r\n\tbeen proven\
+    \ in a different way."
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:26:46'
+  subjects:
+  - G400
+  title: Approximating Minimum Spanning Sets in Hypergraphs and Polymatroids
+  type: monograph
+  uri: http://publications.imp.fu-berlin.de/id/eprint/329
+  userid: 1
+- bibtex: "@inproceedings{fu_mi_publications330,\n author = {M. Bauer and G. W. Klau},\n\
+    \ booktitle = {Proceedings of the 15th International Symposium, ISAAC 2004, Hong\
+    \   Kong},\n pages = {113--125},\n publisher = {Springer Verlag},\n series = {LNCS\
+    \ 3341},\n title = {Structural Alignment of Two RNA Sequences with Lagrangian\
+    \ Relaxation},\n url = {http://publications.imp.fu-berlin.de/330/},\n year = {2004}\n\
+    }\n\n"
+  creators:
+  - name:
+      family: Bauer
+      given: M.
+      honourific: null
+      lineage: null
+  - name:
+      family: Klau
+      given: G. W.
+      honourific: null
+      lineage: null
+  date: 2004
+  datestamp: '2017-03-03 14:40:13'
+  dir: disk0/00/00/03/30
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 330
+  event_title: "Proceedings of the 15th International Symposium, ISAAC 2004, Hong\t\
+    Kong"
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications330
+  lastmod: '2017-03-03 14:40:13'
+  metadata_visibility: show
+  pagerange: 113-125
+  publisher: Springer Verlag
+  refereed: 'TRUE'
+  rev_number: 3
+  series: LNCS 3341
+  status_changed: '2009-03-11 11:26:47'
+  subjects:
+  - G400
+  title: Structural Alignment of Two RNA Sequences with Lagrangian Relaxation
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/330
+  userid: 1
+- bibtex: "@article{fu_mi_publications331,\n author = {M. Bauer and G. W. Klau and\
+    \ K. Reinert},\n journal = {Algorithmic Operations Research},\n note = {to appear},\n\
+    \ title = {An Exact Mathematical Programming Approach to Multiple RNA Sequence-Structure\
+    \       Alignment.},\n url = {http://publications.imp.fu-berlin.de/331/},\n year\
+    \ = {2008}\n}\n\n"
+  creators:
+  - name:
+      family: Bauer
+      given: M.
+      honourific: null
+      lineage: null
+  - name:
+      family: Klau
+      given: G. W.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: 2008
+  datestamp: '2009-08-20 09:47:13'
+  dir: disk0/00/00/03/31
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 331
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications331
+  lastmod: '2009-08-20 09:47:13'
+  metadata_visibility: show
+  note: to appear
+  publication: Algorithmic Operations Research
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:26:47'
+  subjects:
+  - G400
+  title: "An Exact Mathematical Programming Approach to Multiple RNA Sequence-Structure\t\
+    Alignment."
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/331
+  userid: 1
+- bibtex: "@article{fu_mi_publications332,\n author = {M. Bauer and G. W. Klau and\
+    \ K. Reinert},\n journal = {BMC Bioinformatics},\n month = {July},\n number =\
+    \ {1},\n pages = {271},\n title = {Accurate multiple sequence-structure alignment\
+    \ of RNA sequences using       combinatorial optimization.},\n url = {http://publications.imp.fu-berlin.de/332/},\n\
+    \ volume = {8},\n year = {2007}\n}\n\n"
+  creators:
+  - name:
+      family: Bauer
+      given: M.
+      honourific: null
+      lineage: null
+  - name:
+      family: Klau
+      given: G. W.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: 2007-07
+  datestamp: '2017-03-03 14:40:13'
+  dir: disk0/00/00/03/32
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 332
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications332
+  lastmod: '2017-03-03 14:40:13'
+  metadata_visibility: show
+  number: 1
+  pagerange: 271
+  publication: BMC Bioinformatics
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:26:48'
+  subjects:
+  - G400
+  title: "Accurate multiple sequence-structure alignment of RNA sequences using\t\
+    combinatorial optimization."
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/332
+  userid: 1
+  volume: 8
+- bibtex: "@inproceedings{fu_mi_publications333,\n author = {M. Bauer and G. W. Klau\
+    \ and K. Reinert},\n booktitle = {Proceedings of the 5th Workshop on Algorithms\
+    \ Bioinformatics (WABI-05)},\n pages = {303--314},\n title = {Multiple Structural\
+    \ RNA Alignment with Lagrangian Relaxation},\n url = {http://publications.imp.fu-berlin.de/333/},\n\
+    \ year = {2005}\n}\n\n"
+  creators:
+  - name:
+      family: Bauer
+      given: M.
+      honourific: null
+      lineage: null
+  - name:
+      family: Klau
+      given: G. W.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: 2005
+  datestamp: '2017-03-03 14:40:13'
+  dir: disk0/00/00/03/33
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 333
+  event_title: Proceedings of the 5th Workshop on Algorithms Bioinformatics (WABI-05)
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications333
+  lastmod: '2017-03-03 14:40:13'
+  metadata_visibility: show
+  pagerange: 303-314
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:26:48'
+  subjects:
+  - G400
+  title: Multiple Structural RNA Alignment with Lagrangian Relaxation
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/333
+  userid: 1
+- bibtex: "@inproceedings{fu_mi_publications334,\n author = {M. Bauer and G. W. Klau\
+    \ and K. Reinert},\n booktitle = {Proceedings of the 1st International Symposium\
+    \ on Computational Life        Science (CompLife-05)},\n pages = {217--228},\n\
+    \ title = {Fast and Accurate Structural RNA Alignment by Progressive Lagrangian\
+    \        Relaxation},\n url = {http://publications.imp.fu-berlin.de/334/},\n year\
+    \ = {2005}\n}\n\n"
+  creators:
+  - name:
+      family: Bauer
+      given: M.
+      honourific: null
+      lineage: null
+  - name:
+      family: Klau
+      given: G. W.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: 2005
+  datestamp: '2017-03-03 14:40:13'
+  dir: disk0/00/00/03/34
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 334
+  event_title: "Proceedings of the 1st International Symposium on Computational Life\t\
+    Science (CompLife-05)"
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications334
+  lastmod: '2017-03-03 14:40:13'
+  metadata_visibility: show
+  pagerange: 217-228
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:26:49'
+  subjects:
+  - G400
+  title: "Fast and Accurate Structural RNA Alignment by Progressive Lagrangian\tRelaxation"
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/334
+  userid: 1
+- bibtex: "@techreport{fu_mi_publications335,\n author = {M. Block and C. Gr{\\\"\
+    o}pl and H. Preuss and H. J. Pr{\\\"o}mel and A. Srivastav},\n institution = {Humboldt-Universit{\\\
+    \"a}t zu Berlin},\n keywords = {Randomized algorithms and probabilistic analysis,\
+    \ VLSI-Design and   layout, Binary Decision Diagrams, Hardware verification, Local\
+    \ search\nand metaheuristics},\n title = {Efficient ordering of state variables\
+    \ and transition relation partitions    in symbolic model checking},\n type =\
+    \ {Technical Report},\n url = {http://publications.imp.fu-berlin.de/335/},\n year\
+    \ = {1997}\n}\n\n"
+  creators:
+  - name:
+      family: Block
+      given: M.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: Preuss
+      given: H.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Pr\xF6mel"
+      given: H. J.
+      honourific: null
+      lineage: null
+  - name:
+      family: Srivastav
+      given: A.
+      honourific: null
+      lineage: null
+  date: 1997
+  datestamp: '2009-04-14 14:44:15'
+  dir: disk0/00/00/03/35
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 335
+  full_text_status: none
+  institution: "Humboldt-Universit\xE4t zu Berlin"
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications335
+  keywords: "Randomized algorithms and probabilistic analysis, VLSI-Design and\tlayout,\
+    \ Binary Decision Diagrams, Hardware verification, Local search\r\n\tand metaheuristics"
+  lastmod: '2009-04-14 14:44:15'
+  metadata_visibility: show
+  monograph_type: technical_report
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:26:49'
+  subjects:
+  - G400
+  title: "Efficient ordering of state variables and transition relation partitions\t\
+    in symbolic model checking"
+  type: monograph
+  uri: http://publications.imp.fu-berlin.de/id/eprint/335
+  userid: 1
+- bibtex: "@article{fu_mi_publications336,\n address = {Taormina},\n author = {M.\
+    \ Bodirsky and C. Gr{\\\"o}pl and D. Johannsen and M. Kang},\n journal = {S{\\\
+    'e}minaire Lotharingien de Combinatoire},\n keywords = {Three-Connected Planar\
+    \ Graph, Cnet, Planar Graph, Enumeration, Random       graphs, Random Generation,\
+    \ Dynamic Programming, Graph Theory},\n pages = {15 pages},\n title = {A direct\
+    \ decomposition of 3-connected planar graphs},\n url = {http://publications.imp.fu-berlin.de/336/},\n\
+    \ volume = {B54Ak},\n year = {2007}\n}\n\n"
+  creators:
+  - name:
+      family: Bodirsky
+      given: M.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: Johannsen
+      given: D.
+      honourific: null
+      lineage: null
+  - name:
+      family: Kang
+      given: M.
+      honourific: null
+      lineage: null
+  date: 2007
+  datestamp: '2009-04-14 14:18:17'
+  dir: disk0/00/00/03/36
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 336
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications336
+  keywords: "Three-Connected Planar Graph, Cnet, Planar Graph, Enumeration, Random\t\
+    graphs, Random Generation, Dynamic Programming, Graph Theory"
+  lastmod: '2009-04-14 14:18:17'
+  metadata_visibility: show
+  pagerange: 15 pages
+  place_of_pub: Taormina
+  publication: "S\xE9minaire Lotharingien de Combinatoire"
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:26:50'
+  subjects:
+  - G400
+  title: A direct decomposition of 3-connected planar graphs
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/336
+  userid: 1
+  volume: B54Ak
+- bibtex: "@inproceedings{fu_mi_publications337,\n address = {Taormina},\n author\
+    \ = {M. Bodirsky and C. Gr{\\\"o}pl and D. Johannsen and M. Kang},\n booktitle\
+    \ = {Proceedings of the 17th Annual International Conference on Formal   Power\
+    \ Series and Algebraic Combinatorics (FPSAC05)},\n keywords = {Three-Connected\
+    \ Planar Graph, Cnet, Planar Graph, Enumeration, Random       graphs, Random Generation,\
+    \ Dynamic Programming, Graph Theory},\n title = {A direct decomposition of 3-connected\
+    \ planar graphs},\n url = {http://publications.imp.fu-berlin.de/337/},\n year\
+    \ = {2005}\n}\n\n"
+  creators:
+  - name:
+      family: Bodirsky
+      given: M.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: Johannsen
+      given: D.
+      honourific: null
+      lineage: null
+  - name:
+      family: Kang
+      given: M.
+      honourific: null
+      lineage: null
+  date: 2005
+  datestamp: '2009-04-14 14:32:56'
+  dir: disk0/00/00/03/37
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 337
+  event_title: "Proceedings of the 17th Annual International Conference on Formal\t\
+    Power Series and Algebraic Combinatorics (FPSAC05)"
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications337
+  keywords: "Three-Connected Planar Graph, Cnet, Planar Graph, Enumeration, Random\t\
+    graphs, Random Generation, Dynamic Programming, Graph Theory"
+  lastmod: '2009-04-14 14:32:56'
+  metadata_visibility: show
+  place_of_pub: Taormina
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:26:50'
+  subjects:
+  - G400
+  title: A direct decomposition of 3-connected planar graphs
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/337
+  userid: 1
+- abstract: "We present an expected polynomial time algorithm to generate an unlabeled\t\
+    connected cubic planar graph uniformly at random. We first consider\r\n\trooted\
+    \ connected cubic planar graphs, i.e., we count connected cubic\r\n\tplanar graphs\
+    \ up to isomorphisms that fix a certain directed edge.\r\n\tBased on decompositions\
+    \ along the connectivity structure, we derive\r\n\trecurrence formulas for the\
+    \ exact number of rooted cubic planar graphs.\r\n\tThis leads to rooted 3-connected\
+    \ cubic planar graphs, which have\r\n\ta unique embedding on the sphere. Special\
+    \ care has to be taken for\r\n\trooted graphs that have a sense-reversing automorphism.\
+    \ Therefore\r\n\twe introduce the concept of colored networks, which stand in\
+    \ bijective\r\n\tcorrespondence to rooted 3-connected cubic planar graphs with\
+    \ given\r\n\tsymmetries. Colored networks can again be decomposed along the connectivity\r\
+    \n\tstructure. For rooted 3-connected cubic planar graphs embedded in\r\n\tthe\
+    \ plane, we switch to the dual and count rooted triangulations.\r\n\tSince all\
+    \ these numbers can be evaluated in polynomial time using\r\n\tdynamic programming,\
+    \ rooted connected cubic planar graphs can be\r\n\tgenerated uniformly at random\
+    \ in polynomial time by inverting the\r\n\tdecomposition along the connectivity\
+    \ structure. To generate connected\r\n\tcubic planar graphs without a root uniformly\
+    \ at random, we apply\r\n\trejection sampling and obtain an expected polynomial\
+    \ time algorithm"
+  bibtex: "@article{fu_mi_publications338,\n abstract = {We present an expected polynomial\
+    \ time algorithm to generate an unlabeled   connected cubic planar graph uniformly\
+    \ at random. We first consider\nrooted connected cubic planar graphs, i.e., we\
+    \ count connected cubic\nplanar graphs up to isomorphisms that fix a certain directed\
+    \ edge.\nBased on decompositions along the connectivity structure, we derive\n\
+    recurrence formulas for the exact number of rooted cubic planar graphs.\nThis\
+    \ leads to rooted 3-connected cubic planar graphs, which have\na unique embedding\
+    \ on the sphere. Special care has to be taken for\nrooted graphs that have a sense-reversing\
+    \ automorphism. Therefore\nwe introduce the concept of colored networks, which\
+    \ stand in bijective\ncorrespondence to rooted 3-connected cubic planar graphs\
+    \ with given\nsymmetries. Colored networks can again be decomposed along the connectivity\n\
+    structure. For rooted 3-connected cubic planar graphs embedded in\nthe plane,\
+    \ we switch to the dual and count rooted triangulations.\nSince all these numbers\
+    \ can be evaluated in polynomial time using\ndynamic programming, rooted connected\
+    \ cubic planar graphs can be\ngenerated uniformly at random in polynomial time\
+    \ by inverting the\ndecomposition along the connectivity structure. To generate\
+    \ connected\ncubic planar graphs without a root uniformly at random, we apply\n\
+    rejection sampling and obtain an expected polynomial time algorithm},\n author\
+    \ = {M. Bodirsky and C. Gr{\\\"o}pl and M. Kang},\n journal = {Random Structures\
+    \ and Algorithms},\n number = {2},\n pages = {157--180},\n title = {Generating\
+    \ unlabeled connected cubic planar graphs uniformly at random},\n url = {http://publications.imp.fu-berlin.de/338/},\n\
+    \ volume = {32},\n year = {2008}\n}\n\n"
+  creators:
+  - name:
+      family: Bodirsky
+      given: M.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: Kang
+      given: M.
+      honourific: null
+      lineage: null
+  date: 2008
+  datestamp: '2009-04-14 14:13:28'
+  dir: disk0/00/00/03/38
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 338
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications338
+  lastmod: '2009-04-14 14:13:28'
+  metadata_visibility: show
+  number: 2
+  pagerange: 157-180
+  publication: Random Structures and Algorithms
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:26:51'
+  subjects:
+  - G400
+  title: Generating unlabeled connected cubic planar graphs uniformly at random
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/338
+  userid: 1
+  volume: 32
+- abstract: "We present a deterministic polynomial time algorithm to sample a labeled\t\
+    planar graph uniformly at random. Our approach uses recursive formulae\r\n\tfor\
+    \ the exact number of labeled planar graphs with n vertices and\r\n\tm edges,\
+    \ based on a decomposition into 1-, 2-, and 3-connected components.\r\n\tWe can\
+    \ then use known sampling algorithms and counting formulae for\r\n\t3-connected\
+    \ planar graphs."
+  bibtex: "@article{fu_mi_publications339,\n abstract = {We present a deterministic\
+    \ polynomial time algorithm to sample a labeled    planar graph uniformly at random.\
+    \ Our approach uses recursive formulae\nfor the exact number of labeled planar\
+    \ graphs with n vertices and\nm edges, based on a decomposition into 1-, 2-, and\
+    \ 3-connected components.\nWe can then use known sampling algorithms and counting\
+    \ formulae for\n3-connected planar graphs.},\n author = {M. Bodirsky and C. Gr{\\\
+    \"o}pl and M. Kang},\n journal = {Theoretical Computer Science},\n keywords =\
+    \ {Labeled planar graph, Enumeration, Decomposition, Sampling algorithm,     \
+    \  Dynamic programming, Graph theory},\n number = {3},\n pages = {377--386},\n\
+    \ title = {Generating labeled planar graphs uniformly at random},\n url = {http://publications.imp.fu-berlin.de/339/},\n\
+    \ volume = {379},\n year = {2007}\n}\n\n"
+  creators:
+  - name:
+      family: Bodirsky
+      given: M.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: Kang
+      given: M.
+      honourific: null
+      lineage: null
+  date: 2007
+  datestamp: '2009-04-14 14:19:26'
+  dir: disk0/00/00/03/39
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 339
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications339
+  keywords: "Labeled planar graph, Enumeration, Decomposition, Sampling algorithm,\t\
+    Dynamic programming, Graph theory"
+  lastmod: '2009-04-14 14:19:26'
+  metadata_visibility: show
+  number: 3
+  official_url: http://www.sciencedirect.com/science/article/B6V1G-4N4PY45-5/2 /4c06fbabe635c3a288cbf0427e0b395d
+  pagerange: 377-386
+  publication: Theoretical Computer Science
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:26:52'
+  subjects:
+  - G400
+  title: Generating labeled planar graphs uniformly at random
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/339
+  userid: 1
+  volume: 379
+- bibtex: "@inproceedings{fu_mi_publications340,\n author = {M. Bodirsky and C. Gr{\\\
+    \"o}pl and M. Kang},\n booktitle = {Proceedings of the 16th Annual International\
+    \ Symposium on Algorithms        and Computation (ISAAC05)},\n keywords = {Planar\
+    \ Graph, Enumeration, Random graphs, Random Generation, Graph  Theory},\n title\
+    \ = {Sampling Unlabeled Biconnected Planar Graphs},\n url = {http://publications.imp.fu-berlin.de/340/},\n\
+    \ year = {2005}\n}\n\n"
+  creators:
+  - name:
+      family: Bodirsky
+      given: M.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: Kang
+      given: M.
+      honourific: null
+      lineage: null
+  date: 2005
+  datestamp: '2010-09-01 13:43:09'
+  dir: disk0/00/00/03/40
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 340
+  event_title: "Proceedings of the 16th Annual International Symposium on Algorithms\t\
+    and Computation (ISAAC05)"
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications340
+  keywords: "Planar Graph, Enumeration, Random graphs, Random Generation, Graph\t\
+    Theory"
+  lastmod: '2010-09-01 13:43:09'
+  metadata_visibility: show
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:26:52'
+  subjects:
+  - G400
+  title: Sampling Unlabeled Biconnected Planar Graphs
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/340
+  userid: 1
+- abstract: "We present an expected polynomial time algorithm to generate a labeled\t\
+    planar graph uniformly at random. To generate the planar graphs,\r\n\twe derive\
+    \ recurrence formulas that count all such graphs with n vertices\r\n\tand m edges,\
+    \ based on a decomposition into 1-, 2-, and 3-connected\r\n\tcomponents. For 3-connected\
+    \ graphs we apply a recent random generation\r\n\talgorithm by Schaeffer and a\
+    \ counting formula by Mullin and Schellenberg."
+  bibtex: "@inproceedings{fu_mi_publications341,\n abstract = {We present an expected\
+    \ polynomial time algorithm to generate a labeled      planar graph uniformly\
+    \ at random. To generate the planar graphs,\nwe derive recurrence formulas that\
+    \ count all such graphs with n vertices\nand m edges, based on a decomposition\
+    \ into 1-, 2-, and 3-connected\ncomponents. For 3-connected graphs we apply a\
+    \ recent random generation\nalgorithm by Schaeffer and a counting formula by Mullin\
+    \ and Schellenberg.},\n author = {M. Bodirsky and C. Gr{\\\"o}pl and M. Kang},\n\
+    \ booktitle = {Proceedings of ICALP 2003},\n keywords = {Planar Graph, Enumeration,\
+    \ Random graphs, Random Generation, Dynamic        Programming, Graph Theory},\n\
+    \ note = {Appeared 2008 in Theoretical Computer Science. \\{ The download is \
+    \  the journal submission \\&lt;br\\&gt; From time to time we receive requests\n\
+    for source code, so here it is: See the files BGK03b.README and GBK03b.tar.bz2\n\
+    \\}},\n number = {2719},\n pages = {1095--1107},\n publisher = {Springer Verlag},\n\
+    \ series = {Lecture Notes in Computer Science},\n title = {Generating labeled\
+    \ planar graphs uniformly at random},\n url = {http://publications.imp.fu-berlin.de/341/},\n\
+    \ year = {2003}\n}\n\n"
+  creators:
+  - name:
+      family: Bodirsky
+      given: M.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: Kang
+      given: M.
+      honourific: null
+      lineage: null
+  date: 2003
+  datestamp: '2009-04-14 14:37:56'
+  dir: disk0/00/00/03/41
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 341
+  event_title: Proceedings of ICALP 2003
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications341
+  keywords: "Planar Graph, Enumeration, Random graphs, Random Generation, Dynamic\t\
+    Programming, Graph Theory"
+  lastmod: '2009-04-14 14:37:56'
+  metadata_visibility: show
+  note: "Appeared 2008 in Theoretical Computer Science. { The download is\tthe journal\
+    \ submission &lt;br&gt; From time to time we receive requests\r\n\tfor source\
+    \ code, so here it is: See the files BGK03b.README and GBK03b.tar.bz2\r\n\t}"
+  number: 2719
+  pagerange: 1095-1107
+  publisher: Springer Verlag
+  refereed: 'TRUE'
+  rev_number: 3
+  series: Lecture Notes in Computer Science
+  status_changed: '2009-03-11 11:26:53'
+  subjects:
+  - G400
+  title: Generating labeled planar graphs uniformly at random
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/341
+  userid: 1
+- abstract: "We present an expected polynomial time algorithm to generate an unlabeled\t\
+    connected cubic planar graph uniformly at random. We first consider\r\n\trooted\
+    \ cubic planar graphs, i.e., we count connected cubic planar\r\n\tgraphs up to\
+    \ isomorphisms that fix a certain directed edge. Based\r\n\ton decompositions\
+    \ along the connectivity structure, we derive recurrence\r\n\tformulas for counting\
+    \ the exact number of rooted cubic planar graphs.\r\n\tThis leads to 3-connected\
+    \ planar graphs, which have a unique embedding\r\n\ton the sphere; but special\
+    \ care has to be taken for rooted graphs\r\n\tthat have a sense-reversing automorphism.\
+    \ Therefore we introduce\r\n\tthe concept of colored networks, which stand in\
+    \ bijective correspondence\r\n\tto rooted graphs with given symmetries. Colored\
+    \ networks can again\r\n\tbe decomposed along their connectivity structure. For\
+    \ rooted 3-connected\r\n\tcubic planar graphs embedded in the plane, we switch\
+    \ to the dual\r\n\tand count rooted triangulations. All these numbers can be evaluated\r\
+    \n\tin polynomial time by dynamic programming. We can use them to generate\r\n\
+    \trooted cubic planar graphs uniformly at random. To generate connected\r\n\t\
+    cubic planar graphs without a root uniformly at random, we apply\r\n\trejection\
+    \ sampling and obtain an expected polynomial time algorithm."
+  bibtex: "@inproceedings{fu_mi_publications342,\n abstract = {We present an expected\
+    \ polynomial time algorithm to generate an unlabeled   connected cubic planar\
+    \ graph uniformly at random. We first consider\nrooted cubic planar graphs, i.e.,\
+    \ we count connected cubic planar\ngraphs up to isomorphisms that fix a certain\
+    \ directed edge. Based\non decompositions along the connectivity structure, we\
+    \ derive recurrence\nformulas for counting the exact number of rooted cubic planar\
+    \ graphs.\nThis leads to 3-connected planar graphs, which have a unique embedding\n\
+    on the sphere; but special care has to be taken for rooted graphs\nthat have a\
+    \ sense-reversing automorphism. Therefore we introduce\nthe concept of colored\
+    \ networks, which stand in bijective correspondence\nto rooted graphs with given\
+    \ symmetries. Colored networks can again\nbe decomposed along their connectivity\
+    \ structure. For rooted 3-connected\ncubic planar graphs embedded in the plane,\
+    \ we switch to the dual\nand count rooted triangulations. All these numbers can\
+    \ be evaluated\nin polynomial time by dynamic programming. We can use them to\
+    \ generate\nrooted cubic planar graphs uniformly at random. To generate connected\n\
+    cubic planar graphs without a root uniformly at random, we apply\nrejection sampling\
+    \ and obtain an expected polynomial time algorithm.},\n author = {M. Bodirsky\
+    \ and C. Gr{\\\"o}pl and M. Kang},\n booktitle = {European Conference on Combinatorics,\
+    \ Graph Theory, and Applications        EUROCOMB'03 Prague},\n keywords = {Cubic\
+    \ Planar Graph, Planar Graph, Cubic Graph, Enumeration, Random  graphs, Random\
+    \ Generation, Dynamic Programming, Graph Theory},\n title = {Decomposing, Counting,\
+    \ and Generating Unlabeled Cubic Planar Graphs},\n url = {http://publications.imp.fu-berlin.de/342/},\n\
+    \ year = {2003}\n}\n\n"
+  creators:
+  - name:
+      family: Bodirsky
+      given: M.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: Kang
+      given: M.
+      honourific: null
+      lineage: null
+  date: 2003
+  datestamp: '2009-04-14 14:36:27'
+  dir: disk0/00/00/03/42
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 342
+  event_title: "European Conference on Combinatorics, Graph Theory, and Applications\t\
+    EUROCOMB'03 Prague"
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications342
+  keywords: "Cubic Planar Graph, Planar Graph, Cubic Graph, Enumeration, Random\t\
+    graphs, Random Generation, Dynamic Programming, Graph Theory"
+  lastmod: '2009-04-14 14:36:27'
+  metadata_visibility: show
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:26:53'
+  subjects:
+  - G400
+  title: Decomposing, Counting, and Generating Unlabeled Cubic Planar Graphs
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/342
+  userid: 1
+- bibtex: "@inproceedings{fu_mi_publications343,\n author = {P. G. Bradford and K.\
+    \ Reinert},\n booktitle = {Proceedings of the 23rd International Colloquium on\
+    \ Automata, Languages,    and Programming 1996 (ICALP-96), LNCS 1099},\n pages\
+    \ = {454--465},\n title = {Lower Bounds for Row Minima Searching},\n url = {http://publications.imp.fu-berlin.de/343/},\n\
+    \ year = {1996}\n}\n\n"
+  creators:
+  - name:
+      family: Bradford
+      given: P. G.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: 1996
+  datestamp: '2017-03-03 14:40:13'
+  dir: disk0/00/00/03/43
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 343
+  event_title: "Proceedings of the 23rd International Colloquium on Automata, Languages,\t\
+    and Programming 1996 (ICALP-96), LNCS 1099"
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications343
+  lastmod: '2017-03-03 14:40:13'
+  metadata_visibility: show
+  pagerange: 454-465
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:26:54'
+  subjects:
+  - G400
+  title: Lower Bounds for Row Minima Searching
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/343
+  userid: 1
+- abstract: "High throughput analysis of proteins using mass spectrometry requires\t\
+    an efficient signal preprocessing which reduces the amount of data\r\n\twith minimal\
+    \ loss of information. Therefore the peaks that belong\r\n\tto a peptide have\
+    \ to be detected, and important features like their\r\n\tpeak centroid position,\
+    \ the height and the area have to be determined.\r\n\tHere we present a peak picking\
+    \ algorithm which detects peaks in a\r\n\tnoisy mass spectrum using its continuous\
+    \ wavelet transform. By adapting\r\n\tthe wavelet to the theoretical peak shape,\
+    \ each peaks centroid position\r\n\tis precisely identified; thus, overlapping\
+    \ peaks (e.g. caused by\r\n\telectronspray ionization) are well separated. Representing\
+    \ each peak\r\n\tnot only by its centroid position and area but also by the parameters\r\
+    \n\tof the best fitting asymmetric lorentzian or hyperbolic secant squared\r\n\
+    \tfunctions, yields valuable information about the original peak shape\r\n\tfor\
+    \ further analysis. Given a mass spectrum with 100,000 raw data\r\n\tpoints representing\
+    \ 200 peaks, our algorithm stored 5 parameters\r\n\tper peak, and was able to\
+    \ reduce the memory requirement down to 1\r\n\tpercent."
+  bibtex: "@misc{fu_mi_publications344,\n abstract = {High throughput analysis of\
+    \ proteins using mass spectrometry requires       an efficient signal preprocessing\
+    \ which reduces the amount of data\nwith minimal loss of information. Therefore\
+    \ the peaks that belong\nto a peptide have to be detected, and important features\
+    \ like their\npeak centroid position, the height and the area have to be determined.\n\
+    Here we present a peak picking algorithm which detects peaks in a\nnoisy mass\
+    \ spectrum using its continuous wavelet transform. By adapting\nthe wavelet to\
+    \ the theoretical peak shape, each peaks centroid position\nis precisely identified;\
+    \ thus, overlapping peaks (e.g. caused by\nelectronspray ionization) are well\
+    \ separated. Representing each peak\nnot only by its centroid position and area\
+    \ but also by the parameters\nof the best fitting asymmetric lorentzian or hyperbolic\
+    \ secant squared\nfunctions, yields valuable information about the original peak\
+    \ shape\nfor further analysis. Given a mass spectrum with 100,000 raw data\npoints\
+    \ representing 200 peaks, our algorithm stored 5 parameters\nper peak, and was\
+    \ able to reduce the memory requirement down to 1\npercent.},\n author = {E. Lange},\n\
+    \ title = {Peak picking in mass spectra},\n url = {http://publications.imp.fu-berlin.de/344/},\n\
+    \ year = {2004}\n}\n\n"
+  creators:
+  - name:
+      family: Lange
+      given: E.
+      honourific: null
+      lineage: null
+  date: 2004
+  datestamp: '2009-03-11 17:18:04'
+  dir: disk0/00/00/03/44
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 344
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications344
+  lastmod: '2009-03-11 17:18:04'
+  metadata_visibility: show
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:26:54'
+  subjects:
+  - G400
+  title: Peak picking in mass spectra
+  type: other
+  uri: http://publications.imp.fu-berlin.de/id/eprint/344
+  userid: 1
+- abstract: "Mass spectrometry (MS) is becoming a popular approach for quantifying\t\
+    the protein composition of complex samples. A great challenge for\r\n\tcomparative\
+    \ proteomic profiling is to match corresponding peptide\r\n\tfeatures from different\
+    \ experiments to ensure that the same protein\r\n\tintensities are correctly identified.\
+    \ Multi-dimensional data acquisition\r\n\tfrom liquid-chromatography mass spectrometry\
+    \ (LC-MS) makes the alignment\r\n\tproblem harder. We propose a general paradigm\
+    \ for aligning peptide\r\n\tfeatures using a bounded error model. Our method is\
+    \ tolerant of imperfect\r\n\tmeasurements, missing peaks, and extraneous peaks.\
+    \ It can handle\r\n\tan arbitrary number of dimensions of separation, and is very\
+    \ fast\r\n\tin practice even for large data sets. Finally, its parameters are\r\
+    \n\tintuitive and we describe a heuristic for estimating them automatically.\r\
+    \n\tWe demonstrate results on single- and multi-dimensional data."
+  bibtex: "@inproceedings{fu_mi_publications345,\n abstract = {Mass spectrometry (MS)\
+    \ is becoming a popular approach for quantifying       the protein composition\
+    \ of complex samples. A great challenge for\ncomparative proteomic profiling is\
+    \ to match corresponding peptide\nfeatures from different experiments to ensure\
+    \ that the same protein\nintensities are correctly identified. Multi-dimensional\
+    \ data acquisition\nfrom liquid-chromatography mass spectrometry (LC-MS) makes\
+    \ the alignment\nproblem harder. We propose a general paradigm for aligning peptide\n\
+    features using a bounded error model. Our method is tolerant of imperfect\nmeasurements,\
+    \ missing peaks, and extraneous peaks. It can handle\nan arbitrary number of dimensions\
+    \ of separation, and is very fast\nin practice even for large data sets. Finally,\
+    \ its parameters are\nintuitive and we describe a heuristic for estimating them\
+    \ automatically.\nWe demonstrate results on single- and multi-dimensional data.},\n\
+    \ author = {D. Fasulo and A.-K. Emde and L.-Y. Wang and N. J. Edwards},\n booktitle\
+    \ = {Systems Biology and Computational Proteomics},\n pages = {119--129},\n publisher\
+    \ = {Springer Verlag},\n series = {Lecture Notes in Computer Science},\n title\
+    \ = {Alignment of Mass Spectrometry Data by Clique Finding and Optimization},\n\
+    \ url = {http://publications.imp.fu-berlin.de/345/},\n volume = {4532},\n year\
+    \ = {2007}\n}\n\n"
+  creators:
+  - name:
+      family: Fasulo
+      given: D.
+      honourific: null
+      lineage: null
+  - name:
       family: Emde
       given: A.-K.
-      honourific:
+      honourific: null
+      lineage: null
   - name:
-      family: Reinert
-      given: K.
-      honourific:
-      lineage:
-  uri: http://publications.imp.fu-berlin.de/id/eprint/390
-  lastmod: '2010-09-01 13:10:01'
-  ispublished: pub
+      family: Wang
+      given: L.-Y.
+      honourific: null
+      lineage: null
+  - name:
+      family: Edwards
+      given: N. J.
+      honourific: null
+      lineage: null
+  date: 2007
+  datestamp: '2009-03-11 16:59:59'
+  dir: disk0/00/00/03/45
   divisions:
   - group_algbioinf
+  eprint_status: archive
+  eprintid: 345
+  event_title: Systems Biology and Computational Proteomics
+  event_type: workshop
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications345
+  lastmod: '2010-09-01 13:22:04'
+  metadata_visibility: show
+  official_url: http://www.springerlink.com/content/h716314047k25505
+  pagerange: 119-129
+  pres_type: paper
+  publisher: Springer Verlag
+  refereed: 'TRUE'
+  rev_number: 6
+  series: Lecture Notes in Computer Science
+  status_changed: '2009-03-11 11:26:55'
   subjects:
   - G400
-  volume: 9
-  pagerange: P4
-  date: 2008
-  dir: disk0/00/00/03/90
+  title: Alignment of Mass Spectrometry Data by Clique Finding and Optimization
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/345
+  userid: 1
+  volume: 4532
+- abstract: "Motivation: The Dictionary of Interfaces in Proteins (DIP) is a database\t\
+    collecting the 3D structure of interacting parts of proteins that\r\n\tare called\
+    \ patches. It serves as a repository, in which patches similar\r\n\tto given query\
+    \ patches can be found. The computation of the similarity\r\n\tof two patches\
+    \ is time consuming and traversing the entire DIP requires\r\n\tsome hours. In\
+    \ this work we address the question of how the patches\r\n\tsimilar to a given\
+    \ query can be identified by scanning only a small\r\n\tpart of DIP. The answer\
+    \ to this question requires the investigation\r\n\tof the distribution of the\
+    \ similarity of patches. Results: The score\r\n\tvalues describing the similarity\
+    \ of two patches can roughly be divided\r\n\tinto three ranges that correspond\
+    \ to different levels of spatial\r\n\tsimilarity. Interestingly, the two iso-score\
+    \ lines separating the\r\n\tthree classes can be determined by two different approaches.\
+    \ Applying\r\n\ta concept of the theory of random graphs reveals significant structural\r\
+    \n\tproperties of the data in DIP. These can be used to accelerate scanning\r\n\
+    \tthe DIP for patches similar to a given query. Searches for very similar\r\n\t\
+    patches could be accelerated by a factor of more than 25. Patches\r\n\twith a\
+    \ medium similarity could be found 10 times faster than by brute-force\r\n\tsearch.\
+    \ 10.1093/bioinformatics/btg343"
+  bibtex: "@article{fu_mi_publications346,\n abstract = {Motivation: The Dictionary\
+    \ of Interfaces in Proteins (DIP) is a database    collecting the 3D structure\
+    \ of interacting parts of proteins that\nare called patches. It serves as a repository,\
+    \ in which patches similar\nto given query patches can be found. The computation\
+    \ of the similarity\nof two patches is time consuming and traversing the entire\
+    \ DIP requires\nsome hours. In this work we address the question of how the patches\n\
+    similar to a given query can be identified by scanning only a small\npart of DIP.\
+    \ The answer to this question requires the investigation\nof the distribution\
+    \ of the similarity of patches. Results: The score\nvalues describing the similarity\
+    \ of two patches can roughly be divided\ninto three ranges that correspond to\
+    \ different levels of spatial\nsimilarity. Interestingly, the two iso-score lines\
+    \ separating the\nthree classes can be determined by two different approaches.\
+    \ Applying\na concept of the theory of random graphs reveals significant structural\n\
+    properties of the data in DIP. These can be used to accelerate scanning\nthe DIP\
+    \ for patches similar to a given query. Searches for very similar\npatches could\
+    \ be accelerated by a factor of more than 25. Patches\nwith a medium similarity\
+    \ could be found 10 times faster than by brute-force\nsearch. 10.1093/bioinformatics/btg343},\n\
+    \ author = {C. Fr{\\\"o}mmel and Ch. Gille and A. Goede and C. Gr{\\\"o}pl and\
+    \ S. Hougardy and T. Nierhoff and R. Preissner and M. Thimm},\n journal = {Bioinformatics},\n\
+    \ keywords = {algorithm, proteomics, statistics},\n month = {December},\n number\
+    \ = {18},\n pages = {2442--2447},\n title = {Accelerating screening of 3D protein\
+    \ data with a graph theoretical  approach},\n url = {http://publications.imp.fu-berlin.de/346/},\n\
+    \ volume = {19},\n year = {2003}\n}\n\n"
+  creators:
+  - name:
+      family: "Fr\xF6mmel"
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: Gille
+      given: Ch.
+      honourific: null
+      lineage: null
+  - name:
+      family: Goede
+      given: A.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: Hougardy
+      given: S.
+      honourific: null
+      lineage: null
+  - name:
+      family: Nierhoff
+      given: T.
+      honourific: null
+      lineage: null
+  - name:
+      family: Preissner
+      given: R.
+      honourific: null
+      lineage: null
+  - name:
+      family: Thimm
+      given: M.
+      honourific: null
+      lineage: null
+  date: 2003-12
+  datestamp: '2009-04-14 14:35:22'
+  dir: disk0/00/00/03/46
+  divisions:
+  - group_algbioinf
   eprint_status: archive
-  metadata_visibility: show
+  eprintid: 346
   full_text_status: none
+  ispublished: pub
   item_issues_count: 0
+  key: fu_mi_publications346
+  keywords: algorithm, proteomics, statistics
+  lastmod: '2009-04-14 14:35:22'
+  metadata_visibility: show
+  number: 18
+  official_url: http://dx.doi.org/10.1093/bioinformatics/btg343
+  pagerange: 2442-2447
+  publication: Bioinformatics
   refereed: 'TRUE'
-  eprintid: 390
-  number: Suppl 10
-- ispublished: pub
-  lastmod: '2010-11-18 14:19:41'
-  pages: 347
-  book_title: Problem Solving Handbook in Computational Biology and Bioinformatics
-  uri: http://publications.imp.fu-berlin.de/id/eprint/393
-  isbn: 978-0-387-09759-6
-  official_url: http://www.springer.com/computer/bioinformatics/book/978-0-387-09759-6
-  status_changed: '2010-02-04 14:02:02'
+  rev_number: 3
+  status_changed: '2009-03-11 11:26:55'
+  title: "Accelerating screening of 3D protein data with a graph theoretical\tapproach"
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/346
+  userid: 1
+  volume: 19
+- bibtex: "@inproceedings{fu_mi_publications347,\n author = {C. Gr{\\\"o}pl},\n booktitle\
+    \ = {Computational Proteomics},\n note = {Extended abstract for talk given at\
+    \ Dagstuhl Seminar 05471 on Computational Proteomics, 20.-25. November 2005},\n\
+    \ publisher = {Dagstuhl Online Publication Server (DROPS)},\n title = {An Algorithm\
+    \ for Feature Finding in LC/MS Raw Data},\n url = {http://publications.imp.fu-berlin.de/347/},\n\
+    \ year = {2005}\n}\n\n"
+  creators:
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  date: 2005
+  datestamp: '2009-04-14 14:26:41'
+  dir: disk0/00/00/03/47
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 347
+  event_title: Computational Proteomics
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications347
+  lastmod: '2009-04-14 14:26:41'
+  metadata_visibility: show
+  note: "Extended abstract for talk given at Dagstuhl Seminar 05471 on Computational\t\
+    Proteomics, 20.-25. November 2005"
+  official_url: http://www.dagstuhl.de/05471/
+  publisher: Dagstuhl Online Publication Server (DROPS)
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:26:56'
+  subjects:
+  - G400
+  title: An Algorithm for Feature Finding in LC/MS Raw Data
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/347
+  userid: 1
+- bibtex: "@misc{fu_mi_publications348,\n author = {C. Gr{\\\"o}pl},\n note = {Skript\
+    \ zu meiner Vorlesung im Wintersemester 2002/03 am Institut    f{\\\"u}r Informatik\
+    \ der Humboldt-Universit{\\\"a}t zu Berlin},\n title = {Algorithmen in der Bioinformatik},\n\
+    \ url = {http://publications.imp.fu-berlin.de/348/},\n year = {2003}\n}\n\n"
+  creators:
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  date: 2003
+  datestamp: '2009-04-14 14:36:34'
+  dir: disk0/00/00/03/48
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 348
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications348
+  lastmod: '2009-04-14 14:36:34'
+  metadata_visibility: show
+  note: "Skript zu meiner Vorlesung im Wintersemester 2002/03 am Institut\tf\xFCr\
+    \ Informatik der Humboldt-Universit\xE4t zu Berlin"
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:26:56'
+  subjects:
+  - G400
+  title: Algorithmen in der Bioinformatik
+  type: other
+  uri: http://publications.imp.fu-berlin.de/id/eprint/348
+  userid: 1
+- abstract: "(deutsche Zusammenfassung siehe unten)&lt;p&gt; Binary Decision Diagrams\t\
+    (BDDs) are a data structure for Boolean functions which are also\r\n\tknown as\
+    \ branching programs. In ordered binary decision diagrams\r\n\t(OBDDs), the tests\
+    \ have to obey a fixed variable ordering. In free\r\n\tbinary decision diagrams\
+    \ (FBDDs), each variable can be tested at\r\n\tmost once. The efficiency of new\
+    \ variants of the BDD concept is usually\r\n\tdemonstrated with spectacular (worst-case)\
+    \ examples. We pursue another\r\n\tapproach and compare the representation sizes\
+    \ of almost all Boolean\r\n\tfunctions. Whereas I. Wegener proved that for `most'\
+    \ values of n\r\n\tthe expected OBDD size of a random Boolean function of n variables\r\
+    \n\tis equal to the worst-case size up to terms of lower order, we show\r\n\t\
+    that this is not the case for n within intervals of constant length\r\n\taround\
+    \ the values n = 2h + h. Furthermore, ranges of n exist for\r\n\twhich minimal\
+    \ FBDDs are almost always at least a constant factor\r\n\tsmaller than minimal\
+    \ OBDDs. Our main theorems have doubly exponentially\r\n\tsmall probability bounds\
+    \ (in n). We also investigate the evolution\r\n\tof random OBDDs and their worst-case\
+    \ size, revealing an oscillating\r\n\tbehaviour that explains why certain results\
+    \ cannot be improved in\r\n\tgeneral. &lt;p&gt; &lt;b&gt;Zusammenfassung:&lt;/b&gt;&lt;p&gt;\
+    \ Binary Decision Diagrams\r\n\t(BDDs) sind eine Datenstruktur f\xFCr Boolesche\
+    \ Funktionen, die\r\n\tauch unter dem Namen branching program bekannt ist. In\
+    \ ordered binary\r\n\tdecision diagrams (OBDDs) m\xFCssen die Tests einer festen\
+    \ Variablenordnung\r\n\tgen\xFCgen. In free binary decision diagrams (FBDDs) darf\
+    \ jede Variable\r\n\th\xF6chstens einmal getestet werden. Die Effizienz neuer\
+    \ Varianten\r\n\tdes BDD-Konzepts wird gew\xF6hnlich anhand spektakul\xE4rer (worst-case)\r\
+    \n\tBeispiele aufgezeigt. Wir verfolgen einen anderen Ansatz und vergleichen\r\
+    \n\tdie Darstellungsgr\xF6\xDFen f\xFCr fast alle Booleschen Funktionen.\r\n\t\
+    W\xE4hrend I. Wegener bewiesen hat, da\xDF f\xFCr die `meisten'\r\n\tn die erwartete\
+    \ OBDD-Gr\xF6\xDFe einer zuf\xE4lligen Booleschen\r\n\tFunktion von n Variablen\
+    \ gleich der worst-case Gr\xF6\xDFe bis\r\n\tauf Terme kleinerer Ordnung ist,\
+    \ zeigen wir da\xDF dies nicht der\r\n\tFall ist f\xFCr n innerhalb von Intervallen\
+    \ konstanter L\xE4nge\r\n\tum die Werte n = 2h + h. Ferner gibt es Bereiche von\
+    \ n, in denen\r\n\tminimale FBDDs fast immer um mindestens einen konstanten Faktor\
+    \ kleiner\r\n\tsind als minimale OBDDs. Unsere Haupts\xE4tze ha ben doppelt exponentielle\r\
+    \n\tWahrschein- lichkeitsschranken (in n). Au\xDFerdem untersuchen wir\r\n\tdie\
+    \ Entwicklung zuf\xE4lliger OBDDs und ihrer worst-case Gr\xF6\xDFe\r\n\tund decken\
+    \ dabei ein oszillierendes Verhalten auf, das erkl\xE4rt,\r\n\twarum gewisse Aussagen\
+    \ im allgemeinen nicht verst\xE4rkt werden\r\n\tk\xF6nnen. &lt;p&gt;Schlagw\xF6\
+    rter:&lt;p&gt; Bin\xE4res Entscheidungsdiagramm,\r\n\tBoolesche Funktion,probabilistische\
+    \ Analyse, Shannon Effekt."
+  bibtex: "@unpublished{fu_mi_publications349,\n abstract = {(deutsche Zusammenfassung\
+    \ siehe unten)\\&lt;p\\&gt; Binary Decision Diagrams  (BDDs) are a data structure\
+    \ for Boolean functions which are also\nknown as branching programs. In ordered\
+    \ binary decision diagrams\n(OBDDs), the tests have to obey a fixed variable ordering.\
+    \ In free\nbinary decision diagrams (FBDDs), each variable can be tested at\n\
+    most once. The efficiency of new variants of the BDD concept is usually\ndemonstrated\
+    \ with spectacular (worst-case) examples. We pursue another\napproach and compare\
+    \ the representation sizes of almost all Boolean\nfunctions. Whereas I. Wegener\
+    \ proved that for `most' values of n\nthe expected OBDD size of a random Boolean\
+    \ function of n variables\nis equal to the worst-case size up to terms of lower\
+    \ order, we show\nthat this is not the case for n within intervals of constant\
+    \ length\naround the values n = 2h + h. Furthermore, ranges of n exist for\nwhich\
+    \ minimal FBDDs are almost always at least a constant factor\nsmaller than minimal\
+    \ OBDDs. Our main theorems have doubly exponentially\nsmall probability bounds\
+    \ (in n). We also investigate the evolution\nof random OBDDs and their worst-case\
+    \ size, revealing an oscillating\nbehaviour that explains why certain results\
+    \ cannot be improved in\ngeneral. \\&lt;p\\&gt; \\&lt;b\\&gt;Zusammenfassung:\\\
+    &lt;/b\\&gt;\\&lt;p\\&gt; Binary Decision Diagrams\n(BDDs) sind eine Datenstruktur\
+    \ f{\\\"u}r Boolesche Funktionen, die\nauch unter dem Namen branching program\
+    \ bekannt ist. In ordered binary\ndecision diagrams (OBDDs) m{\\\"u}ssen die Tests\
+    \ einer festen Variablenordnung\ngen{\\\"u}gen. In free binary decision diagrams\
+    \ (FBDDs) darf jede Variable\nh{\\\"o}chstens einmal getestet werden. Die Effizienz\
+    \ neuer Varianten\ndes BDD-Konzepts wird gew{\\\"o}hnlich anhand spektakul{\\\"\
+    a}rer (worst-case)\nBeispiele aufgezeigt. Wir verfolgen einen anderen Ansatz und\
+    \ vergleichen\ndie Darstellungsgr{\\\"o}{\\ss}en f{\\\"u}r fast alle Booleschen\
+    \ Funktionen.\nW{\\\"a}hrend I. Wegener bewiesen hat, da{\\ss} f{\\\"u}r die `meisten'\n\
+    n die erwartete OBDD-Gr{\\\"o}{\\ss}e einer zuf{\\\"a}lligen Booleschen\nFunktion\
+    \ von n Variablen gleich der worst-case Gr{\\\"o}{\\ss}e bis\nauf Terme kleinerer\
+    \ Ordnung ist, zeigen wir da{\\ss} dies nicht der\nFall ist f{\\\"u}r n innerhalb\
+    \ von Intervallen konstanter L{\\\"a}nge\num die Werte n = 2h + h. Ferner gibt\
+    \ es Bereiche von n, in denen\nminimale FBDDs fast immer um mindestens einen konstanten\
+    \ Faktor kleiner\nsind als minimale OBDDs. Unsere Haupts{\\\"a}tze ha ben doppelt\
+    \ exponentielle\nWahrschein- lichkeitsschranken (in n). Au{\\ss}erdem untersuchen\
+    \ wir\ndie Entwicklung zuf{\\\"a}lliger OBDDs und ihrer worst-case Gr{\\\"o}{\\\
+    ss}e\nund decken dabei ein oszillierendes Verhalten auf, das erkl{\\\"a}rt,\n\
+    warum gewisse Aussagen im allgemeinen nicht verst{\\\"a}rkt werden\nk{\\\"o}nnen.\
+    \ \\&lt;p\\&gt;Schlagw{\\\"o}rter:\\&lt;p\\&gt; Bin{\\\"a}res Entscheidungsdiagramm,\n\
+    Boolesche Funktion,probabilistische Analyse, Shannon Effekt.},\n author = {C.\
+    \ Gr{\\\"o}pl},\n keywords = {Binary decision diagram, Boolean function, probabilistic\
+    \ analysis,  Shannon effect},\n school = {Humboldt-Universit{\\\"a}t zu Berlin},\n\
+    \ title = {Binary Decision Diagrams for Random Boolean Functions},\n url = {http://publications.imp.fu-berlin.de/349/},\n\
+    \ year = {1999}\n}\n\n"
+  creators:
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  date: 1999
+  datestamp: '2009-04-14 14:41:14'
+  dir: disk0/00/00/03/49
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 349
+  full_text_status: none
+  institution: "Humboldt-Universit\xE4t zu Berlin"
+  ispublished: unpub
+  item_issues_count: 0
+  key: fu_mi_publications349
+  keywords: "Binary decision diagram, Boolean function, probabilistic analysis,\t\
+    Shannon effect"
+  lastmod: '2009-04-14 14:41:14'
+  metadata_visibility: show
+  official_url: http://dochost.rz.hu-berlin.de/dissertationen/informatik/groepl-clemens
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:26:57'
+  subjects:
+  - G400
+  thesis_type: phd
+  title: Binary Decision Diagrams for Random Boolean Functions
+  type: thesis
+  uri: http://publications.imp.fu-berlin.de/id/eprint/349
+  userid: 1
+- bibtex: "@unpublished{fu_mi_publications350,\n address = {Forschungsinstitut f{\\\
+    \"u}r Diskrete Mathematik},\n author = {C. Gr{\\\"o}pl},\n keywords = {Approximation\
+    \ algorithms, Colouring, packing and covering},\n month = {January},\n school\
+    \ = {Rheinische Friedrich-Wilhelms-Universit{\\\"a}t Bonn},\n title = {{\\\"U}ber\
+    \ Approximationsalgorithmen zur F{\\\"a}rbung k-f{\\\"a}rbbarer  Graphen, die\
+    \ vektorchromatische Zahl und andere Varianten der vartheta-Funktion},\n url =\
+    \ {http://publications.imp.fu-berlin.de/350/},\n year = {1996}\n}\n\n"
+  creators:
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  date: 1996-01
+  datestamp: '2009-04-14 14:43:52'
+  dir: disk0/00/00/03/50
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 350
+  full_text_status: none
+  institution: "Rheinische Friedrich-Wilhelms-Universit\xE4t Bonn"
+  ispublished: unpub
+  item_issues_count: 0
+  key: fu_mi_publications350
+  keywords: Approximation algorithms, Colouring, packing and covering
+  lastmod: '2009-04-14 14:43:52'
+  metadata_visibility: show
+  place_of_pub: "Forschungsinstitut f\xFCr Diskrete Mathematik"
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:26:57'
+  subjects:
+  - G400
+  thesis_type: masters
+  title: "\xDCber Approximationsalgorithmen zur F\xE4rbung k-f\xE4rbbarer\tGraphen,\
+    \ die vektorchromatische Zahl und andere Varianten der vartheta-Funktion"
+  type: thesis
+  uri: http://publications.imp.fu-berlin.de/id/eprint/350
+  userid: 1
+- bibtex: "@misc{fu_mi_publications351,\n author = {C. Gr{\\\"o}pl and A. Hildebrandt\
+    \ and E. Lange and S. L{\\\"o}venich and M. Sturm},\n keywords = {mass spectrometry,\
+    \ proteomics, open source software},\n note = {http://mbi.osu.edu/2004/workshops2004.html},\n\
+    \ title = {OpenMS - Software for Mass Spectrometry},\n url = {http://publications.imp.fu-berlin.de/351/},\n\
+    \ year = {2005}\n}\n\n"
+  creators:
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: Hildebrandt
+      given: A.
+      honourific: null
+      lineage: null
+  - name:
+      family: Lange
+      given: E.
+      honourific: null
+      lineage: null
+  - name:
+      family: "L\xF6venich"
+      given: S.
+      honourific: null
+      lineage: null
+  - name:
+      family: Sturm
+      given: M.
+      honourific: null
+      lineage: null
+  date: 2005
+  datestamp: '2009-03-11 16:53:50'
+  dir: disk0/00/00/03/51
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 351
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications351
+  keywords: mass spectrometry, proteomics, open source software
+  lastmod: '2010-09-01 13:38:57'
+  metadata_visibility: show
+  note: http://mbi.osu.edu/2004/workshops2004.html
+  refereed: 'TRUE'
+  rev_number: 4
+  status_changed: '2009-03-11 11:26:58'
+  subjects:
+  - G400
+  title: OpenMS - Software for Mass Spectrometry
+  type: other
+  uri: http://publications.imp.fu-berlin.de/id/eprint/351
+  userid: 1
+- bibtex: "@misc{fu_mi_publications352,\n author = {C. Gr{\\\"o}pl and A. Hildebrandt\
+    \ and E. Lange and M. Sturm},\n keywords = {mass spectrometry, proteomics, open\
+    \ source software},\n note = {http://www.hupo2005.com/},\n title = {OpenMS - a\
+    \ generic open source framework for HPLC/MS-based proteomics},\n url = {http://publications.imp.fu-berlin.de/352/},\n\
+    \ year = {2005}\n}\n\n"
+  creators:
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: Hildebrandt
+      given: A.
+      honourific: null
+      lineage: null
+  - name:
+      family: Lange
+      given: E.
+      honourific: null
+      lineage: null
+  - name:
+      family: Sturm
+      given: M.
+      honourific: null
+      lineage: null
+  date: 2005
+  datestamp: '2010-09-01 13:40:54'
+  dir: disk0/00/00/03/52
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 352
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications352
+  keywords: mass spectrometry, proteomics, open source software
+  lastmod: '2010-09-01 13:40:54'
+  metadata_visibility: show
+  note: http://www.hupo2005.com/
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:26:59'
+  subjects:
+  - G400
+  title: OpenMS - a generic open source framework for HPLC/MS-based proteomics
+  type: other
+  uri: http://publications.imp.fu-berlin.de/id/eprint/352
+  userid: 1
+- bibtex: "@incollection{fu_mi_publications353,\n author = {C. Gr{\\\"o}pl and S.\
+    \ Hougardy and T. Nierhoff and H.-J. Pr{\\\"o}mel},\n booktitle = {Steiner Trees\
+    \ in Industry},\n editor = {X. Cheng and D. Z. Du},\n keywords = {Approximation\
+    \ algorithms, Combinatorial optimization, Graph algorithms,     Steiner trees},\n\
+    \ note = {Survey article with new proofs},\n pages = {235--279},\n publisher =\
+    \ {Kluwer Academic Publishers},\n title = {Approximation Algorithms for the Steiner\
+    \ Tree Problem in Graphs},\n url = {http://publications.imp.fu-berlin.de/353/},\n\
+    \ year = {2001}\n}\n\n"
+  book_title: Steiner Trees in Industry
+  creators:
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: Hougardy
+      given: S.
+      honourific: null
+      lineage: null
+  - name:
+      family: Nierhoff
+      given: T.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Pr\xF6mel"
+      given: H.-J.
+      honourific: null
+      lineage: null
+  date: 2001
+  datestamp: '2009-04-14 14:39:16'
+  dir: disk0/00/00/03/53
+  divisions:
+  - group_algbioinf
   editors:
   - name:
-      given: L. S.
-      honourific:
-      family: Heath
-      lineage:
+      family: Cheng
+      given: X.
+      honourific: null
+      lineage: null
   - name:
-      lineage:
-      family: Ramakrishnan
-      honourific:
-      given: N.
-  abstract: Abstract Multiple sequence alignment as a means of comparing DNA, RNA
-    or amino acid sequences is an essential precondition for various analyses, including
-    structure prediction, modeling binding sites, phylogeny or function prediction.
-    This range of applications implies a demand for versatile, flexible and specialized
-    meth- ods to compute accurate alignments. This chapter summarizes the key algorithmic
-    insights gained in the past years to facilitate both, an easy understanding of
-    the current multiple sequence alignment literature and to enable the readers to
-    use and apply current tools in their own everyday research.
-  title: Practical multiple Sequence alignment
-  publisher: Springer Science+Business Media
-  rev_number: 8
-  type: book_section
-  userid: 1
-  creators:
-  - name:
-      lineage:
-      given: T.
-      honourific:
-      family: Rausch
-  - name:
-      lineage:
-      honourific:
-      given: K.
-      family: Reinert
-  datestamp: '2009-11-24 15:20:29'
-  related_url:
-  - url: http://www.springerlink.com/content/978-0-387-09759-6#section=798327&page=1&locus=0
-  item_issues_count: 0
-  date_type: published
-  full_text_status: none
-  id_number: DOI 10.1007/978-0-387-09760-2
-  metadata_visibility: show
-  eprintid: 393
-  refereed: 'TRUE'
-  pagerange: 21-43
-  date: 2011
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
+      family: Du
+      given: D. Z.
+      honourific: null
+      lineage: null
   eprint_status: archive
-  dir: disk0/00/00/03/93
-- eprint_status: archive
-  dir: disk0/00/00/03/89
-  date: 2006-09
-  subjects:
-  - G400
-  divisions:
-  - group_algbioinf
-  institution: "Hasso-Plattner-Institut für Softwaresystemtechnik GmbH, UniversitätPotsdam"
-  refereed: 'TRUE'
-  eprintid: 389
-  item_issues_count: 0
+  eprintid: 353
   full_text_status: none
-  metadata_visibility: show
-  creators:
-  - name:
-      lineage:
-      family: Rausch
-      honourific:
-      given: T.
-  datestamp: '2017-03-03 14:40:14'
-  thesis_type: masters
-  status_changed: '2009-03-11 11:27:20'
-  title: Discovering causes of multifactorial diseases
-  rev_number: 3
-  type: thesis
-  userid: 1
-  ispublished: unpub
-  lastmod: '2017-03-03 14:40:14'
-  uri: http://publications.imp.fu-berlin.de/id/eprint/389
-- date: 2008-07
-  pagerange: 826-836
-  volume: 38
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  eprint_status: archive
-  dir: disk0/00/00/03/94
-  item_issues_count: 0
-  full_text_status: none
-  metadata_visibility: show
-  eprintid: 394
-  refereed: 'TRUE'
-  abstract: "This paper describes a novel algorithm to analyze genetic linkagedata
-    using pattern recognition techniques and genetic algorithms(GA). The method
-    allows a search for regions of the chromosome thatmay contain genetic variations
-    that jointly predispose individualsfor a particular disease. The method uses
-    correlation analysis, filteringtheory and genetic algorithms to achieve this
-    goal. Because currentgenome scans use from hundreds to hundreds of thousands
-    of markers,two versions of the method have been implemented. The first is
-    anexhaustive analysis version that can be used to visualize, explore,and
-    analyze small genetic data sets for two marker correlations;the second is
-    a GA version, which uses a parallel implementationallowing searches of higher-order
-    correlations in large data sets.Results on simulated data sets indicate that
-    the method can be informativein the identification of major disease loci and
-    geneâ\x80\x93gene interactionsin genome-wide linkage data and that further
-    exploration of thesetechniques is justified. The results presented for both
-    variantsof the method show that it can help genetic epidemiologists to identifypromising
-    combinations of genetic factors that might predispose tocomplex disorders.
-    In particular, the correlation analysis of IBDexpression patterns might hint
-    to possible geneâ\x80\x93gene interactionsand the filtering might be a fruitful
-    approach to distinguish truecorrelation signals from noise."
-  status_changed: '2009-03-11 11:27:23'
-  title: "A parallel genetic algorithm to discover patterns in genetic markersthat
-    indicate predisposition to multifactorial disease"
-  type: article
-  rev_number: 3
-  userid: 1
-  creators:
-  - name:
-      lineage:
-      family: Rausch
-      given: T.
-      honourific:
-  - name:
-      honourific:
-      given: A.
-      family: Thomas
-      lineage:
-  - name:
-      honourific:
-      given: N. J.
-      family: Camp
-      lineage:
-  - name:
-      family: Facelli
-      honourific:
-      given: L. A.
-      lineage:
-  datestamp: '2017-03-03 14:40:15'
-  publication: Comput. Biol. Med.
   ispublished: pub
-  lastmod: '2017-03-03 14:40:15'
-  uri: http://publications.imp.fu-berlin.de/id/eprint/394
-  official_url: http://www.ncbi.nlm.nih.gov/pubmed/18547558
-- title: Segment-based multiple sequence alignment
-  status_changed: '2009-03-11 11:27:21'
-  abstract: "Motivation: Many multiple sequence alignment tools have been developedin
-    the past, progressing either in speed or alignment accuracy. Giventhe importance
-    and wide-spread use of alignment tools, progress inboth categories is a
-    contribution to the community and has drivenresearch in the field so far.
-    Results: We introduce a graph-basedextension to the consistency-based, progressive
-    alignment strategy.We apply the consistency notion to segments instead of
-    single characters.The main problem we solve in this context is to define
-    segments ofthe sequences in such a way that a graph-based alignment is possible.We
-    implemented the algorithm using the SeqAn library and report resultson amino
-    acid and DNA sequences. The benefit of our approach is threefold:(1) sequences
-    with conserved blocks can be rapidly aligned, (2) theimplementation is conceptually
-    easy, generic and fast and (3) theconsistency idea can be extended to align
-    multiple genomic sequences.Availability: The segment-based multiple sequence
-    alignment toolcan be downloaded from http://www.seqan.de/projects/msa.html.
-    A novelversion of T-Coffee interfaced with the tool is available from http://www.tcoffee.org.The
-    usage of the tool is described in both documentations. Contact:rausch@inf.fu-berlin.de"
+  item_issues_count: 0
+  key: fu_mi_publications353
+  keywords: "Approximation algorithms, Combinatorial optimization, Graph algorithms,\t\
+    Steiner trees"
+  lastmod: '2009-04-14 14:39:16'
+  metadata_visibility: show
+  note: Survey article with new proofs
+  pagerange: 235-279
+  publisher: Kluwer Academic Publishers
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:26:59'
+  subjects:
+  - G400
+  title: Approximation Algorithms for the Steiner Tree Problem in Graphs
+  type: book_section
+  uri: http://publications.imp.fu-berlin.de/id/eprint/353
   userid: 1
-  rev_number: 7
+- abstract: "The area of approximation algorithms for the Steiner tree problem\tin\
+    \ graphs has seen continuous progress over the last years. Currently\r\n\tthe\
+    \ best approximation algorithm has a performance ratio of 1.550.\r\n\tThis is\
+    \ still far away from 1.0074, the largest known lower bound\r\n\ton the achievable\
+    \ performance ratio. As all instances resulting from\r\n\tknown lower bound reductions\
+    \ are uniformly quasi-bipartite, it is\r\n\tinteresting whether this special case\
+    \ can be approximated better\r\n\tthan the general case. We present an approximation\
+    \ algorithm with\r\n\tperformance ratio 73/60 &lt; 1.217 for the uniformly quasi-bipartite\r\
+    \n\tcase. This improves on the previously known ratio of 1.279 of Robins\r\n\t\
+    and Zelikovsky. We use a new method of analysis that combines ideas\r\n\tfrom\
+    \ the greedy algorithm for set cover with a matroid-style exchange\r\n\targument\
+    \ to model the connectivity constraint. As a consequence,\r\n\twe are able to\
+    \ provide a tight instance."
+  bibtex: "@article{fu_mi_publications354,\n abstract = {The area of approximation\
+    \ algorithms for the Steiner tree problem   in graphs has seen continuous progress\
+    \ over the last years. Currently\nthe best approximation algorithm has a performance\
+    \ ratio of 1.550.\nThis is still far away from 1.0074, the largest known lower\
+    \ bound\non the achievable performance ratio. As all instances resulting from\n\
+    known lower bound reductions are uniformly quasi-bipartite, it is\ninteresting\
+    \ whether this special case can be approximated better\nthan the general case.\
+    \ We present an approximation algorithm with\nperformance ratio 73/60 \\&lt; 1.217\
+    \ for the uniformly quasi-bipartite\ncase. This improves on the previously known\
+    \ ratio of 1.279 of Robins\nand Zelikovsky. We use a new method of analysis that\
+    \ combines ideas\nfrom the greedy algorithm for set cover with a matroid-style\
+    \ exchange\nargument to model the connectivity constraint. As a consequence,\n\
+    we are able to provide a tight instance.},\n author = {C. Gr{\\\"o}pl and S. Hougardy\
+    \ and T. Nierhoff and H.-J. Pr{\\\"o}mel},\n journal = {Information Processing\
+    \ Letters},\n keywords = {Steiner trees, Graph algorithms, Approximation algorithms},\n\
+    \ pages = {195--200},\n title = {Steiner trees in uniformly quasi-bipartite graphs},\n\
+    \ url = {http://publications.imp.fu-berlin.de/354/},\n volume = {83},\n year =\
+    \ {2002}\n}\n\n"
+  creators:
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: Hougardy
+      given: S.
+      honourific: null
+      lineage: null
+  - name:
+      family: Nierhoff
+      given: T.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Pr\xF6mel"
+      given: H.-J.
+      honourific: null
+      lineage: null
+  date: 2002
+  datestamp: '2009-04-14 14:39:09'
+  dir: disk0/00/00/03/54
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 354
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications354
+  keywords: Steiner trees, Graph algorithms, Approximation algorithms
+  lastmod: '2009-04-14 14:39:09'
+  metadata_visibility: show
+  pagerange: 195-200
+  publication: Information Processing Letters
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:00'
+  subjects:
+  - G400
+  title: Steiner trees in uniformly quasi-bipartite graphs
   type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/354
+  userid: 1
+  volume: 83
+- abstract: "The Steiner tree problem asks for a shortest subgraph connecting a\t\
+    given set of terminals in a graph. It is known to be APX-complete,\r\n\twhich\
+    \ means that no polynomial time approximation scheme can exist\r\n\tfor this problem,\
+    \ unless P=NP. Currently, the best approximation\r\n\talgorithm for the Steiner\
+    \ tree problem has a performance ratio of\r\n\t<span class='mathrm'>1.55</span>,\
+    \ whereas the corresponding lower bound is smaller than <span class='mathrm'>1.01</span>.\r\
+    \n\tIn this paper, we provide for several Steiner tree approximation\r\n\talgorithms\
+    \ lower bounds on their performance ratio that are much\r\n\tlarger. For two algorithms\
+    \ that solve the Steiner tree problem on\r\n\tquasi-bipartite instances, we even\
+    \ prove lower bounds that match\r\n\tthe upper bounds. Quasi-bipartite instances\
+    \ are of special interest,\r\n\tas currently all known lower bound reductions\
+    \ for the Steiner tree\r\n\tproblem in graphs produce such instances."
+  bibtex: "@inproceedings{fu_mi_publications355,\n abstract = {The Steiner tree problem\
+    \ asks for a shortest subgraph connecting a  given set of terminals in a graph.\
+    \ It is known to be APX-complete,\nwhich means that no polynomial time approximation\
+    \ scheme can exist\nfor this problem, unless P=NP. Currently, the best approximation\n\
+    algorithm for the Steiner tree problem has a performance ratio of\n{\\ensuremath{<}}span\
+    \ class='mathrm'{\\ensuremath{>}}1.55{\\ensuremath{<}}/span{\\ensuremath{>}},\
+    \ whereas the corresponding lower bound is smaller than {\\ensuremath{<}}span\
+    \ class='mathrm'{\\ensuremath{>}}1.01{\\ensuremath{<}}/span{\\ensuremath{>}}.\n\
+    In this paper, we provide for several Steiner tree approximation\nalgorithms lower\
+    \ bounds on their performance ratio that are much\nlarger. For two algorithms\
+    \ that solve the Steiner tree problem on\nquasi-bipartite instances, we even prove\
+    \ lower bounds that match\nthe upper bounds. Quasi-bipartite instances are of\
+    \ special interest,\nas currently all known lower bound reductions for the Steiner\
+    \ tree\nproblem in graphs produce such instances.},\n author = {C. Gr{\\\"o}pl\
+    \ and S. Hougardy and T. Nierhoff and H.-J. Pr{\\\"o}mel},\n booktitle = {Proceedings\
+    \ of the 27th International Workshop on Graph-Theoretic   Concepts in Computer\
+    \ Science (2001)},\n keywords = {Steiner trees, Approximation algorithms, Combinatorial\
+    \ optimization,        Graph algorithms, Hypergraphs, set systems, and designs},\n\
+    \ publisher = {Springer Verlag},\n series = {LNCS},\n title = {Lower bounds for\
+    \ approximation algorithms for the Steiner tree      problem},\n url = {http://publications.imp.fu-berlin.de/355/},\n\
+    \ year = {2001}\n}\n\n"
+  creators:
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: Hougardy
+      given: S.
+      honourific: null
+      lineage: null
+  - name:
+      family: Nierhoff
+      given: T.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Pr\xF6mel"
+      given: H.-J.
+      honourific: null
+      lineage: null
+  date: 2001
+  datestamp: '2009-04-14 14:40:07'
+  dir: disk0/00/00/03/55
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 355
+  event_title: "Proceedings of the 27th International Workshop on Graph-Theoretic\t\
+    Concepts in Computer Science (2001)"
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications355
+  keywords: "Steiner trees, Approximation algorithms, Combinatorial optimization,\t\
+    Graph algorithms, Hypergraphs, set systems, and designs"
+  lastmod: '2009-04-14 14:40:07'
+  metadata_visibility: show
+  publisher: Springer Verlag
+  refereed: 'TRUE'
+  rev_number: 3
+  series: LNCS
+  status_changed: '2009-03-11 11:27:00'
+  subjects:
+  - G400
+  title: "Lower bounds for approximation algorithms for the Steiner tree\tproblem"
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/355
+  userid: 1
+- bibtex: "@misc{fu_mi_publications356,\n author = {C. Gr{\\\"o}pl and S. Hougardy\
+    \ and T. Nierhoff and H.-J. Pr{\\\"o}mel and M. Thimm},\n title = {Approximationsalgorithmen\
+    \ f{\\\"u}r das Steinerbaumproblem in Graphen},\n url = {http://publications.imp.fu-berlin.de/356/},\n\
+    \ year = {2002}\n}\n\n"
+  creators:
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: Hougardy
+      given: S.
+      honourific: null
+      lineage: null
+  - name:
+      family: Nierhoff
+      given: T.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Pr\xF6mel"
+      given: H.-J.
+      honourific: null
+      lineage: null
+  - name:
+      family: Thimm
+      given: M.
+      honourific: null
+      lineage: null
+  date: 2002
+  datestamp: '2009-04-14 14:37:28'
+  dir: disk0/00/00/03/56
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 356
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications356
+  lastmod: '2009-04-14 14:37:28'
+  metadata_visibility: show
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:01'
+  subjects:
+  - G400
+  title: "Approximationsalgorithmen f\xFCr das Steinerbaumproblem in Graphen"
+  type: other
+  uri: http://publications.imp.fu-berlin.de/id/eprint/356
+  userid: 1
+- abstract: "HPLC-ESI-MS is rapidly becoming an established standard method for\t\
+    shotgun proteomics. Currently, its major drawbacks are twofold: quantification\r\
+    \n\tis mostly limited to relative quantification and the large amount\r\n\tof\
+    \ data produced by every individual experiment can make manual analysis\r\n\t\
+    quite difficult. Here we present a new, combined experimental and\r\n\talgorithmic\
+    \ approach to absolutely quantify proteins from samples\r\n\twith unprecedented\
+    \ precision. We apply the method to the analysis\r\n\tof myoglobin in human blood\
+    \ serum, which is an important diagnostic\r\n\tmarker for myocardial infarction.\
+    \ Our approach was able to determine\r\n\tthe absolute amount of myoglobin in\
+    \ a serum sample through a series\r\n\tof standard addition experiments with a\
+    \ relative error of 2.5 percent.\r\n\tCompared to a manual analysis of the same\
+    \ dataset we could improve\r\n\tthe precision and conduct it in a fraction of\
+    \ the time needed for\r\n\tthe manual analysis. We anticipate that our automatic\
+    \ quantitation\r\n\tmethod will facilitate further absolute or relative quantitation\r\
+    \n\tof even more complex peptide samples. The algorithm was developed\r\n\tusing\
+    \ our publically available software framework OpenMS (www.openms.de)."
+  bibtex: "@inproceedings{fu_mi_publications358,\n abstract = {HPLC-ESI-MS is rapidly\
+    \ becoming an established standard method for  shotgun proteomics. Currently,\
+    \ its major drawbacks are twofold: quantification\nis mostly limited to relative\
+    \ quantification and the large amount\nof data produced by every individual experiment\
+    \ can make manual analysis\nquite difficult. Here we present a new, combined experimental\
+    \ and\nalgorithmic approach to absolutely quantify proteins from samples\nwith\
+    \ unprecedented precision. We apply the method to the analysis\nof myoglobin in\
+    \ human blood serum, which is an important diagnostic\nmarker for myocardial infarction.\
+    \ Our approach was able to determine\nthe absolute amount of myoglobin in a serum\
+    \ sample through a series\nof standard addition experiments with a relative error\
+    \ of 2.5 percent.\nCompared to a manual analysis of the same dataset we could\
+    \ improve\nthe precision and conduct it in a fraction of the time needed for\n\
+    the manual analysis. We anticipate that our automatic quantitation\nmethod will\
+    \ facilitate further absolute or relative quantitation\nof even more complex peptide\
+    \ samples. The algorithm was developed\nusing our publically available software\
+    \ framework OpenMS (www.openms.de).},\n author = {C. Gr{\\\"o}pl and E. Lange\
+    \ and K. Reinert and M. Sturm and Ch. Huber and B. M. Mayr and C. L. Klein},\n\
+    \ booktitle = {Proceedings of the 1st International Symposium on Computational\
+    \ Life        Science (CompLife05)},\n pages = {151--163},\n title = {Algorithms\
+    \ for the automated absolute quantification of diagnostic  markers in complex\
+    \ proteomics samples},\n url = {http://publications.imp.fu-berlin.de/358/},\n\
+    \ year = {2005}\n}\n\n"
+  creators:
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: Lange
+      given: E.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  - name:
+      family: Sturm
+      given: M.
+      honourific: null
+      lineage: null
+  - name:
+      family: Huber
+      given: Ch.
+      honourific: null
+      lineage: null
+  - name:
+      family: Mayr
+      given: B. M.
+      honourific: null
+      lineage: null
+  - name:
+      family: Klein
+      given: C. L.
+      honourific: null
+      lineage: null
+  date: 2005
+  datestamp: '2009-04-14 14:27:04'
+  dir: disk0/00/00/03/58
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 358
+  event_title: "Proceedings of the 1st International Symposium on Computational Life\t\
+    Science (CompLife05)"
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications358
+  lastmod: '2009-04-14 14:27:04'
+  metadata_visibility: show
+  pagerange: 151-163
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:02'
+  subjects:
+  - G400
+  title: "Algorithms for the automated absolute quantification of diagnostic\tmarkers\
+    \ in complex proteomics samples"
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/358
+  userid: 1
+- bibtex: "@inproceedings{fu_mi_publications359,\n address = {Berlin, Heidelberg,\
+    \ New York},\n author = {C. Gr{\\\"o}pl and H.-J. Pr{\\\"o}mel and A. Srivastav},\n\
+    \ booktitle = {STACS 98},\n editor = {D. Korb and Ch. Meinel and M. Morvan},\n\
+    \ keywords = {VLSI-Design and layout, Hardware verification, Random graphs},\n\
+    \ number = {1373},\n pages = {238--248},\n publisher = {Springer Verlag},\n series\
+    \ = {Lecture Notes in Computer Science},\n title = {Size and Structure of Random\
+    \ Ordered Binary Decision Diagrams (Extended     Abstract)},\n url = {http://publications.imp.fu-berlin.de/359/},\n\
+    \ year = {1998}\n}\n\n"
+  creators:
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Pr\xF6mel"
+      given: H.-J.
+      honourific: null
+      lineage: null
+  - name:
+      family: Srivastav
+      given: A.
+      honourific: null
+      lineage: null
+  date: 1998
+  datestamp: '2009-04-14 14:42:04'
+  dir: disk0/00/00/03/59
+  divisions:
+  - group_algbioinf
+  editors:
+  - name:
+      family: Korb
+      given: D.
+      honourific: null
+      lineage: null
+  - name:
+      family: Meinel
+      given: Ch.
+      honourific: null
+      lineage: null
+  - name:
+      family: Morvan
+      given: M.
+      honourific: null
+      lineage: null
+  eprint_status: archive
+  eprintid: 359
+  event_title: STACS 98
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications359
+  keywords: VLSI-Design and layout, Hardware verification, Random graphs
+  lastmod: '2009-04-14 14:42:04'
+  metadata_visibility: show
+  number: 1373
+  pagerange: 238-248
+  place_of_pub: Berlin, Heidelberg, New York
+  publisher: Springer Verlag
+  refereed: 'TRUE'
+  rev_number: 3
+  series: Lecture Notes in Computer Science
+  status_changed: '2009-03-11 11:27:03'
+  subjects:
+  - G400
+  title: "Size and Structure of Random Ordered Binary Decision Diagrams (Extended\t\
+    Abstract)"
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/359
+  userid: 1
+- abstract: "We investigate the size and structure of ordered binary decision diagrams\t\
+    (OBDDs) for random Boolean functions. It was known that for most\r\n\tvalues of\
+    \ n, the expected OBDD size of a random Boolean function\r\n\twith n variables\
+    \ is equal to the worst-case size up to terms of lower\r\n\torder. Such a phenomenon\
+    \ is generally called strong Shannon effect.\r\n\tHere we show that the strong\
+    \ Shannon effect is not valid for all\r\n\tn. Instead it undergoes a certain periodic\
+    \ `phase transition': If\r\n\tn lies within intervals of constant width around\
+    \ the values n = 2h\r\n\t+ h, then the strong Shannon effect does not hold, whereas\
+    \ it does\r\n\thold outside these intervals. Our analysis provides doubly exponential\r\
+    \n\tprobability bounds and generalises to ordered Kronecker functional\r\n\tdecision\
+    \ diagrams (OKFDDs). "
+  bibtex: "@article{fu_mi_publications360,\n abstract = {We investigate the size and\
+    \ structure of ordered binary decision diagrams   (OBDDs) for random Boolean functions.\
+    \ It was known that for most\nvalues of n, the expected OBDD size of a random\
+    \ Boolean function\nwith n variables is equal to the worst-case size up to terms\
+    \ of lower\norder. Such a phenomenon is generally called strong Shannon effect.\n\
+    Here we show that the strong Shannon effect is not valid for all\nn. Instead it\
+    \ undergoes a certain periodic `phase transition': If\nn lies within intervals\
+    \ of constant width around the values n = 2h\n+ h, then the strong Shannon effect\
+    \ does not hold, whereas it does\nhold outside these intervals. Our analysis provides\
+    \ doubly exponential\nprobability bounds and generalises to ordered Kronecker\
+    \ functional\ndecision diagrams (OKFDDs). },\n author = {C. Gr{\\\"o}pl and H.-J.\
+    \ Pr{\\\"o}mel and A. Srivastav},\n journal = {Discrete Applied Mathematics},\n\
+    \ keywords = {VLSI-Design and layout, Binary Decision Diagrams, Graph theory (other),\
+    \     Hardware verification, Probability theory, Random graphs, Randomized\nalgorithms\
+    \ and probabilistic analysis, Theoretical computer science\n(other)},\n pages\
+    \ = {67--85},\n title = {Ordered binary decision diagrams and the Shannon effect},\n\
+    \ url = {http://publications.imp.fu-berlin.de/360/},\n volume = {142},\n year\
+    \ = {2004}\n}\n\n"
+  creators:
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Pr\xF6mel"
+      given: H.-J.
+      honourific: null
+      lineage: null
+  - name:
+      family: Srivastav
+      given: A.
+      honourific: null
+      lineage: null
+  date: 2004
+  datestamp: '2009-04-14 14:35:30'
+  dir: disk0/00/00/03/60
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 360
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications360
+  keywords: "VLSI-Design and layout, Binary Decision Diagrams, Graph theory (other),\t\
+    Hardware verification, Probability theory, Random graphs, Randomized\r\n\talgorithms\
+    \ and probabilistic analysis, Theoretical computer science\r\n\t(other)"
+  lastmod: '2009-04-14 14:35:30'
+  metadata_visibility: show
+  pagerange: 67-85
+  publication: Discrete Applied Mathematics
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:03'
+  subjects:
+  - G400
+  title: Ordered binary decision diagrams and the Shannon effect
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/360
+  userid: 1
+  volume: 142
+- abstract: "We prove matching lower and upper bounds on the worst-case OBDD size\t\
+    of a Boolean function, revealing an interesting ocillating behaviour."
+  bibtex: "@article{fu_mi_publications361,\n abstract = {We prove matching lower and\
+    \ upper bounds on the worst-case OBDD size        of a Boolean function, revealing\
+    \ an interesting ocillating behaviour.},\n author = {C. Gr{\\\"o}pl and H.-J.\
+    \ Pr{\\\"o}mel and A. Srivastav},\n journal = {Information Processing Letters},\n\
+    \ keywords = {Binary Decision Diagrams},\n pages = {1--7},\n title = {On the Evolution\
+    \ of the Worst-Case OBDD Size},\n url = {http://publications.imp.fu-berlin.de/361/},\n\
+    \ volume = {77},\n year = {2001}\n}\n\n"
+  creators:
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Pr\xF6mel"
+      given: H.-J.
+      honourific: null
+      lineage: null
+  - name:
+      family: Srivastav
+      given: A.
+      honourific: null
+      lineage: null
+  date: 2001
+  datestamp: '2009-04-14 14:40:13'
+  dir: disk0/00/00/03/61
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 361
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications361
+  keywords: Binary Decision Diagrams
+  lastmod: '2009-04-14 14:40:13'
+  metadata_visibility: show
+  pagerange: 1-7
+  publication: Information Processing Letters
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:04'
+  subjects:
+  - G400
+  title: On the Evolution of the Worst-Case OBDD Size
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/361
+  userid: 1
+  volume: 77
+- bibtex: "@incollection{fu_mi_publications363,\n author = {C. Gr{\\\"o}pl and M.\
+    \ Skutella},\n booktitle = {Lectures on Proof Verification and Approximation Algorithms},\n\
+    \ editor = {E. W. Mayr and H.-J. Pr{\\\"o}mel and A. Steger},\n keywords = {Theoretical\
+    \ computer science (other), Approximation algorithms, PCP and non-approximability},\n\
+    \ note = {The book grow out of a Dagstuhl Seminar, April 21-25, 1997},\n pages\
+    \ = {161--177},\n publisher = {Springer},\n series = {Lecture Notes in Computer\
+    \ Science},\n title = {Parallel Repetition of MIP(2,1) Systems},\n url = {http://publications.imp.fu-berlin.de/363/},\n\
+    \ volume = {1367},\n year = {1998}\n}\n\n"
+  book_title: Lectures on Proof Verification and Approximation Algorithms
+  creators:
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: Skutella
+      given: M.
+      honourific: null
+      lineage: null
+  date: 1998
+  datestamp: '2009-04-14 14:42:14'
+  dir: disk0/00/00/03/63
+  divisions:
+  - group_algbioinf
+  editors:
+  - name:
+      family: Mayr
+      given: E. W.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Pr\xF6mel"
+      given: H.-J.
+      honourific: null
+      lineage: null
+  - name:
+      family: Steger
+      given: A.
+      honourific: null
+      lineage: null
+  eprint_status: archive
+  eprintid: 363
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications363
+  keywords: "Theoretical computer science (other), Approximation algorithms, PCP\t\
+    and non-approximability"
+  lastmod: '2009-04-14 14:42:14'
+  metadata_visibility: show
+  note: The book grow out of a Dagstuhl Seminar, April 21-25, 1997
+  pagerange: 161-177
+  publisher: Springer
+  refereed: 'TRUE'
+  rev_number: 3
+  series: Lecture Notes in Computer Science
+  status_changed: '2009-03-11 11:27:05'
+  subjects:
+  - G400
+  title: Parallel Repetition of MIP(2,1) Systems
+  type: book_section
+  uri: http://publications.imp.fu-berlin.de/id/eprint/363
+  userid: 1
+  volume: 1367
+- bibtex: "@inproceedings{fu_mi_publications364,\n author = {A. L. Halpern and D.\
+    \ H. Huson and K. Reinert},\n booktitle = {Proceedings of the 2nd Workshop on\
+    \ Algorithms Bioinformatics (WABI-02)},\n pages = {126--139},\n title = {Segment\
+    \ Match refinment and applications},\n url = {http://publications.imp.fu-berlin.de/364/},\n\
+    \ year = {2002}\n}\n\n"
+  creators:
+  - name:
+      family: Halpern
+      given: A. L.
+      honourific: null
+      lineage: null
+  - name:
+      family: Huson
+      given: D. H.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: 2002
+  datestamp: '2017-03-03 14:40:14'
+  dir: disk0/00/00/03/64
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 364
+  event_title: Proceedings of the 2nd Workshop on Algorithms Bioinformatics (WABI-02)
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications364
+  lastmod: '2017-03-03 14:40:14'
+  metadata_visibility: show
+  pagerange: 126-139
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:06'
+  subjects:
+  - G400
+  title: Segment Match refinment and applications
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/364
+  userid: 1
+- bibtex: "@inproceedings{fu_mi_publications365,\n author = {D. H. Huson and A. L.\
+    \ Halpern and Z. Lai and E. W. Myers and K. Reinert and G. G. Sutton},\n booktitle\
+    \ = {Proceedings of the 1st Workshop on Algorithms Bioinformatics (WABI-01)},\n\
+    \ pages = {294--306},\n title = {Comparing Assemblies using Fragments and Mate-pairs},\n\
+    \ url = {http://publications.imp.fu-berlin.de/365/},\n year = {2001}\n}\n\n"
+  creators:
+  - name:
+      family: Huson
+      given: D. H.
+      honourific: null
+      lineage: null
+  - name:
+      family: Halpern
+      given: A. L.
+      honourific: null
+      lineage: null
+  - name:
+      family: Lai
+      given: Z.
+      honourific: null
+      lineage: null
+  - name:
+      family: Myers
+      given: E. W.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  - name:
+      family: Sutton
+      given: G. G.
+      honourific: null
+      lineage: null
+  date: 2001
+  datestamp: '2017-03-03 14:40:14'
+  dir: disk0/00/00/03/65
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 365
+  event_title: Proceedings of the 1st Workshop on Algorithms Bioinformatics (WABI-01)
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications365
+  lastmod: '2017-03-03 14:40:14'
+  metadata_visibility: show
+  pagerange: 294-306
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:06'
+  subjects:
+  - G400
+  title: Comparing Assemblies using Fragments and Mate-pairs
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/365
+  userid: 1
+- bibtex: "@inproceedings{fu_mi_publications366,\n author = {D. H. Huson and K. Reinert\
+    \ and S. A. Kravitz and K. A. Remington and A. L. Delcher and I. M. Dew and M.\
+    \ J. Flanigan and A. L. Halpern and Z. Lai and C. M. Mobarry and G. G. Sutton\
+    \ and E. W. Myers},\n booktitle = {Proceedings of the Ninth International Conference\
+    \ on Intelligent    Systems for Molecular Biology (ISMB-01)},\n pages = {132--139},\n\
+    \ title = {Design of a compartmentalized Shotgun Assembler for the Human Genome},\n\
+    \ url = {http://publications.imp.fu-berlin.de/366/},\n year = {2001}\n}\n\n"
+  creators:
+  - name:
+      family: Huson
+      given: D. H.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  - name:
+      family: Kravitz
+      given: S. A.
+      honourific: null
+      lineage: null
+  - name:
+      family: Remington
+      given: "K.\tA."
+      honourific: null
+      lineage: null
+  - name:
+      family: Delcher
+      given: A. L.
+      honourific: null
+      lineage: null
+  - name:
+      family: Dew
+      given: I. M.
+      honourific: null
+      lineage: null
+  - name:
+      family: Flanigan
+      given: M. J.
+      honourific: null
+      lineage: null
+  - name:
+      family: Halpern
+      given: A. L.
+      honourific: null
+      lineage: null
+  - name:
+      family: Lai
+      given: Z.
+      honourific: null
+      lineage: null
+  - name:
+      family: Mobarry
+      given: C. M.
+      honourific: null
+      lineage: null
+  - name:
+      family: Sutton
+      given: G. G.
+      honourific: null
+      lineage: null
+  - name:
+      family: Myers
+      given: E. W.
+      honourific: null
+      lineage: null
+  date: 2001
+  datestamp: '2017-03-03 14:40:14'
+  dir: disk0/00/00/03/66
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 366
+  event_title: "Proceedings of the Ninth International Conference on Intelligent\t\
+    Systems for Molecular Biology (ISMB-01)"
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications366
+  lastmod: '2017-03-03 14:40:14'
+  metadata_visibility: show
+  pagerange: 132-139
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:07'
+  subjects:
+  - G400
+  title: Design of a compartmentalized Shotgun Assembler for the Human Genome
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/366
+  userid: 1
+- bibtex: "@article{fu_mi_publications367,\n author = {D. H. Huson and K. Reinert\
+    \ and E. W. Myers},\n journal = {Journal of the ACM},\n number = {5},\n pages\
+    \ = {603--615},\n title = {The Greedy Path-Merging Algorithm for Sequence Assembly},\n\
+    \ url = {http://publications.imp.fu-berlin.de/367/},\n volume = {49},\n year =\
+    \ {2002}\n}\n\n"
+  creators:
+  - name:
+      family: Huson
+      given: D. H.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  - name:
+      family: Myers
+      given: E. W.
+      honourific: null
+      lineage: null
+  date: 2002
+  datestamp: '2017-03-03 14:40:14'
+  dir: disk0/00/00/03/67
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 367
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications367
+  lastmod: '2017-03-03 14:40:14'
+  metadata_visibility: show
+  number: 5
+  pagerange: 603-615
+  publication: Journal of the ACM
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:08'
+  subjects:
+  - G400
+  title: The Greedy Path-Merging Algorithm for Sequence Assembly
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/367
+  userid: 1
+  volume: 49
+- bibtex: "@inproceedings{fu_mi_publications368,\n author = {D. H. Huson and K. Reinert\
+    \ and E. W. Myers},\n booktitle = {Proceedings of the Fifth Annual International\
+    \ Conference on Computational   Molecular Biology (RECOMB-01)},\n pages = {157--163},\n\
+    \ title = {The Greedy Path-Merging Algorithm for Sequence Assembly},\n url = {http://publications.imp.fu-berlin.de/368/},\n\
+    \ year = {2001}\n}\n\n"
+  creators:
+  - name:
+      family: Huson
+      given: D. H.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  - name:
+      family: Myers
+      given: E. W.
+      honourific: null
+      lineage: null
+  date: 2001
+  datestamp: '2017-03-03 14:40:14'
+  dir: disk0/00/00/03/68
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 368
+  event_title: "Proceedings of the Fifth Annual International Conference on Computational\t\
+    Molecular Biology (RECOMB-01)"
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications368
+  lastmod: '2017-03-03 14:40:14'
+  metadata_visibility: show
+  pagerange: 157-163
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:08'
+  subjects:
+  - G400
+  title: The Greedy Path-Merging Algorithm for Sequence Assembly
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/368
+  userid: 1
+- bibtex: "@article{fu_mi_publications369,\n author = {S. Istrail and G. G. Sutton\
+    \ and L. Florea and C. M. Mobarry and R. Lippert and B. Walenz and H. Shatkay\
+    \ and Ian Dew and J. R. Miller and M. J. Flanigan and N. J. Edwards and R. Bolanos\
+    \ and D. Fasulo and B. V. Halldorsson and S. Hannenhalli and R. J. Turner and\
+    \ S. Yooseph and Fu Lu and D. R. Nusskern and B. C. Shue and X. H. Zheng and F.\
+    \ Zhong and A. L. Delcher and D. H. Huson and S. A. Kravitz and L. Mouchard and\
+    \ K. Reinert and K. A. Remington and A. G. Clark and M. S. Waterman and E. E.\
+    \ Eichler and M. D. Adams and M. W. Hunkapillar and E. W. Myers and J. C. Venter},\n\
+    \ journal = {Proceedings of the national academy of science (PNAS)},\n number\
+    \ = {7},\n pages = {1916--1921},\n title = {Whole-genome shotgun assembly and\
+    \ comparison of human genome assemblies},\n url = {http://publications.imp.fu-berlin.de/369/},\n\
+    \ volume = {101},\n year = {2004}\n}\n\n"
+  creators:
+  - name:
+      family: Istrail
+      given: S.
+      honourific: null
+      lineage: null
+  - name:
+      family: Sutton
+      given: G. G.
+      honourific: null
+      lineage: null
+  - name:
+      family: Florea
+      given: L.
+      honourific: null
+      lineage: null
+  - name:
+      family: Mobarry
+      given: C. M.
+      honourific: null
+      lineage: null
+  - name:
+      family: Lippert
+      given: R.
+      honourific: null
+      lineage: null
+  - name:
+      family: Walenz
+      given: B.
+      honourific: null
+      lineage: null
+  - name:
+      family: Shatkay
+      given: H.
+      honourific: null
+      lineage: null
+  - name:
+      family: Dew
+      given: Ian
+      honourific: null
+      lineage: null
+  - name:
+      family: Miller
+      given: J. R.
+      honourific: null
+      lineage: null
+  - name:
+      family: Flanigan
+      given: M. J.
+      honourific: null
+      lineage: null
+  - name:
+      family: Edwards
+      given: N. J.
+      honourific: null
+      lineage: null
+  - name:
+      family: Bolanos
+      given: R.
+      honourific: null
+      lineage: null
+  - name:
+      family: Fasulo
+      given: D.
+      honourific: null
+      lineage: null
+  - name:
+      family: Halldorsson
+      given: B. V.
+      honourific: null
+      lineage: null
+  - name:
+      family: Hannenhalli
+      given: S.
+      honourific: null
+      lineage: null
+  - name:
+      family: Turner
+      given: R. J.
+      honourific: null
+      lineage: null
+  - name:
+      family: Yooseph
+      given: S.
+      honourific: null
+      lineage: null
+  - name:
+      family: Lu
+      given: Fu
+      honourific: null
+      lineage: null
+  - name:
+      family: Nusskern
+      given: D. R.
+      honourific: null
+      lineage: null
+  - name:
+      family: Shue
+      given: B. C.
+      honourific: null
+      lineage: null
+  - name:
+      family: Zheng
+      given: X. H.
+      honourific: null
+      lineage: null
+  - name:
+      family: Zhong
+      given: F.
+      honourific: null
+      lineage: null
+  - name:
+      family: Delcher
+      given: A. L.
+      honourific: null
+      lineage: null
+  - name:
+      family: Huson
+      given: D. H.
+      honourific: null
+      lineage: null
+  - name:
+      family: Kravitz
+      given: S. A.
+      honourific: null
+      lineage: null
+  - name:
+      family: Mouchard
+      given: L.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  - name:
+      family: Remington
+      given: K. A.
+      honourific: null
+      lineage: null
+  - name:
+      family: Clark
+      given: A. G.
+      honourific: null
+      lineage: null
+  - name:
+      family: Waterman
+      given: M. S.
+      honourific: null
+      lineage: null
+  - name:
+      family: Eichler
+      given: E. E.
+      honourific: null
+      lineage: null
+  - name:
+      family: Adams
+      given: M. D.
+      honourific: null
+      lineage: null
+  - name:
+      family: Hunkapillar
+      given: M. W.
+      honourific: null
+      lineage: null
+  - name:
+      family: Myers
+      given: E. W.
+      honourific: null
+      lineage: null
+  - name:
+      family: Venter
+      given: J. C.
+      honourific: null
+      lineage: null
+  date: 2004
+  datestamp: '2017-03-03 14:40:14'
+  dir: disk0/00/00/03/69
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 369
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications369
+  lastmod: '2017-03-03 14:40:14'
+  metadata_visibility: show
+  number: 7
+  pagerange: 1916-1921
+  publication: Proceedings of the national academy of science (PNAS)
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:09'
+  subjects:
+  - G400
+  title: Whole-genome shotgun assembly and comparison of human genome assemblies
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/369
+  userid: 1
+  volume: 101
+- bibtex: "@article{fu_mi_publications370,\n author = {J. D. Kececioglu and H.-P.\
+    \ Lenhof and K. Mehlhorn and K. Reinert and M. Vingron},\n journal = {Discrete\
+    \ Applied Mathematics},\n pages = {143--186},\n title = {A Polyhedral Approach\
+    \ to Sequence Alignment Problems},\n url = {http://publications.imp.fu-berlin.de/370/},\n\
+    \ volume = {104},\n year = {2000}\n}\n\n"
+  creators:
+  - name:
+      family: Kececioglu
+      given: J. D.
+      honourific: null
+      lineage: null
+  - name:
+      family: Lenhof
+      given: H.-P.
+      honourific: null
+      lineage: null
+  - name:
+      family: Mehlhorn
+      given: K.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  - name:
+      family: Vingron
+      given: M.
+      honourific: null
+      lineage: null
+  date: 2000
+  datestamp: '2017-03-03 14:40:14'
+  dir: disk0/00/00/03/70
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 370
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications370
+  lastmod: '2017-03-03 14:40:14'
+  metadata_visibility: show
+  pagerange: 143-186
+  publication: Discrete Applied Mathematics
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:10'
+  subjects:
+  - G400
+  title: A Polyhedral Approach to Sequence Alignment Problems
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/370
+  userid: 1
+  volume: 104
+- bibtex: "@article{fu_mi_publications371,\n author = {G. W. Klau and S. Rahmann and\
+    \ A. Schliep and M. Vingron and K. Reinert},\n journal = {Discrete Applied Mathematics},\n\
+    \ pages = {840--856},\n title = {Integer Linear Programming Approaches for Non-unique\
+    \ Probe Selection},\n url = {http://publications.imp.fu-berlin.de/371/},\n volume\
+    \ = {155},\n year = {2007}\n}\n\n"
+  creators:
+  - name:
+      family: Klau
+      given: G. W.
+      honourific: null
+      lineage: null
+  - name:
+      family: Rahmann
+      given: S.
+      honourific: null
+      lineage: null
+  - name:
+      family: Schliep
+      given: A.
+      honourific: null
+      lineage: null
+  - name:
+      family: Vingron
+      given: M.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: 2007
+  datestamp: '2017-03-03 14:40:14'
+  dir: disk0/00/00/03/71
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 371
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications371
+  lastmod: '2017-03-03 14:40:14'
+  metadata_visibility: show
+  pagerange: 840-856
+  publication: Discrete Applied Mathematics
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:10'
+  subjects:
+  - G400
+  title: Integer Linear Programming Approaches for Non-unique Probe Selection
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/371
+  userid: 1
+  volume: 155
+- bibtex: "@inproceedings{fu_mi_publications372,\n author = {G. W. Klau and S. Rahmann\
+    \ and A. Schliep and K. Reinert},\n booktitle = {Proceedings of the Twelfth International\
+    \ Conference on Intelligent  Systems for Molecular Biology (ISMB-04)},\n pages\
+    \ = {186--193},\n title = {Optimal Robust Non-Unique Probe Selection Using Integer\
+    \ Linear Programming},\n url = {http://publications.imp.fu-berlin.de/372/},\n\
+    \ year = {2004}\n}\n\n"
+  creators:
+  - name:
+      family: Klau
+      given: G. W.
+      honourific: null
+      lineage: null
+  - name:
+      family: Rahmann
+      given: S.
+      honourific: null
+      lineage: null
+  - name:
+      family: Schliep
+      given: A.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: 2004
+  datestamp: '2017-03-03 14:40:14'
+  dir: disk0/00/00/03/72
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 372
+  event_title: "Proceedings of the Twelfth International Conference on Intelligent\t\
+    Systems for Molecular Biology (ISMB-04)"
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications372
+  lastmod: '2017-03-03 14:40:14'
+  metadata_visibility: show
+  pagerange: 186-193
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:11'
+  subjects:
+  - G400
+  title: Optimal Robust Non-Unique Probe Selection Using Integer Linear Programming
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/372
+  userid: 1
+- bibtex: "@article{fu_mi_publications373,\n author = {C. L. Klein and O. Kohlbacher\
+    \ and K. Reinert},\n journal = {FEBS Journal},\n number = {Supplement 1},\n pages\
+    \ = {490--504},\n title = {Reference methods and materials in standardisation\
+    \ and quality assurance    (abstract)},\n url = {http://publications.imp.fu-berlin.de/373/},\n\
+    \ volume = {272},\n year = {2005}\n}\n\n"
+  creators:
+  - name:
+      family: Klein
+      given: C. L.
+      honourific: null
+      lineage: null
+  - name:
+      family: Kohlbacher
+      given: O.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: 2005
+  datestamp: '2017-03-03 14:40:14'
+  dir: disk0/00/00/03/73
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 373
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications373
+  lastmod: '2017-03-03 14:40:14'
+  metadata_visibility: show
+  number: Supplement 1
+  pagerange: 490-504
+  publication: FEBS Journal
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:11'
+  subjects:
+  - G400
+  title: "Reference methods and materials in standardisation and quality assurance\t\
+    (abstract)"
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/373
+  userid: 1
+  volume: 272
+- bibtex: "@article{fu_mi_publications374,\n author = {O. Kohlbacher and K. Reinert},\n\
+    \ journal = {it -- Information technology},\n pages = {31--38},\n title = {Differenzielle\
+    \ Proteomanalyse -- Experimentelle Methoden, Algorithmische    Herausforderungen},\n\
+    \ url = {http://publications.imp.fu-berlin.de/374/},\n volume = {46},\n year =\
+    \ {2004}\n}\n\n"
+  creators:
+  - name:
+      family: Kohlbacher
+      given: O.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: 2004
+  datestamp: '2017-03-03 14:40:14'
+  dir: disk0/00/00/03/74
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 374
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications374
+  lastmod: '2017-03-03 14:40:14'
+  metadata_visibility: show
+  pagerange: 31-38
+  publication: it -- Information technology
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:12'
+  subjects:
+  - G400
+  title: "Differenzielle Proteomanalyse -- Experimentelle Methoden, Algorithmische\t\
+    Herausforderungen"
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/374
+  userid: 1
+  volume: 46
+- abstract: "Motivation: Experimental techniques in proteomics have seen rapid\tdevelopment\
+    \ over the last few years. Volume and complexity of the\r\n\tdata have both been\
+    \ growing at a similar rate. Accordingly, data\r\n\tmanagement and analysis are\
+    \ one of the major challenges in proteomics.\r\n\tFlexible algorithms are required\
+    \ to handle changing experimental\r\n\tsetups and to assist in developing and\
+    \ validating new methods. In\r\n\torder to facilitate these studies, it would\
+    \ be desirable to have\r\n\ta flexible `toolbox' of versatile and user-friendly\
+    \ applications\r\n\tallowing for rapid construction of computational workflows\
+    \ in proteomics.\r\n\tResults: We describe a set of tools for proteomics data\
+    \ analysis\r\n\t-- TOPP, The OpenMS Proteomics Pipeline. TOPP provides a set of\
+    \ computational\r\n\ttools which can be easily combined into analysis pipelines\
+    \ even by\r\n\tnon-experts and can be used in proteomics workflows. These applications\r\
+    \n\trange from useful utilities (file format conversion, peak picking)\r\n\tover\
+    \ wrapper applications for known applications (e.g. Mascot) to\r\n\tcompletely\
+    \ new algorithmic techniques for data reduction and data\r\n\tanalysis. We anticipate\
+    \ that TOPP will greatly facilitate rapid prototyping\r\n\tof proteomics data\
+    \ evaluation pipelines. As such, we describe the\r\n\tbasic concepts and the current\
+    \ abilities of TOPP and illustrate these\r\n\tconcepts in the context of two example\
+    \ applications: the identification\r\n\tof peptides from a raw data set through\
+    \ database search and the complex\r\n\tanalysis of a standard addition experiment\
+    \ for the absolute quantitation\r\n\tof biomarkers. The latter example demonstrates\
+    \ TOPP's ability to\r\n\tconstruct flexible analysis pipelines in support of complex\
+    \ experimental\r\n\tsetups. Availability: The TOPP components are available as\
+    \ open-source\r\n\tsoftware under the lesser GNU public license (LGPL). Source\
+    \ code\r\n\tis available from the project web site at www.OpenMS.de"
+  bibtex: "@inproceedings{fu_mi_publications375,\n abstract = {Motivation: Experimental\
+    \ techniques in proteomics have seen rapid   development over the last few years.\
+    \ Volume and complexity of the\ndata have both been growing at a similar rate.\
+    \ Accordingly, data\nmanagement and analysis are one of the major challenges in\
+    \ proteomics.\nFlexible algorithms are required to handle changing experimental\n\
+    setups and to assist in developing and validating new methods. In\norder to facilitate\
+    \ these studies, it would be desirable to have\na flexible `toolbox' of versatile\
+    \ and user-friendly applications\nallowing for rapid construction of computational\
+    \ workflows in proteomics.\nResults: We describe a set of tools for proteomics\
+    \ data analysis\n-- TOPP, The OpenMS Proteomics Pipeline. TOPP provides a set\
+    \ of computational\ntools which can be easily combined into analysis pipelines\
+    \ even by\nnon-experts and can be used in proteomics workflows. These applications\n\
+    range from useful utilities (file format conversion, peak picking)\nover wrapper\
+    \ applications for known applications (e.g. Mascot) to\ncompletely new algorithmic\
+    \ techniques for data reduction and data\nanalysis. We anticipate that TOPP will\
+    \ greatly facilitate rapid prototyping\nof proteomics data evaluation pipelines.\
+    \ As such, we describe the\nbasic concepts and the current abilities of TOPP and\
+    \ illustrate these\nconcepts in the context of two example applications: the identification\n\
+    of peptides from a raw data set through database search and the complex\nanalysis\
+    \ of a standard addition experiment for the absolute quantitation\nof biomarkers.\
+    \ The latter example demonstrates TOPP's ability to\nconstruct flexible analysis\
+    \ pipelines in support of complex experimental\nsetups. Availability: The TOPP\
+    \ components are available as open-source\nsoftware under the lesser GNU public\
+    \ license (LGPL). Source code\nis available from the project web site at www.OpenMS.de},\n\
+    \ author = {O. Kohlbacher and K. Reinert and C. Gr{\\\"o}pl and E. Lange and N.\
+    \ Pfeiffer and O. Schulz-Trieglaff and M. Sturm},\n booktitle = {Proceedings of\
+    \ the 5th European Conference on Computational Biology (ECCB 2006)},\n title =\
+    \ {TOPP - The OpenMS Proteomics Pipeline},\n url = {http://publications.imp.fu-berlin.de/375/},\n\
+    \ year = {2006}\n}\n\n"
+  creators:
+  - name:
+      family: Kohlbacher
+      given: O.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: Lange
+      given: E.
+      honourific: null
+      lineage: null
+  - name:
+      family: Pfeiffer
+      given: N.
+      honourific: null
+      lineage: null
+  - name:
+      family: Schulz-Trieglaff
+      given: O.
+      honourific: null
+      lineage: null
+  - name:
+      family: Sturm
+      given: M.
+      honourific: null
+      lineage: null
+  date: 2006
+  datestamp: '2009-04-14 14:25:23'
+  dir: disk0/00/00/03/75
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 375
+  event_title: "Proceedings of the 5th European Conference on Computational Biology\t\
+    (ECCB 2006)"
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications375
+  lastmod: '2009-04-14 14:25:23'
+  metadata_visibility: show
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:12'
+  subjects:
+  - G400
+  title: TOPP - The OpenMS Proteomics Pipeline
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/375
+  userid: 1
+- bibtex: "@inproceedings{fu_mi_publications376,\n author = {E. Lange and C. Gr{\\\
+    \"o}pl and K. Reinert and A. Hildebrandt},\n booktitle = {Proceedings of the 11th\
+    \ Pacific Symposium on Biocomputing (PSB-06)},\n pages = {243--254},\n title =\
+    \ {High Accuracy Peak-Picking of Proteomics Data using Wavelet Techniques},\n\
+    \ url = {http://publications.imp.fu-berlin.de/376/},\n year = {2006}\n}\n\n"
+  creators:
+  - name:
+      family: Lange
+      given: E.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  - name:
+      family: Hildebrandt
+      given: A.
+      honourific: null
+      lineage: null
+  date: 2006
+  datestamp: '2009-04-14 14:22:41'
+  dir: disk0/00/00/03/76
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 376
+  event_title: Proceedings of the 11th Pacific Symposium on Biocomputing (PSB-06)
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications376
+  lastmod: '2009-04-14 14:22:41'
+  metadata_visibility: show
+  pagerange: 243-254
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:13'
+  subjects:
+  - G400
+  title: High Accuracy Peak-Picking of Proteomics Data using Wavelet Techniques
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/376
+  userid: 1
+- bibtex: "@inproceedings{fu_mi_publications377,\n author = {E. Lange and C. Gr{\\\
+    \"o}pl and K. Reinert and A. Hildebrandt},\n booktitle = {Computational Proteomics},\n\
+    \ note = {Extended abstract for talk given at Dagstuhl Seminar 05471 on Computational\
+    \ Proteomics, 20.-25. November 2005},\n publisher = {Dagstuhl Online Publication\
+    \ Server (DROPS)},\n title = {High-accuracy peak picking of proteomics data},\n\
+    \ url = {http://publications.imp.fu-berlin.de/377/},\n year = {2005}\n}\n\n"
+  creators:
+  - name:
+      family: Lange
+      given: E.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  - name:
+      family: Hildebrandt
+      given: A.
+      honourific: null
+      lineage: null
+  date: 2005
+  datestamp: '2009-04-14 14:33:24'
+  dir: disk0/00/00/03/77
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 377
+  event_title: Computational Proteomics
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications377
+  lastmod: '2009-04-14 14:33:24'
+  metadata_visibility: show
+  note: "Extended abstract for talk given at Dagstuhl Seminar 05471 on Computational\t\
+    Proteomics, 20.-25. November 2005"
+  official_url: http://www.dagstuhl.de/05471/
+  publisher: Dagstuhl Online Publication Server (DROPS)
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:14'
+  subjects:
+  - G400
+  title: High-accuracy peak picking of proteomics data
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/377
+  userid: 1
+- bibtex: "@article{fu_mi_publications379,\n author = {E. Lange and R. Tautenhahn\
+    \ and S. Neumann and C. Gr{\\\"o}pl},\n journal = {BMC Bioinformatics},\n number\
+    \ = {375},\n title = {Critical assessment of alignment procedures for LC-MS proteomics\
+    \    and metabolomic measurements},\n url = {http://publications.imp.fu-berlin.de/379/},\n\
+    \ volume = {9},\n year = {2008}\n}\n\n"
+  creators:
+  - name:
+      family: Lange
+      given: E.
+      honourific: null
+      lineage: null
+  - name:
+      family: Tautenhahn
+      given: R.
+      honourific: null
+      lineage: null
+  - name:
+      family: Neumann
+      given: S.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  date: 2008
+  datestamp: '2009-04-14 14:12:16'
+  dir: disk0/00/00/03/79
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 379
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications379
+  lastmod: '2009-04-14 14:12:16'
+  metadata_visibility: show
+  number: 375
+  official_url: http://www.biomedcentral.com/1471-2105/9/375
+  publication: BMC Bioinformatics
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:15'
+  subjects:
+  - G400
+  title: "Critical assessment of alignment procedures for LC-MS proteomics\tand metabolomic\
+    \ measurements"
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/379
+  userid: 1
+  volume: 9
+- bibtex: "@inproceedings{fu_mi_publications380,\n author = {H.-P. Lenhof and K. Reinert\
+    \ and M. Vingron},\n booktitle = {Proceedings of the Second Annual International\
+    \ Conference on Computational  Molecular Biology (RECOMB-98)},\n pages = {153--162},\n\
+    \ title = {A polyhedral approach to RNA sequence structure alignment},\n url =\
+    \ {http://publications.imp.fu-berlin.de/380/},\n year = {1998}\n}\n\n"
+  creators:
+  - name:
+      family: Lenhof
+      given: H.-P.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  - name:
+      family: Vingron
+      given: M.
+      honourific: null
+      lineage: null
+  date: 1998
+  datestamp: '2010-11-02 13:46:49'
+  dir: disk0/00/00/03/80
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 380
+  event_title: "Proceedings of the Second Annual International Conference on Computational\t\
+    Molecular Biology (RECOMB-98)"
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications380
+  lastmod: '2010-11-02 13:46:56'
+  metadata_visibility: show
+  pagerange: 153-162
+  refereed: 'TRUE'
+  rev_number: 5
+  status_changed: '2010-11-02 13:46:56'
+  subjects:
+  - G400
+  title: A polyhedral approach to RNA sequence structure alignment
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/380
+  userid: 1
+- bibtex: "@article{fu_mi_publications381,\n author = {H.-P. Lenhof and B. Morgenstern\
+    \ and K. Reinert},\n journal = {BIOINFORMATICS},\n number = {3},\n pages = {203--210},\n\
+    \ title = {An exact solution for the segment-to-segment multiple sequence alignment\
+    \    problem},\n url = {http://publications.imp.fu-berlin.de/381/},\n volume =\
+    \ {15},\n year = {1999}\n}\n\n"
+  creators:
+  - name:
+      family: Lenhof
+      given: H.-P.
+      honourific: null
+      lineage: null
+  - name:
+      family: Morgenstern
+      given: B.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: 1999
+  datestamp: '2017-03-03 14:40:14'
+  dir: disk0/00/00/03/81
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 381
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications381
+  lastmod: '2017-03-03 14:40:14'
+  metadata_visibility: show
+  number: 3
+  pagerange: 203-210
+  publication: BIOINFORMATICS
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:16'
+  subjects:
+  - G400
+  title: "An exact solution for the segment-to-segment multiple sequence alignment\t\
+    problem"
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/381
+  userid: 1
+  volume: 15
+- bibtex: "@article{fu_mi_publications382,\n author = {H.-P. Lenhof and K. Reinert\
+    \ and M. Vingron},\n journal = {Journal of Computational Biology},\n number =\
+    \ {3},\n pages = {517--530},\n title = {A Polyhedral Approach to RNA Sequence\
+    \ Structure Alignment},\n url = {http://publications.imp.fu-berlin.de/382/},\n\
+    \ volume = {5},\n year = {1998}\n}\n\n"
+  creators:
+  - name:
+      family: Lenhof
+      given: H.-P.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  - name:
+      family: Vingron
+      given: M.
+      honourific: null
+      lineage: null
+  date: 1998
+  datestamp: '2017-03-03 14:40:14'
+  dir: disk0/00/00/03/82
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 382
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications382
+  lastmod: '2017-03-03 14:40:14'
+  metadata_visibility: show
+  number: 3
+  pagerange: 517-530
+  publication: Journal of Computational Biology
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:16'
+  subjects:
+  - G400
+  title: A Polyhedral Approach to RNA Sequence Structure Alignment
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/382
+  userid: 1
+  volume: 5
+- bibtex: "@article{fu_mi_publications383,\n author = {M. Lermen and K. Reinert},\n\
+    \ journal = {Journal of Computational Biology},\n pages = {655--671},\n title\
+    \ = {The Practical Use of the A* Algorithm for Exact Multiple Sequence   Alignment},\n\
+    \ url = {http://publications.imp.fu-berlin.de/383/},\n year = {2000}\n}\n\n"
+  creators:
+  - name:
+      family: Lermen
+      given: M.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: 2000
+  datestamp: '2017-03-03 14:40:14'
+  dir: disk0/00/00/03/83
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 383
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications383
+  lastmod: '2017-03-03 14:40:14'
+  metadata_visibility: show
+  pagerange: 655-671
+  publication: Journal of Computational Biology
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:17'
+  subjects:
+  - G400
+  title: "The Practical Use of the A* Algorithm for Exact Multiple Sequence\tAlignment"
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/383
+  userid: 1
+- bibtex: "@inproceedings{fu_mi_publications384,\n author = {P. May and G. W. Klau\
+    \ and M. Bauer and T. Steinke},\n booktitle = {Proc. of GCCB 2006},\n pages =\
+    \ {19--32},\n series = {LNBI},\n title = {Accelerated microRNA Precursor Detection\
+    \ Using the Smith-Waterman   Algorithm on FPGAs},\n url = {http://publications.imp.fu-berlin.de/384/},\n\
+    \ volume = {4360},\n year = {2007}\n}\n\n"
+  creators:
+  - name:
+      family: May
+      given: P.
+      honourific: null
+      lineage: null
+  - name:
+      family: Klau
+      given: G. W.
+      honourific: null
+      lineage: null
+  - name:
+      family: Bauer
+      given: M.
+      honourific: null
+      lineage: null
+  - name:
+      family: Steinke
+      given: T.
+      honourific: null
+      lineage: null
+  date: 2007
+  datestamp: '2017-03-03 14:40:14'
+  dir: disk0/00/00/03/84
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 384
+  event_title: Proc. of GCCB 2006
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications384
+  lastmod: '2017-03-03 14:40:14'
+  metadata_visibility: show
+  pagerange: 19-32
+  refereed: 'TRUE'
+  rev_number: 3
+  series: LNBI
+  status_changed: '2009-03-11 11:27:17'
+  subjects:
+  - G400
+  title: "Accelerated microRNA Precursor Detection Using the Smith-Waterman\tAlgorithm\
+    \ on FPGAs"
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/384
+  userid: 1
+  volume: 4360
+- bibtex: "@article{fu_mi_publications385,\n author = {B. M. Mayr and O. Kohlbacher\
+    \ and K. Reinert and C. Gr{\\\"o}pl and E. Lange and C. L. Klein and Ch. Huber},\n\
+    \ journal = {Journal of Proteome Research},\n pages = {414--421},\n title = {Absolute\
+    \ Myoglobin Quantitation in Serum by Combining Two-Dimensional       Liquid Chromatography-Electrospray\
+    \ Ionization Mass Spectrometry and\nNovel Data Analysis Algorithms},\n url = {http://publications.imp.fu-berlin.de/385/},\n\
+    \ volume = {5},\n year = {2006}\n}\n\n"
+  creators:
+  - name:
+      family: Mayr
+      given: B. M.
+      honourific: null
+      lineage: null
+  - name:
+      family: Kohlbacher
+      given: O.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: Lange
+      given: E.
+      honourific: null
+      lineage: null
+  - name:
+      family: Klein
+      given: C. L.
+      honourific: null
+      lineage: null
+  - name:
+      family: Huber
+      given: Ch.
+      honourific: null
+      lineage: null
+  date: 2006
+  datestamp: '2009-04-14 14:21:42'
+  dir: disk0/00/00/03/85
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 385
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications385
+  lastmod: '2009-04-14 14:21:42'
+  metadata_visibility: show
+  pagerange: 414-421
+  publication: Journal of Proteome Research
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:18'
+  subjects:
+  - G400
+  title: "Absolute Myoglobin Quantitation in Serum by Combining Two-Dimensional\t\
+    Liquid Chromatography-Electrospray Ionization Mass Spectrometry and\r\n\tNovel\
+    \ Data Analysis Algorithms"
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/385
+  userid: 1
+  volume: 5
+- bibtex: "@misc{fu_mi_publications386,\n author = {Ch. Meier},\n month = {June},\n\
+    \ note = {Der Artikel eines freien Medienjournalisten beschreibt den Einsatz \
+    \ von OpenMS in der Proteomik},\n title = {Bioinformatik: Aktuelle Proteinausstattung\
+    \ erlaubt Aussagen {\\\"u}ber den Gesundheitszustand. Software hilft {\\\"A}rzten\
+    \ k{\\\"u}nftig\nbei der Diagnose.},\n url = {http://publications.imp.fu-berlin.de/386/},\n\
+    \ year = {2007}\n}\n\n"
+  creators:
+  - name:
+      family: Meier
+      given: Ch.
+      honourific: null
+      lineage: null
+  date: 2007-06
+  datestamp: '2017-03-03 14:40:14'
+  dir: disk0/00/00/03/86
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 386
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications386
+  lastmod: '2017-03-03 14:40:14'
+  metadata_visibility: show
+  note: "Der Artikel eines freien Medienjournalisten beschreibt den Einsatz\tvon OpenMS\
+    \ in der Proteomik"
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:18'
+  subjects:
+  - G400
+  title: "Bioinformatik: Aktuelle Proteinausstattung erlaubt Aussagen\t\xFCber den\
+    \ Gesundheitszustand. Software hilft \xC4rzten k\xFCnftig\n\tbei der Diagnose."
+  type: other
+  uri: http://publications.imp.fu-berlin.de/id/eprint/386
+  userid: 1
+- abstract: The high degree of similarity between the mouse and human genomes is demonstrated
+    through analysis of the sequence of mouse chromosome 16 (Mmu 16), which was obtained
+    as part of a whole-genome shotgun assembly of the mouse genome. The mouse genome
+    is about 10% smaller than the human genome, owing to a lower repetitive DNA content.
+    Comparison of the structure and protein-coding potential of Mmu 16 with that of
+    the homologous segments of the human genome identifies regions of conserved synteny
+    with human chromosomes (Hsa) 3, 8, 12, 16, 21, and 22. Gene content and order
+    are highly conserved between Mmu 16 and the syntenic blocks of the human genome.
+    Of the 731 predicted genes on Mmu 16, 509 align with orthologs on the corre- sponding
+    portions of the human genome, 44 are likely paralogous to these genes, and 164
+    genes have homologs elsewhere in the human genome; there are 14 genes for which
+    we could find no human counterpart.
+  bibtex: "@article{fu_mi_publications387,\n abstract = {The high degree of similarity\
+    \ between the mouse and human genomes is demonstrated through analysis of the\
+    \ sequence of mouse chromosome 16 (Mmu 16), which was obtained as part of a whole-genome\
+    \ shotgun assembly of the mouse genome. The mouse genome is about 10\\% smaller\
+    \ than the human genome, owing to a lower repetitive DNA content. Comparison of\
+    \ the structure and protein-coding potential of Mmu 16 with that of the homologous\
+    \ segments of the human genome identifies regions of conserved synteny with human\
+    \ chromosomes (Hsa) 3, 8, 12, 16, 21, and 22. Gene content and order are highly\
+    \ conserved between Mmu 16 and the syntenic blocks of the human genome. Of the\
+    \ 731 predicted genes on Mmu 16, 509 align with orthologs on the corre- sponding\
+    \ portions of the human genome, 44 are likely paralogous to these genes, and 164\
+    \ genes have homologs elsewhere in the human genome; there are 14 genes for which\
+    \ we could find no human counterpart.},\n author = {Richard Mural and M. D. Adams\
+    \ and K. Reinert},\n journal = {Science},\n pages = {1661--1671},\n title = {A\
+    \ Comparison of Whole-Genome Shotgun-Derived Mouse Chromosome 16    and the Human\
+    \ Genome},\n url = {http://publications.imp.fu-berlin.de/387/},\n volume = {296},\n\
+    \ year = {2002}\n}\n\n"
+  creators:
+  - name:
+      family: Mural
+      given: Richard
+      honourific: null
+      lineage: null
+  - name:
+      family: Adams
+      given: M. D.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: 2002
+  datestamp: '2009-11-24 15:48:00'
+  dir: disk0/00/00/03/87
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 387
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications387
+  lastmod: '2009-11-24 15:49:20'
+  metadata_visibility: show
+  pagerange: 1661-1671
+  publication: Science
+  refereed: 'TRUE'
+  rev_number: 4
+  status_changed: '2009-03-11 11:27:19'
+  subjects:
+  - G400
+  title: "A Comparison of Whole-Genome Shotgun-Derived Mouse Chromosome 16\tand the\
+    \ Human Genome"
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/387
+  userid: 1
+  volume: 296
+- bibtex: "@article{fu_mi_publications388,\n author = {E. W. Myers and G. G. Sutton\
+    \ and A. L. Delcher and D. P. Dew and M. J. Flanigan and S. A. Kravitz and C.\
+    \ M. Mobarry and K. Reinert and K. A. Remington and E. L. Anson and R. Bolanos\
+    \ and H.-H. Chou and C. M. Jordan and A. L. Halpern and S. Lonardi and E. M. Beasly\
+    \ and R. C. Brandon and L. Chen and P. J. Dunn and Z. Lai and Y. Liang and D.\
+    \ R. Nusskern and M. Zhan and Q. Zhang and X. H. Zheng and G. M. Rubin and M.\
+    \ D. Adams and J. C. Venter},\n journal = {Science},\n keywords = {ASSEMBLY},\n\
+    \ number = {5461},\n pages = {2196--2203},\n title = {A Whole-Genome Assembly\
+    \ of Drosophila},\n url = {http://publications.imp.fu-berlin.de/388/},\n volume\
+    \ = {287},\n year = {2000}\n}\n\n"
+  creators:
+  - name:
+      family: Myers
+      given: E. W.
+      honourific: null
+      lineage: null
+  - name:
+      family: Sutton
+      given: G. G.
+      honourific: null
+      lineage: null
+  - name:
+      family: Delcher
+      given: A. L.
+      honourific: null
+      lineage: null
+  - name:
+      family: Dew
+      given: D. P.
+      honourific: null
+      lineage: null
+  - name:
+      family: Flanigan
+      given: M. J.
+      honourific: null
+      lineage: null
+  - name:
+      family: Kravitz
+      given: S. A.
+      honourific: null
+      lineage: null
+  - name:
+      family: Mobarry
+      given: C. M.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  - name:
+      family: Remington
+      given: K. A.
+      honourific: null
+      lineage: null
+  - name:
+      family: Anson
+      given: E. L.
+      honourific: null
+      lineage: null
+  - name:
+      family: Bolanos
+      given: R.
+      honourific: null
+      lineage: null
+  - name:
+      family: Chou
+      given: H.-H.
+      honourific: null
+      lineage: null
+  - name:
+      family: Jordan
+      given: C. M.
+      honourific: null
+      lineage: null
+  - name:
+      family: Halpern
+      given: A. L.
+      honourific: null
+      lineage: null
+  - name:
+      family: Lonardi
+      given: S.
+      honourific: null
+      lineage: null
+  - name:
+      family: Beasly
+      given: E. M.
+      honourific: null
+      lineage: null
+  - name:
+      family: Brandon
+      given: R. C.
+      honourific: null
+      lineage: null
+  - name:
+      family: Chen
+      given: L.
+      honourific: null
+      lineage: null
+  - name:
+      family: Dunn
+      given: P. J.
+      honourific: null
+      lineage: null
+  - name:
+      family: Lai
+      given: Z.
+      honourific: null
+      lineage: null
+  - name:
+      family: Liang
+      given: Y.
+      honourific: null
+      lineage: null
+  - name:
+      family: Nusskern
+      given: D. R.
+      honourific: null
+      lineage: null
+  - name:
+      family: Zhan
+      given: M.
+      honourific: null
+      lineage: null
+  - name:
+      family: Zhang
+      given: Q.
+      honourific: null
+      lineage: null
+  - name:
+      family: Zheng
+      given: X. H.
+      honourific: null
+      lineage: null
+  - name:
+      family: Rubin
+      given: G. M.
+      honourific: null
+      lineage: null
+  - name:
+      family: Adams
+      given: M. D.
+      honourific: null
+      lineage: null
+  - name:
+      family: Venter
+      given: J. C.
+      honourific: null
+      lineage: null
+  date: 2000
+  datestamp: '2009-04-03 12:23:26'
+  dir: disk0/00/00/03/88
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 388
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications388
+  keywords: ASSEMBLY
+  lastmod: '2009-04-03 12:23:26'
+  metadata_visibility: show
+  number: 5461
+  pagerange: 2196-2203
+  publication: Science
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:20'
+  subjects:
+  - G400
+  title: A Whole-Genome Assembly of Drosophila
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/388
+  userid: 1
+  volume: 287
+- bibtex: "@unpublished{fu_mi_publications389,\n author = {T. Rausch},\n month = {September},\n\
+    \ school = {Hasso-Plattner-Institut f{\\\"u}r Softwaresystemtechnik GmbH, Universit{\\\
+    \"a}t Potsdam},\n title = {Discovering causes of multifactorial diseases},\n url\
+    \ = {http://publications.imp.fu-berlin.de/389/},\n year = {2006}\n}\n\n"
   creators:
   - name:
       family: Rausch
-      honourific:
       given: T.
-      lineage:
+      honourific: null
+      lineage: null
+  date: 2006-09
+  datestamp: '2017-03-03 14:40:14'
+  dir: disk0/00/00/03/89
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 389
+  full_text_status: none
+  institution: "Hasso-Plattner-Institut f\xFCr Softwaresystemtechnik GmbH, Universit\xE4\
+    t\tPotsdam"
+  ispublished: unpub
+  item_issues_count: 0
+  key: fu_mi_publications389
+  lastmod: '2017-03-03 14:40:14'
+  metadata_visibility: show
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:20'
+  subjects:
+  - G400
+  thesis_type: masters
+  title: Discovering causes of multifactorial diseases
+  type: thesis
+  uri: http://publications.imp.fu-berlin.de/id/eprint/389
+  userid: 1
+- bibtex: "@article{fu_mi_publications390,\n author = {T. Rausch and A.-K. Emde and\
+    \ K. Reinert},\n journal = {BMC Bioinformatics},\n number = {Suppl 10},\n pages\
+    \ = {P4},\n title = {Robust consensus computation},\n url = {http://publications.imp.fu-berlin.de/390/},\n\
+    \ volume = {9},\n year = {2008}\n}\n\n"
+  creators:
+  - name:
+      family: Rausch
+      given: T.
+      honourific: null
+      lineage: null
   - name:
       family: Emde
-      honourific:
       given: A.-K.
-      lineage:
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: 2008
+  datestamp: '2010-09-01 13:10:01'
+  dir: disk0/00/00/03/90
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 390
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications390
+  lastmod: '2010-09-01 13:10:01'
+  metadata_visibility: show
+  number: Suppl 10
+  pagerange: P4
+  publication: BMC Bioinformatics
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:21'
+  subjects:
+  - G400
+  title: Robust consensus computation
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/390
+  userid: 1
+  volume: 9
+- abstract: "Motivation: Many multiple sequence alignment tools have been developed\t\
+    in the past, progressing either in speed or alignment accuracy. Given\r\n\tthe\
+    \ importance and wide-spread use of alignment tools, progress in\r\n\tboth categories\
+    \ is a contribution to the community and has driven\r\n\tresearch in the field\
+    \ so far. Results: We introduce a graph-based\r\n\textension to the consistency-based,\
+    \ progressive alignment strategy.\r\n\tWe apply the consistency notion to segments\
+    \ instead of single characters.\r\n\tThe main problem we solve in this context\
+    \ is to define segments of\r\n\tthe sequences in such a way that a graph-based\
+    \ alignment is possible.\r\n\tWe implemented the algorithm using the SeqAn library\
+    \ and report results\r\n\ton amino acid and DNA sequences. The benefit of our\
+    \ approach is threefold:\r\n\t(1) sequences with conserved blocks can be rapidly\
+    \ aligned, (2) the\r\n\timplementation is conceptually easy, generic and fast\
+    \ and (3) the\r\n\tconsistency idea can be extended to align multiple genomic\
+    \ sequences.\r\n\tAvailability: The segment-based multiple sequence alignment\
+    \ tool\r\n\tcan be downloaded from http://www.seqan.de/projects/msa.html. A novel\r\
+    \n\tversion of T-Coffee interfaced with the tool is available from http://www.tcoffee.org.\r\
+    \n\tThe usage of the tool is described in both documentations. Contact:\r\n\t\
+    rausch@inf.fu-berlin.de"
+  bibtex: "@article{fu_mi_publications391,\n abstract = {Motivation: Many multiple\
+    \ sequence alignment tools have been developed      in the past, progressing either\
+    \ in speed or alignment accuracy. Given\nthe importance and wide-spread use of\
+    \ alignment tools, progress in\nboth categories is a contribution to the community\
+    \ and has driven\nresearch in the field so far. Results: We introduce a graph-based\n\
+    extension to the consistency-based, progressive alignment strategy.\nWe apply\
+    \ the consistency notion to segments instead of single characters.\nThe main problem\
+    \ we solve in this context is to define segments of\nthe sequences in such a way\
+    \ that a graph-based alignment is possible.\nWe implemented the algorithm using\
+    \ the SeqAn library and report results\non amino acid and DNA sequences. The benefit\
+    \ of our approach is threefold:\n(1) sequences with conserved blocks can be rapidly\
+    \ aligned, (2) the\nimplementation is conceptually easy, generic and fast and\
+    \ (3) the\nconsistency idea can be extended to align multiple genomic sequences.\n\
+    Availability: The segment-based multiple sequence alignment tool\ncan be downloaded\
+    \ from http://www.seqan.de/projects/msa.html. A novel\nversion of T-Coffee interfaced\
+    \ with the tool is available from http://www.tcoffee.org.\nThe usage of the tool\
+    \ is described in both documentations. Contact:\nrausch@inf.fu-berlin.de},\n author\
+    \ = {T. Rausch and A.-K. Emde and D. Weese and C. Notredame and K. Reinert},\n\
+    \ journal = {Bioinformatics},\n number = {16},\n pages = {i187--192},\n title\
+    \ = {Segment-based multiple sequence alignment},\n url = {http://publications.imp.fu-berlin.de/391/},\n\
+    \ volume = {24},\n year = {2008}\n}\n\n"
+  creators:
+  - name:
+      family: Rausch
+      given: T.
+      honourific: null
+      lineage: null
+  - name:
+      family: Emde
+      given: A.-K.
+      honourific: null
+      lineage: null
   - name:
       family: Weese
-      honourific:
       given: D.
-      lineage:
+      honourific: null
+      lineage: null
   - name:
       family: Notredame
-      honourific:
       given: C.
-      lineage:
+      honourific: null
+      lineage: null
   - name:
       family: Reinert
       given: K.
-      honourific:
-      lineage:
-  documents:
-  - format: application/pdf
-    uri: http://publications.imp.fu-berlin.de/id/document/181
-    main: Bioinformatics_2008_RauschSegment-based_multiple_sequence_alignment.pdf
-    docid: 181
-    mime_type: application/pdf
-    pos: 1
-    eprintid: 391
-    security: public
-    rev_number: 3
-    relation:
-    - type: http://eprints.org/relation/haspreviewThumbnailVersion
-      uri: "/id/document/1005"
-    - type: http://eprints.org/relation/hasVolatileVersion
-      uri: "/id/document/1005"
-    - type: http://eprints.org/relation/hasVersion
-      uri: "/id/document/1005"
-    language: en
-    files:
-    - datasetid: document
-      mtime: '2017-03-03 14:40:15'
-      fileid: 5101
-      filename: Bioinformatics_2008_RauschSegment-based_multiple_sequence_alignment.pdf
-      objectid: 181
-      mime_type: application/pdf
-      uri: http://publications.imp.fu-berlin.de/id/file/5101
-      filesize: 212460
-  publication: Bioinformatics
-  datestamp: '2009-04-03 20:10:51'
-  lastmod: '2017-03-03 14:40:15'
-  ispublished: pub
-  uri: http://publications.imp.fu-berlin.de/id/eprint/391
-  official_url: http://bioinformatics.oxfordjournals.org/cgi/content/abstract/24/16/i187
+      honourific: null
+      lineage: null
   date: 2008
-  pagerange: i187-192
-  subjects:
-  - G400
+  datestamp: '2009-04-03 20:10:51'
+  dir: disk0/00/00/03/91
   divisions:
   - group_algbioinf
-  volume: 24
+  documents:
+  - docid: 181
+    eprintid: 391
+    files:
+    - datasetid: document
+      fileid: 5101
+      filename: Bioinformatics_2008_RauschSegment-based_multiple_sequence_alignment.pdf
+      filesize: 212460
+      mime_type: application/pdf
+      mtime: '2017-03-03 14:40:15'
+      objectid: 181
+      uri: http://publications.imp.fu-berlin.de/id/file/5101
+    format: application/pdf
+    language: en
+    main: Bioinformatics_2008_RauschSegment-based_multiple_sequence_alignment.pdf
+    mime_type: application/pdf
+    pos: 1
+    relation:
+    - type: http://eprints.org/relation/haspreviewThumbnailVersion
+      uri: /id/document/1005
+    - type: http://eprints.org/relation/hasVolatileVersion
+      uri: /id/document/1005
+    - type: http://eprints.org/relation/hasVersion
+      uri: /id/document/1005
+    rev_number: 3
+    security: public
+    uri: http://publications.imp.fu-berlin.de/id/document/181
   eprint_status: archive
-  dir: disk0/00/00/03/91
-  item_issues_count: 0
-  metadata_visibility: show
-  full_text_status: public
-  refereed: 'TRUE'
   eprintid: 391
+  full_text_status: public
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications391
+  lastmod: '2017-03-03 14:40:15'
+  metadata_visibility: show
   number: 16
-- rev_number: 25
-  publisher: Oxford University Press
+  official_url: http://bioinformatics.oxfordjournals.org/cgi/content/abstract/24/16/i187
+  pagerange: i187-192
+  publication: Bioinformatics
+  refereed: 'TRUE'
+  rev_number: 7
+  status_changed: '2009-03-11 11:27:21'
+  subjects:
+  - G400
+  title: Segment-based multiple sequence alignment
   type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/391
   userid: 1
-  abstract: 'Motivation: Novel high-throughput sequencing technologies pose new algorithmic
+  volume: 24
+- abstract: 'Motivation: Novel high-throughput sequencing technologies pose new algorithmic
     challenges in handling massive amounts of short- read, high-coverage data. A robust
     and versatile consensus tool is of particular interest for such data since a sound
     multi-read alignment is a prerequisite for variation analyses, accurate genome
@@ -7623,3405 +11507,2014 @@
     can be used stand- alone or in conjunction with the Celera Assembler. Both application
     scenarios as well as the usage of the tool are described in the documentation.
     Contact: rausch@inf.fu-berlin.de'
-  status_changed: '2010-02-04 14:00:19'
-  title: "A consistency-based consensus algorithm for de novo and reference-guidedsequence
-    assembly of short reads"
-  publication: Bioinformatics
-  datestamp: '2009-04-14 13:41:05'
-  documents:
-  - relation:
-    - uri: "/id/document/1006"
-      type: http://eprints.org/relation/haspreviewThumbnailVersion
-    - type: http://eprints.org/relation/hasVolatileVersion
-      uri: "/id/document/1006"
-    - uri: "/id/document/1006"
-      type: http://eprints.org/relation/hasVersion
-    language: en
-    files:
-    - objectid: 235
-      filename: Bioinformatics_2009_RauschA_Consistency-based_Consensus_Algorithm_for.pdf
-      fileid: 5137
-      mtime: '2017-03-03 14:40:15'
-      datasetid: document
-      filesize: 285683
-      mime_type: application/pdf
-      uri: http://publications.imp.fu-berlin.de/id/file/5137
-    rev_number: 4
-    pos: 1
-    eprintid: 392
-    security: public
-    format: application/pdf
-    docid: 235
-    uri: http://publications.imp.fu-berlin.de/id/document/235
-    main: Bioinformatics_2009_RauschA_Consistency-based_Consensus_Algorithm_for.pdf
-    mime_type: application/pdf
-    content: published
+  bibtex: "@article{fu_mi_publications392,\n abstract = {Motivation: Novel high-throughput\
+    \ sequencing technologies pose new algorithmic challenges in handling massive\
+    \ amounts of short- read, high-coverage data. A robust and versatile consensus\
+    \ tool is of particular interest for such data since a sound multi-read alignment\
+    \ is a prerequisite for variation analyses, accurate genome assemblies and insert\
+    \ sequencing. Results: A multi-read alignment algorithm for de novo or reference-\
+    \ guided genome assembly is presented. The program identifies segments shared\
+    \ by multiple reads and then aligns these segments using a consistency-enhanced\
+    \ alignment graph. On real de novo sequencing data obtained from the newly established\
+    \ NCBI Short Read Archive, the program performs similarly in quality to other\
+    \ comparable programs. On more challenging simulated datasets for insert sequencing\
+    \ and variation analyses, our program outperforms the other tools. Availability:\
+    \ The consensus program can be downloaded from http://www.seqan.de/projects/consensus.html.\
+    \ It can be used stand- alone or in conjunction with the Celera Assembler. Both\
+    \ application scenarios as well as the usage of the tool are described in the\
+    \ documentation. Contact: rausch@inf.fu-berlin.de},\n author = {T. Rausch and\
+    \ S. Koren and G. Denisov and D. Weese and A.-K. Emde and A. D{\\\"o}ring and\
+    \ K. Reinert},\n journal = {Bioinformatics},\n number = {9},\n pages = {1118--1124},\n\
+    \ publisher = {Oxford University Press},\n title = {A consistency-based consensus\
+    \ algorithm for de novo and reference-guided    sequence assembly of short reads},\n\
+    \ url = {http://publications.imp.fu-berlin.de/392/},\n volume = {25},\n year =\
+    \ {2009}\n}\n\n"
   creators:
   - name:
-      lineage:
-      given: T.
-      honourific:
       family: Rausch
+      given: T.
+      honourific: null
+      lineage: null
   - name:
       family: Koren
-      honourific:
       given: S.
-      lineage:
+      honourific: null
+      lineage: null
   - name:
-      honourific:
-      given: G.
       family: Denisov
-      lineage:
+      given: G.
+      honourific: null
+      lineage: null
   - name:
       family: Weese
-      honourific:
       given: D.
-      lineage:
+      honourific: null
+      lineage: null
   - name:
-      lineage:
-      honourific:
-      given: A.-K.
       family: Emde
+      given: A.-K.
+      honourific: null
+      lineage: null
   - name:
+      family: "D\xF6ring"
       given: A.
-      honourific:
-      family: Döring
-      lineage:
+      honourific: null
+      lineage: null
   - name:
       family: Reinert
-      honourific:
       given: K.
-      lineage:
-  uri: http://publications.imp.fu-berlin.de/id/eprint/392
-  lastmod: '2017-03-03 14:40:15'
-  ispublished: pub
-  volume: 25
-  subjects:
-  - G400
+      honourific: null
+      lineage: null
+  date: 2009
+  date_type: published
+  datestamp: '2009-04-14 13:41:05'
+  dir: disk0/00/00/03/92
   divisions:
   - group_algbioinf
-  date: 2009
-  pagerange: 1118-1124
-  dir: disk0/00/00/03/92
+  documents:
+  - content: published
+    docid: 235
+    eprintid: 392
+    files:
+    - datasetid: document
+      fileid: 5137
+      filename: Bioinformatics_2009_RauschA_Consistency-based_Consensus_Algorithm_for.pdf
+      filesize: 285683
+      mime_type: application/pdf
+      mtime: '2017-03-03 14:40:15'
+      objectid: 235
+      uri: http://publications.imp.fu-berlin.de/id/file/5137
+    format: application/pdf
+    language: en
+    main: Bioinformatics_2009_RauschA_Consistency-based_Consensus_Algorithm_for.pdf
+    mime_type: application/pdf
+    pos: 1
+    relation:
+    - type: http://eprints.org/relation/haspreviewThumbnailVersion
+      uri: /id/document/1006
+    - type: http://eprints.org/relation/hasVolatileVersion
+      uri: /id/document/1006
+    - type: http://eprints.org/relation/hasVersion
+      uri: /id/document/1006
+    rev_number: 4
+    security: public
+    uri: http://publications.imp.fu-berlin.de/id/document/235
   eprint_status: archive
-  date_type: published
-  full_text_status: public
-  metadata_visibility: show
-  id_number: doi:10.1093/bioinformatics/btp131
-  item_issues_count: 0
-  number: 9
   eprintid: 392
+  full_text_status: public
+  id_number: doi:10.1093/bioinformatics/btp131
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications392
+  lastmod: '2017-03-03 14:40:15'
+  metadata_visibility: show
+  number: 9
+  pagerange: 1118-1124
+  publication: Bioinformatics
+  publisher: Oxford University Press
   refereed: 'TRUE'
-- rev_number: 4
-  type: conference_item
+  rev_number: 25
+  status_changed: '2010-02-04 14:00:19'
+  subjects:
+  - G400
+  title: "A consistency-based consensus algorithm for de novo and reference-guided\t\
+    sequence assembly of short reads"
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/392
   userid: 1
-  status_changed: '2009-03-11 11:27:24'
-  title: "A general paradigm for fast and adaptive clustering of biologicalsequences"
-  datestamp: '2009-04-14 13:45:54'
+  volume: 25
+- abstract: Abstract Multiple sequence alignment as a means of comparing DNA, RNA
+    or amino acid sequences is an essential precondition for various analyses, including
+    structure prediction, modeling binding sites, phylogeny or function prediction.
+    This range of applications implies a demand for versatile, flexible and specialized
+    meth- ods to compute accurate alignments. This chapter summarizes the key algorithmic
+    insights gained in the past years to facilitate both, an easy understanding of
+    the current multiple sequence alignment literature and to enable the readers to
+    use and apply current tools in their own everyday research.
+  bibtex: "@incollection{fu_mi_publications393,\n abstract = {Abstract Multiple sequence\
+    \ alignment as a means of comparing DNA, RNA or amino acid sequences is an essential\
+    \ precondition for various analyses, including structure prediction, modeling\
+    \ binding sites, phylogeny or function prediction. This range of applications\
+    \ implies a demand for versatile, flexible and specialized meth- ods to compute\
+    \ accurate alignments. This chapter summarizes the key algorithmic insights gained\
+    \ in the past years to facilitate both, an easy understanding of the current multiple\
+    \ sequence alignment literature and to enable the readers to use and apply current\
+    \ tools in their own everyday research.},\n author = {T. Rausch and K. Reinert},\n\
+    \ booktitle = {Problem Solving Handbook in Computational Biology and Bioinformatics},\n\
+    \ editor = {L. S. Heath and N. Ramakrishnan},\n pages = {21--43},\n publisher\
+    \ = {Springer Science+Business Media},\n title = {Practical multiple Sequence\
+    \ alignment},\n url = {http://publications.imp.fu-berlin.de/393/},\n year = {2011}\n\
+    }\n\n"
+  book_title: Problem Solving Handbook in Computational Biology and Bioinformatics
   creators:
   - name:
-      honourific:
-      given: K.
+      family: Rausch
+      given: T.
+      honourific: null
+      lineage: null
+  - name:
       family: Reinert
-      lineage:
-  - name:
-      lineage:
-      given: M.
-      honourific:
-      family: Bauer
-  - name:
-      family: Döring
-      given: A.
-      honourific:
-      lineage:
-  - name:
-      given: A. L.
-      honourific:
-      family: Halpern
-      lineage:
-  event_title: German Conference on Bioinformatics (GCB 2007)
-  uri: http://publications.imp.fu-berlin.de/id/eprint/395
-  ispublished: pub
-  lastmod: '2009-04-14 13:47:53'
+      given: K.
+      honourific: null
+      lineage: null
+  date: 2011
+  date_type: published
+  datestamp: '2009-11-24 15:20:29'
+  dir: disk0/00/00/03/93
   divisions:
   - group_algbioinf
-  subjects:
-  - G400
-  pagerange: 15-29
-  date: 2007
-  dir: disk0/00/00/03/95
-  eprint_status: archive
-  full_text_status: none
-  metadata_visibility: show
-  item_issues_count: 0
-  eprintid: 395
-  refereed: 'TRUE'
-- full_text_status: none
-  metadata_visibility: show
-  item_issues_count: 0
-  series: Dagstuhl Seminar Proceedings
-  number: 5471
-  refereed: 'TRUE'
-  eprintid: 397
-  subjects:
-  - G400
-  divisions:
-  - group_algbioinf
-  date: 2006
-  dir: disk0/00/00/03/97
-  eprint_status: archive
-  uri: http://publications.imp.fu-berlin.de/id/eprint/397
-  event_title: Computational Proteomics
-  ispublished: pub
-  lastmod: '2009-04-14 14:22:33'
-  note: "<span class='mathrm'>&lt;</span>http://drops.dagstuhl.de/opus/volltexte/2006/546<span
-    class='mathrm'>&gt;</span> [date of citation:2006-01-01]"
-  rev_number: 3
-  publisher: "Internationales Begegnungs- und Forschungszentrum fÃ¼r Informatik(IBFI),
-    Schloss Dagstuhl, Germany"
-  type: conference_item
-  userid: 1
-  status_changed: '2009-03-11 11:27:25'
   editors:
   - name:
-      given: C. G.
-      honourific:
-      family: Huber
-      lineage:
+      family: Heath
+      given: L. S.
+      honourific: null
+      lineage: null
   - name:
-      given: O.
-      honourific:
-      family: Kohlbacher
-      lineage:
-  - name:
-      given: K.
-      honourific:
-      family: Reinert
-      lineage:
-  title: OpenMS - A Framework for Quantitative HPLC/MS-Based Proteomics
-  datestamp: '2009-04-14 14:22:33'
-  creators:
-  - name:
-      honourific:
-      given: K.
-      family: Reinert
-      lineage:
-  - name:
-      lineage:
-      family: Kohlbacher
-      honourific:
-      given: O.
-  - name:
-      family: Gröpl
-      honourific:
-      given: C.
-      lineage:
-  - name:
-      lineage:
-      family: Lange
-      given: E.
-      honourific:
-  - name:
-      given: O.
-      honourific:
-      family: Schulz-Trieglaff
-      lineage:
-  - name:
-      lineage:
-      given: M.
-      honourific:
-      family: Sturm
-  - name:
-      family: Pfeifer
+      family: Ramakrishnan
       given: N.
-      honourific:
-      lineage:
-- eprint_status: archive
-  dir: disk0/00/00/03/98
-  date: 2005
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  eprintid: 398
-  refereed: 'TRUE'
-  item_issues_count: 0
-  metadata_visibility: show
-  full_text_status: none
-  creators:
-  - name:
-      honourific:
-      given: K.
-      family: Reinert
-      lineage:
-  - name:
-      family: Kohlbacher
-      honourific:
-      given: O.
-      lineage:
-  - name:
-      given: C.
-      honourific:
-      family: Gröpl
-      lineage:
-  - name:
-      family: Lange
-      given: E.
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      family: Schulz-Trieglaff
-      honourific:
-      given: O.
-  - name:
-      lineage:
-      given: M.
-      honourific:
-      family: Sturm
-  - name:
-      lineage:
-      family: Pfeifer
-      honourific:
-      given: N.
-  datestamp: '2009-04-14 14:33:46'
-  title: OpenMS - A Framework for Quantitative HPLC/MS-Based Proteomics
-  status_changed: '2009-03-11 11:27:26'
-  userid: 1
-  publisher: Dagstuhl Online Publication Server (DROPS)
-  type: conference_item
-  rev_number: 3
-  official_url: http://www.dagstuhl.de/05471/
-  note: "Extended abstract for talk given at Dagstuhl Seminar 05471 on ComputationalProteomics,
-    20.-25. November 2005"
-  ispublished: pub
-  lastmod: '2009-04-14 14:33:46'
-  event_title: Computational Proteomics
-  uri: http://publications.imp.fu-berlin.de/id/eprint/398
-- metadata_visibility: show
-  id_number: doi:10.1146/annurev-genom-090413-025358
-  full_text_status: none
-  date_type: published
-  item_issues_count: 0
-  refereed: 'TRUE'
-  eprintid: 1544
-  number: 1
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  volume: 16
-  pagerange: 133-151
-  date: '2015-05-04'
-  dir: disk0/00/00/15/44
-  issn: 1527-8204
+      honourific: null
+      lineage: null
   eprint_status: archive
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1544
-  ispublished: pub
-  lastmod: '2016-02-25 13:11:02'
-  official_url: http://dx.doi.org/10.1146/annurev-genom-090413-025358
-  userid: 132
-  type: article
-  rev_number: 13
-  title: Alignment of Next-Generation Sequencing Reads
-  status_changed: '2016-02-25 13:11:02'
-  abstract: "High-throughput DNA sequencing has considerably changed the possibilities
-    for conducting biomedical research by measuring billions of short DNA or RNA fragments.
-    A central computational problem, and for many applications a first step, consists
-    of determining where the fragments came fromin the original genome. In this
-    article, we review the main techniques for generating the fragments, the main
-    applications, and the main algorithmic ideas for computing a solution to the read
-    alignment problem. In addition, we describe pitfalls and difficulties connected
-    to determining the correct positions of reads."
-  datestamp: '2015-05-07 12:25:03'
-  publication: Annual Review of Genomics and Human Genetics
-  creators:
-  - name:
-      lineage:
-      family: Reinert
-      given: K.
-      honourific:
-  - name:
-      given: B.
-      honourific:
-      family: Langmead
-      lineage:
-  - name:
-      lineage:
-      family: Weese
-      honourific:
-      given: D.
-  - name:
-      lineage:
-      family: Evers
-      honourific:
-      given: D.J.
-- uri: http://publications.imp.fu-berlin.de/id/eprint/400
-  ispublished: pub
-  lastmod: '2017-03-03 14:40:15'
-  userid: 1
-  type: article
-  rev_number: 3
-  title: An Iterative Methods for Faster Sum-of-Pairs Multiple Sequence Alignment
-  status_changed: '2009-03-11 11:27:27'
-  publication: BIOINFORMATICS
-  datestamp: '2017-03-03 14:40:15'
-  creators:
-  - name:
-      lineage:
-      given: K.
-      honourific:
-      family: Reinert
-  - name:
-      family: Stoye
-      honourific:
-      given: J.
-      lineage:
-  - name:
-      family: Will
-      given: T.
-      honourific:
-      lineage:
-  metadata_visibility: show
+  eprintid: 393
   full_text_status: none
+  id_number: DOI 10.1007/978-0-387-09760-2
+  isbn: 978-0-387-09759-6
+  ispublished: pub
   item_issues_count: 0
+  key: fu_mi_publications393
+  lastmod: '2010-11-18 14:19:41'
+  metadata_visibility: show
+  official_url: http://www.springer.com/computer/bioinformatics/book/978-0-387-09759-6
+  pagerange: 21-43
+  pages: 347
+  publisher: Springer Science+Business Media
   refereed: 'TRUE'
-  eprintid: 400
-  number: 9
-  divisions:
-  - group_algbioinf
+  related_url:
+  - url: http://www.springerlink.com/content/978-0-387-09759-6#section=798327&page=1&locus=0
+  rev_number: 8
+  status_changed: '2010-02-04 14:02:02'
   subjects:
   - G400
-  volume: 16
-  date: 2000
-  pagerange: 808-814
-  dir: disk0/00/00/04/00
-  eprint_status: archive
-- dir: disk0/00/00/03/96
-  eprint_status: archive
-  volume: 1
-  subjects:
-  - G400
-  divisions:
-  - group_algbioinf
-  place_of_pub: Weinheim
-  date: 2007-12
-  pagerange: 25-55
-  eprintid: 396
-  refereed: 'TRUE'
-  full_text_status: none
-  metadata_visibility: show
-  item_issues_count: 0
-  series: Bioinformatics - From Genomes to Therapies
-  datestamp: '2017-03-03 14:40:15'
-  creators:
-  - name:
-      lineage:
-      family: Reinert
-      honourific:
-      given: K.
-  - name:
-      lineage:
-      given: D. H.
-      honourific:
-      family: Huson
-  rev_number: 3
-  publisher: Wiley-VCH
+  title: Practical multiple Sequence alignment
   type: book_section
+  uri: http://publications.imp.fu-berlin.de/id/eprint/393
   userid: 1
-  status_changed: '2009-03-11 11:27:24'
-  title: Sequence Assembly
-  uri: http://publications.imp.fu-berlin.de/id/eprint/396
-  ispublished: pub
-  lastmod: '2017-03-03 14:40:15'
-- event_title: "Proceedings of the First Annual International Conference on ComputationalMolecular
-    Biology (RECOMB-97)"
-  uri: http://publications.imp.fu-berlin.de/id/eprint/399
-  lastmod: '2017-03-03 14:40:15'
-  ispublished: pub
-  datestamp: '2017-03-03 14:40:15'
+- abstract: "This paper describes a novel algorithm to analyze genetic linkage\tdata\
+    \ using pattern recognition techniques and genetic algorithms\n\t(GA). The method\
+    \ allows a search for regions of the chromosome that\n\tmay contain genetic variations\
+    \ that jointly predispose individuals\n\tfor a particular disease. The method\
+    \ uses correlation analysis, filtering\n\ttheory and genetic algorithms to achieve\
+    \ this goal. Because current\n\tgenome scans use from hundreds to hundreds of\
+    \ thousands of markers,\n\ttwo versions of the method have been implemented. The\
+    \ first is an\n\texhaustive analysis version that can be used to visualize, explore,\n\
+    \tand analyze small genetic data sets for two marker correlations;\n\tthe second\
+    \ is a GA version, which uses a parallel implementation\n\tallowing searches of\
+    \ higher-order correlations in large data sets.\n\tResults on simulated data sets\
+    \ indicate that the method can be informative\n\tin the identification of major\
+    \ disease loci and gene\xE2\x80\x93gene interactions\n\tin genome-wide linkage\
+    \ data and that further exploration of these\n\ttechniques is justified. The results\
+    \ presented for both variants\n\tof the method show that it can help genetic epidemiologists\
+    \ to identify\n\tpromising combinations of genetic factors that might predispose\
+    \ to\n\tcomplex disorders. In particular, the correlation analysis of IBD\n\t\
+    expression patterns might hint to possible gene\xE2\x80\x93gene interactions\n\
+    \tand the filtering might be a fruitful approach to distinguish true\n\tcorrelation\
+    \ signals from noise."
+  bibtex: "@article{fu_mi_publications394,\n abstract = {This paper describes a novel\
+    \ algorithm to analyze genetic linkage   data using pattern recognition techniques\
+    \ and genetic algorithms\n(GA). The method allows a search for regions of the\
+    \ chromosome that\nmay contain genetic variations that jointly predispose individuals\n\
+    for a particular disease. The method uses correlation analysis, filtering\ntheory\
+    \ and genetic algorithms to achieve this goal. Because current\ngenome scans use\
+    \ from hundreds to hundreds of thousands of markers,\ntwo versions of the method\
+    \ have been implemented. The first is an\nexhaustive analysis version that can\
+    \ be used to visualize, explore,\nand analyze small genetic data sets for two\
+    \ marker correlations;\nthe second is a GA version, which uses a parallel implementation\n\
+    allowing searches of higher-order correlations in large data sets.\nResults on\
+    \ simulated data sets indicate that the method can be informative\nin the identification\
+    \ of major disease loci and gene{\\^a}??gene interactions\nin genome-wide linkage\
+    \ data and that further exploration of these\ntechniques is justified. The results\
+    \ presented for both variants\nof the method show that it can help genetic epidemiologists\
+    \ to identify\npromising combinations of genetic factors that might predispose\
+    \ to\ncomplex disorders. In particular, the correlation analysis of IBD\nexpression\
+    \ patterns might hint to possible gene{\\^a}??gene interactions\nand the filtering\
+    \ might be a fruitful approach to distinguish true\ncorrelation signals from noise.},\n\
+    \ author = {T. Rausch and A. Thomas and N. J. Camp and L. A. Facelli},\n journal\
+    \ = {Comput. Biol. Med.},\n month = {July},\n pages = {826--836},\n title = {A\
+    \ parallel genetic algorithm to discover patterns in genetic markers        that\
+    \ indicate predisposition to multifactorial disease},\n url = {http://publications.imp.fu-berlin.de/394/},\n\
+    \ volume = {38},\n year = {2008}\n}\n\n"
   creators:
   - name:
-      lineage:
+      family: Rausch
+      given: T.
+      honourific: null
+      lineage: null
+  - name:
+      family: Thomas
+      given: A.
+      honourific: null
+      lineage: null
+  - name:
+      family: Camp
+      given: N. J.
+      honourific: null
+      lineage: null
+  - name:
+      family: Facelli
+      given: L. A.
+      honourific: null
+      lineage: null
+  date: 2008-07
+  datestamp: '2017-03-03 14:40:15'
+  dir: disk0/00/00/03/94
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 394
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications394
+  lastmod: '2017-03-03 14:40:15'
+  metadata_visibility: show
+  official_url: http://www.ncbi.nlm.nih.gov/pubmed/18547558
+  pagerange: 826-836
+  publication: Comput. Biol. Med.
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:23'
+  subjects:
+  - G400
+  title: "A parallel genetic algorithm to discover patterns in genetic markers\tthat\
+    \ indicate predisposition to multifactorial disease"
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/394
+  userid: 1
+  volume: 38
+- bibtex: "@inproceedings{fu_mi_publications395,\n author = {K. Reinert and M. Bauer\
+    \ and A. D{\\\"o}ring and A. L. Halpern},\n booktitle = {German Conference on\
+    \ Bioinformatics (GCB 2007)},\n pages = {15--29},\n title = {A general paradigm\
+    \ for fast and adaptive clustering of biological   sequences},\n url = {http://publications.imp.fu-berlin.de/395/},\n\
+    \ year = {2007}\n}\n\n"
+  creators:
+  - name:
       family: Reinert
       given: K.
-      honourific:
+      honourific: null
+      lineage: null
+  - name:
+      family: Bauer
+      given: M.
+      honourific: null
+      lineage: null
+  - name:
+      family: "D\xF6ring"
+      given: A.
+      honourific: null
+      lineage: null
+  - name:
+      family: Halpern
+      given: A. L.
+      honourific: null
+      lineage: null
+  date: 2007
+  datestamp: '2009-04-14 13:45:54'
+  dir: disk0/00/00/03/95
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 395
+  event_title: German Conference on Bioinformatics (GCB 2007)
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications395
+  lastmod: '2009-04-14 13:47:53'
+  metadata_visibility: show
+  pagerange: 15-29
+  refereed: 'TRUE'
+  rev_number: 4
+  status_changed: '2009-03-11 11:27:24'
+  subjects:
+  - G400
+  title: "A general paradigm for fast and adaptive clustering of biological\tsequences"
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/395
+  userid: 1
+- bibtex: "@incollection{fu_mi_publications396,\n address = {Weinheim},\n author =\
+    \ {K. Reinert and D. H. Huson},\n month = {December},\n pages = {25--55},\n publisher\
+    \ = {Wiley-VCH},\n series = {Bioinformatics - From Genomes to Therapies},\n title\
+    \ = {Sequence Assembly},\n url = {http://publications.imp.fu-berlin.de/396/},\n\
+    \ volume = {1},\n year = {2007}\n}\n\n"
+  creators:
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  - name:
+      family: Huson
+      given: D. H.
+      honourific: null
+      lineage: null
+  date: 2007-12
+  datestamp: '2017-03-03 14:40:15'
+  dir: disk0/00/00/03/96
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 396
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications396
+  lastmod: '2017-03-03 14:40:15'
+  metadata_visibility: show
+  pagerange: 25-55
+  place_of_pub: Weinheim
+  publisher: Wiley-VCH
+  refereed: 'TRUE'
+  rev_number: 3
+  series: Bioinformatics - From Genomes to Therapies
+  status_changed: '2009-03-11 11:27:24'
+  subjects:
+  - G400
+  title: Sequence Assembly
+  type: book_section
+  uri: http://publications.imp.fu-berlin.de/id/eprint/396
+  userid: 1
+  volume: 1
+- bibtex: "@inproceedings{fu_mi_publications397,\n author = {K. Reinert and O. Kohlbacher\
+    \ and C. Gr{\\\"o}pl and E. Lange and O. Schulz-Trieglaff and M. Sturm and N.\
+    \ Pfeifer},\n booktitle = {Computational Proteomics},\n editor = {C. G. Huber\
+    \ and O. Kohlbacher and K. Reinert},\n note = {{\\ensuremath{<}}span class='mathrm'{\\\
+    ensuremath{>}}\\&lt;{\\ensuremath{<}}/span{\\ensuremath{>}}http://drops.dagstuhl.de/opus/volltexte/2006/546{\\\
+    ensuremath{<}}span class='mathrm'{\\ensuremath{>}}\\&gt;{\\ensuremath{<}}/span{\\\
+    ensuremath{>}} [date of citation:       2006-01-01]},\n number = {05471},\n publisher\
+    \ = {Internationales Begegnungs- und Forschungszentrum f{\\~A}?r Informatik  \
+    \     (IBFI), Schloss Dagstuhl, Germany},\n series = {Dagstuhl Seminar Proceedings},\n\
+    \ title = {OpenMS - A Framework for Quantitative HPLC/MS-Based Proteomics},\n\
+    \ url = {http://publications.imp.fu-berlin.de/397/},\n year = {2006}\n}\n\n"
+  creators:
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  - name:
+      family: Kohlbacher
+      given: O.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: Lange
+      given: E.
+      honourific: null
+      lineage: null
+  - name:
+      family: Schulz-Trieglaff
+      given: O.
+      honourific: null
+      lineage: null
+  - name:
+      family: Sturm
+      given: M.
+      honourific: null
+      lineage: null
+  - name:
+      family: Pfeifer
+      given: N.
+      honourific: null
+      lineage: null
+  date: 2006
+  datestamp: '2009-04-14 14:22:33'
+  dir: disk0/00/00/03/97
+  divisions:
+  - group_algbioinf
+  editors:
+  - name:
+      family: Huber
+      given: C. G.
+      honourific: null
+      lineage: null
+  - name:
+      family: Kohlbacher
+      given: O.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  eprint_status: archive
+  eprintid: 397
+  event_title: Computational Proteomics
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications397
+  lastmod: '2009-04-14 14:22:33'
+  metadata_visibility: show
+  note: "<span class='mathrm'>&lt;</span>http://drops.dagstuhl.de/opus/volltexte/2006/546<span\
+    \ class='mathrm'>&gt;</span> [date of citation:\t2006-01-01]"
+  number: 5471
+  publisher: "Internationales Begegnungs- und Forschungszentrum f\xC3\xBCr Informatik\t\
+    (IBFI), Schloss Dagstuhl, Germany"
+  refereed: 'TRUE'
+  rev_number: 3
+  series: Dagstuhl Seminar Proceedings
+  status_changed: '2009-03-11 11:27:25'
+  subjects:
+  - G400
+  title: OpenMS - A Framework for Quantitative HPLC/MS-Based Proteomics
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/397
+  userid: 1
+- bibtex: "@inproceedings{fu_mi_publications398,\n author = {K. Reinert and O. Kohlbacher\
+    \ and C. Gr{\\\"o}pl and E. Lange and O. Schulz-Trieglaff and M. Sturm and N.\
+    \ Pfeifer},\n booktitle = {Computational Proteomics},\n note = {Extended abstract\
+    \ for talk given at Dagstuhl Seminar 05471 on Computational Proteomics, 20.-25.\
+    \ November 2005},\n publisher = {Dagstuhl Online Publication Server (DROPS)},\n\
+    \ title = {OpenMS - A Framework for Quantitative HPLC/MS-Based Proteomics},\n\
+    \ url = {http://publications.imp.fu-berlin.de/398/},\n year = {2005}\n}\n\n"
+  creators:
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  - name:
+      family: Kohlbacher
+      given: O.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: Lange
+      given: E.
+      honourific: null
+      lineage: null
+  - name:
+      family: Schulz-Trieglaff
+      given: O.
+      honourific: null
+      lineage: null
+  - name:
+      family: Sturm
+      given: M.
+      honourific: null
+      lineage: null
+  - name:
+      family: Pfeifer
+      given: N.
+      honourific: null
+      lineage: null
+  date: 2005
+  datestamp: '2009-04-14 14:33:46'
+  dir: disk0/00/00/03/98
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 398
+  event_title: Computational Proteomics
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications398
+  lastmod: '2009-04-14 14:33:46'
+  metadata_visibility: show
+  note: "Extended abstract for talk given at Dagstuhl Seminar 05471 on Computational\t\
+    Proteomics, 20.-25. November 2005"
+  official_url: http://www.dagstuhl.de/05471/
+  publisher: Dagstuhl Online Publication Server (DROPS)
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:26'
+  subjects:
+  - G400
+  title: OpenMS - A Framework for Quantitative HPLC/MS-Based Proteomics
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/398
+  userid: 1
+- bibtex: "@inproceedings{fu_mi_publications399,\n author = {K. Reinert and H.-P.\
+    \ Lenhof and P. Mutzel and J. D. Kececioglu},\n booktitle = {Proceedings of the\
+    \ First Annual International Conference on Computational   Molecular Biology (RECOMB-97)},\n\
+    \ pages = {241--249},\n title = {A branch-and-Cut algorithm for multiple sequence\
+    \ alignment },\n url = {http://publications.imp.fu-berlin.de/399/},\n year = {1997}\n\
+    }\n\n"
+  creators:
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
   - name:
       family: Lenhof
       given: H.-P.
-      honourific:
-      lineage:
+      honourific: null
+      lineage: null
   - name:
-      lineage:
-      honourific:
-      given: P.
       family: Mutzel
+      given: P.
+      honourific: null
+      lineage: null
   - name:
-      lineage:
       family: Kececioglu
       given: J. D.
-      honourific:
-  rev_number: 3
-  type: conference_item
-  userid: 1
-  status_changed: '2009-03-11 11:27:26'
-  title: 'A branch-and-Cut algorithm for multiple sequence alignment '
-  refereed: 'TRUE'
-  eprintid: 399
-  full_text_status: none
-  metadata_visibility: show
-  item_issues_count: 0
-  dir: disk0/00/00/03/99
-  eprint_status: archive
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
+      honourific: null
+      lineage: null
   date: 1997
-  pagerange: 241-249
-- eprint_status: archive
-  issn: 1681656
-  dir: disk0/00/00/21/03
-  date: '2017-11-10'
-  pagerange: 157-168
-  volume: 261
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  refereed: 'TRUE'
-  eprintid: 2103
-  full_text_status: none
-  date_type: published
-  id_number: doi:10.1016/j.jbiotec.2017.07.017
-  metadata_visibility: show
-  creators:
-  - name:
-      lineage:
-      given: Knut
-      honourific:
-      family: Reinert
-  - name:
-      family: Dadi
-      honourific:
-      given: Temesgen Hailemariam
-      lineage:
-  - name:
-      lineage:
-      family: Ehrhardt
-      honourific:
-      given: Marcel
-  - name:
-      lineage:
-      given: Hannes
-      honourific:
-      family: Hauswedell
-  - name:
-      family: Mehringer
-      honourific:
-      given: Svenja
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: René
-      family: Rahn
-  - name:
-      lineage:
-      given: Jongkyu
-      honourific:
-      family: Kim
-  - name:
-      given: Christopher
-      honourific:
-      family: Pockrandt
-      lineage:
-  - name:
-      lineage:
-      given: Jörg
-      honourific:
-      family: Winkler
-  - name:
-      honourific:
-      given: Enrico
-      family: Siragusa
-      lineage:
-  - name:
-      family: Urgese
-      given: Gianvito
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: David
-      family: Weese
-  datestamp: '2017-09-12 14:16:48'
-  publication: Journal of Biotechnology
-  status_changed: '2017-09-12 14:16:48'
-  abstract: "BackgroundThe use of novel algorithmic techniques is pivotal
-    to many important problems in life science. For example the sequencing of the
-    human genome (Venter et al., 2001) would not have been possible without advanced
-    assembly algorithms and the development of practical BWT based read mappers have
-    been instrumental for NGS analysis. However, owing to the high speed of technological
-    progress and the urgent need for bioinformatics tools, there was a widening gap
-    between state-of-the-art algorithmic techniques and the actual algorithmic components
-    of tools that are in widespread use. We previously addressed this by introducing
-    the SeqAn library of efficient data types and algorithms in 2008 (Döring et al.,
-    2008).ResultsThe SeqAn library has matured considerably since
-    its first publication 9 years ago. In this article we review its status as an
-    established resource for programmers in the field of sequence analysis and its
-    contributions to many analysis tools.ConclusionsWe anticipate
-    that SeqAn will continue to be a valuable resource, especially since it started
-    to actively support various hardware acceleration techniques in a systematic manner.KeywordsNGS
-    analysis; Software libraries; C++; Data structures"
-  title: 'The SeqAn C++ template library for efficient sequence analysis: A resource
-    for programmers'
-  rev_number: 6
-  publisher: ELSEVIER
-  type: article
-  userid: 132
-  official_url: http://doi.org/10.1016/j.jbiotec.2017.07.017
-  keywords: NGS analysis; Software libraries; C++; Data structures
-  lastmod: '2017-10-12 11:37:39'
-  ispublished: pub
-  uri: http://publications.imp.fu-berlin.de/id/eprint/2103
-- divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  volume: 33
-  pagerange: 2941-2942
-  date: '2017-09-15'
-  dir: disk0/00/00/21/17
-  issn: 1367-4803
-  eprint_status: archive
-  metadata_visibility: show
-  id_number: doi:10.1093/bioinformatics/btx330
-  full_text_status: none
-  date_type: published
-  eprintid: 2117
-  refereed: 'TRUE'
-  number: 18
-  userid: 132
-  type: article
-  rev_number: 5
-  title: Flexbar 3.0 – SIMD and multicore parallelization
-  abstract: "Motivation: High-throughput sequencing machines can process many
-    samples in a single run. For Illumina systems, sequencing reads are barcoded with
-    an additional DNA tag that is contained in the respective sequencing adapters.
-    The recognition of barcode and adapter sequences is hence commonly needed for
-    the analysis of next-generation sequencing data. Flexbar performs demultiplexing
-    based on barcodes and adapter trimming for such data. The massive amounts of data
-    generated on modern sequencing machines demand that this preprocessing is done
-    as efficiently as possible.Results: We present Flexbar 3.0, the successor
-    of the popular program Flexbar. It employs now twofold parallelism: multi-threading
-    and additionally SIMD vectorization. Both types of parallelism are used to speed-up
-    the computation of pair-wise sequence alignments, which are used for the detection
-    of barcodes and adapters. Furthermore, new features were included to cover a wide
-    range of applications. We evaluated the performance of Flexbar based on a simulated
-    sequencing dataset. Our program outcompetes other tools in terms of speed and
-    is among the best tools in the presented quality benchmark.Availability
-    and implementation:https://github.com/seqan/flexbarContact:johannes.roehr@fu-berlin.de
-    or knut.reinert@fu-berlin.de"
-  status_changed: '2017-10-12 12:16:48'
-  datestamp: '2017-10-12 12:16:48'
-  publication: Bioinformatics
-  creators:
-  - name:
-      given: Johannes T.
-      honourific:
-      family: Roehr
-      lineage:
-  - name:
-      given: Christoph
-      honourific:
-      family: Dieterich
-      lineage:
-  - name:
-      lineage:
-      family: Reinert
-      given: Knut
-      honourific:
-  uri: http://publications.imp.fu-berlin.de/id/eprint/2117
-  lastmod: '2017-10-12 12:16:48'
-  ispublished: pub
-  official_url: http://doi.org/10.1093/bioinformatics/btx330
-- full_text_status: none
-  date_type: published
-  metadata_visibility: show
-  id_number: doi:10.1038/nmeth.3959
-  number: 9
-  eprintid: 2129
-  refereed: 'TRUE'
-  pagerange: 741-748
-  date: '2016-08-30'
-  volume: 13
-  subjects:
-  - G400
+  datestamp: '2017-03-03 14:40:15'
+  dir: disk0/00/00/03/99
   divisions:
   - group_algbioinf
   eprint_status: archive
-  issn: 1548-7091
-  dir: disk0/00/00/21/29
-  ispublished: pub
-  lastmod: '2017-11-22 13:17:53'
-  uri: http://publications.imp.fu-berlin.de/id/eprint/2129
-  official_url: http://doi.org/10.1038/nmeth.3959
-  status_changed: '2017-11-22 13:17:53'
-  abstract: High-resolution mass spectrometry (MS) has become an important tool in
-    the life sciences, contributing to the diagnosis and understanding of human diseases,
-    elucidating biomolecular structural information and characterizing cellular signaling
-    networks. However, the rapid growth in the volume and complexity of MS data makes
-    transparent, accurate and reproducible analysis difficult. We present OpenMS 2.0
-    (http://www.openms.de), a robust, open-source, cross-platform software specifically
-    designed for the flexible and reproducible analysis of high-throughput MS data.
-    The extensible OpenMS software implements common mass spectrometric data processing
-    tasks through a well-defined application programming interface in C++ and Python
-    and through standardized open data formats. OpenMS additionally provides a set
-    of 185 tools and ready-made workflows for common mass spectrometric data processing
-    tasks, which enable users to perform complex quantitative mass spectrometric analyses
-    with ease.
-  title: 'OpenMS: a flexible open-source software platform for mass spectrometry data
-    analysis'
-  rev_number: 5
-  publisher: Springer Nature/Macmillan Publishers Limited
-  type: article
-  userid: 132
-  creators:
-  - name:
-      family: Röst
-      given: Hannes L
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      family: Sachsenberg
-      given: Timo
-      honourific:
-  - name:
-      lineage:
-      honourific:
-      given: Stephan
-      family: Aiche
-  - name:
-      given: Chris
-      honourific:
-      family: Bielow
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: Hendrik
-      family: Weisser
-  - name:
-      lineage:
-      honourific:
-      given: Fabian
-      family: Aicheler
-  - name:
-      lineage:
-      family: Andreotti
-      given: Sandro
-      honourific:
-  - name:
-      honourific:
-      given: Hans-Christian
-      family: Ehrlich
-      lineage:
-  - name:
-      given: Petra
-      honourific:
-      family: Gutenbrunner
-      lineage:
-  - name:
-      honourific:
-      given: Erhan
-      family: Kenar
-      lineage:
-  - name:
-      honourific:
-      given: Xiao
-      family: Liang
-      lineage:
-  - name:
-      given: Sven
-      honourific:
-      family: Nahnsen
-      lineage:
-  - name:
-      family: Nilse
-      given: Lars
-      honourific:
-      lineage:
-  - name:
-      family: Pfeuffer
-      given: Julianus
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      family: Rosenberger
-      given: George
-      honourific:
-  - name:
-      lineage:
-      family: Rurik
-      honourific:
-      given: Marc
-  - name:
-      family: Schmitt
-      honourific:
-      given: Uwe
-      lineage:
-  - name:
-      lineage:
-      family: Veit
-      honourific:
-      given: Johannes
-  - name:
-      honourific:
-      given: Mathias
-      family: Walzer
-      lineage:
-  - name:
-      family: Wojnar
-      honourific:
-      given: David
-      lineage:
-  - name:
-      given: Witold E
-      honourific:
-      family: Wolski
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: Oliver
-      family: Schilling
-  - name:
-      family: Choudhary
-      given: Jyoti S
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      family: Malmström
-      honourific:
-      given: Lars
-  - name:
-      lineage:
-      family: Aebersold
-      given: Ruedi
-      honourific:
-  - name:
-      honourific:
-      given: Knut
-      family: Reinert
-      lineage:
-  - name:
-      lineage:
-      given: Oliver
-      honourific:
-      family: Kohlbacher
-  datestamp: '2017-11-22 13:17:53'
-  publication: Nature Methods
-- creators:
-  - name:
-      honourific:
-      given: L.
-      family: Schultz
-      lineage:
-    id:
-  - id:
-    name:
-      lineage:
-      family: Zurich
-      honourific:
-      given: M.-G.
-  - id:
-    name:
-      family: Culot
-      given: M.
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      given: A.
-      honourific:
-      family: da Costa
-    id:
-  - id:
-    name:
-      family: Landry
-      honourific:
-      given: C.
-      lineage:
-  - id:
-    name:
-      lineage:
-      family: Bellwon
-      given: P.
-      honourific:
-  - id:
-    name:
-      lineage:
-      family: Kristl
-      given: T.
-      honourific:
-  - name:
-      honourific:
-      given: K.
-      family: Hörmann
-      lineage:
-    id:
-  - id:
-    name:
-      lineage:
-      family: Ruzek
-      honourific:
-      given: S.
-  - name:
-      given: S.
-      honourific:
-      family: Aiche
-      lineage:
-    id:
-  - name:
-      lineage:
-      family: Reinert
-      given: K.
-      honourific:
-    id: knut.reinert@fu-berlin.de
-  - name:
-      given: C.
-      honourific:
-      family: Bielow
-      lineage:
-    id:
-  - name:
-      lineage:
-      given: F.
-      honourific:
-      family: Gosselet
-    id:
-  - name:
-      honourific:
-      given: R.
-      family: Cecchelli
-      lineage:
-    id:
-  - id:
-    name:
-      honourific:
-      given: C. G.
-      family: Huber
-      lineage:
-  - name:
-      lineage:
-      family: Schroeder
-      honourific:
-      given: O. H.-U.
-    id:
-  - id:
-    name:
-      honourific:
-      given: A.
-      family: Gramowski-Voss
-      lineage:
-  - id:
-    name:
-      lineage:
-      family: Weiss
-      honourific:
-      given: D. G.
-  - name:
-      lineage:
-      family: Bal-Price
-      honourific:
-      given: A.
-    id:
-  datestamp: '2015-10-01 08:35:15'
-  abstract: "The present study was performed in an attempt to develop an in vitro
-    integrated testing strategy (ITS) to evaluate drug-induced neurotoxicity. A number
-    of endpoints were analyzed using two complementary brain cell culture models and
-    an in vitro blood–brain barrier (BBB) model after single and repeated exposure
-    treatments with selected drugs that covered the major biological, pharmacological
-    and neuro-toxicological responses. Furthermore, four drugs (diazepam, cyclosporine
-    A, chlorpromazine and amiodarone) were tested more in depth as representatives
-    of different classes of neurotoxicants, inducing toxicity through different pathways
-    of toxicity.The developed in vitro BBB model allowed detection of toxic
-    effects at the level of BBB and evaluation of drug transport through the barrier
-    for predicting free brain concentrations of the studied drugs. The measurement
-    of neuronal electrical activity was found to be a sensitive tool to predict the
-    neuroactivity and neurotoxicity of drugs after acute exposure. The histotypic
-    3D re-aggregating brain cell cultures, containing all brain cell types, were found
-    to be well suited for OMICs analyses after both acute and long term treatment.The
-    obtained data suggest that an in vitro ITS based on the information obtained from
-    BBB studies and combined with metabolomics, proteomics and neuronal electrical
-    activity measurements performed in stable in vitro neuronal cell culture systems,
-    has high potential to improve current in vitro drug-induced neurotoxicity evaluation.Abbreviations:BBB,
-    blood brain barrier; DMSO, dimethylsulfoxide; EC, endothelial cells; DIV, day
-    in vitro; IPA, Ingenuity Pathway Analysis; ITS, integrated testing strategy; LY,
-    Lucifer Yellow; MEA, micro-electrode array; RH, Ringer HEPES medium; SPSS, Statistical
-    Package for the Social Sciences"
-  title: Evaluation of drug-induced neurotoxicity based on metabolomics, proteomics
-    and electrical activity measurements in complementary CNS in vitro models
-  type: article
-  userid: 132
-  keywords: In vitro blood brain barrier; MEA; Neuronal network culture; OMICs; Drug
-    development; 3D brain culture
-  note: 'Online publication: May 2015'
-  date: '2015-12-25'
-  subjects:
-  - G400
-  refereed: 'TRUE'
-  eprintid: 1736
+  eprintid: 399
+  event_title: "Proceedings of the First Annual International Conference on Computational\t\
+    Molecular Biology (RECOMB-97)"
   full_text_status: none
-  publication: Toxicology in Vitro
-  status_changed: '2016-11-15 13:58:51'
-  rev_number: 15
-  publisher: Elsevier B.V.
-  official_url: http://dx.doi.org/10.1016/j.tiv.2015.05.016
-  lastmod: '2016-11-15 13:58:51'
   ispublished: pub
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1736
-  eprint_status: archive
-  issn: 8872333
-  dir: disk0/00/00/17/36
-  pagerange: 138-165
-  volume: 30
-  divisions:
-  - group_algbioinf
-  number: 1
   item_issues_count: 0
-  date_type: published
+  key: fu_mi_publications399
+  lastmod: '2017-03-03 14:40:15'
   metadata_visibility: show
-  id_number: doi:10.1016/j.tiv.2015.05.016
-- event_title: "Proceedings of the 8th International Workshop in Algorithms in Bioinformatics(WABI'08)"
-  uri: http://publications.imp.fu-berlin.de/id/eprint/401
-  lastmod: '2009-04-15 07:16:23'
-  ispublished: pub
-  datestamp: '2009-04-15 07:15:58'
+  pagerange: 241-249
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:26'
+  subjects:
+  - G400
+  title: 'A branch-and-Cut algorithm for multiple sequence alignment '
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/399
+  userid: 1
+- bibtex: "@article{fu_mi_publications400,\n author = {K. Reinert and J. Stoye and\
+    \ T. Will},\n journal = {BIOINFORMATICS},\n number = {9},\n pages = {808--814},\n\
+    \ title = {An Iterative Methods for Faster Sum-of-Pairs Multiple Sequence Alignment},\n\
+    \ url = {http://publications.imp.fu-berlin.de/400/},\n volume = {16},\n year =\
+    \ {2000}\n}\n\n"
   creators:
   - name:
-      lineage:
-      given: M. H.
-      honourific:
-      family: Schulz
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
   - name:
-      lineage:
+      family: Stoye
+      given: J.
+      honourific: null
+      lineage: null
+  - name:
+      family: Will
+      given: T.
+      honourific: null
+      lineage: null
+  date: 2000
+  datestamp: '2017-03-03 14:40:15'
+  dir: disk0/00/00/04/00
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 400
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications400
+  lastmod: '2017-03-03 14:40:15'
+  metadata_visibility: show
+  number: 9
+  pagerange: 808-814
+  publication: BIOINFORMATICS
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:27'
+  subjects:
+  - G400
+  title: An Iterative Methods for Faster Sum-of-Pairs Multiple Sequence Alignment
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/400
+  userid: 1
+  volume: 16
+- abstract: " Variable order Markov chains (VOMCs) are a flexible class of models\t\
+    that extend the well-known Markov chains. They have been applied\r\n\tto a variety\
+    \ of problems in computational biology, e.g. protein family\r\n\tclassification.\
+    \ A linear time and space construction algorithm has\r\n\tbeen published in 2000\
+    \ by Apostolico and Bejerano. However, neither\r\n\ta report of the actual running\
+    \ time nor an implementation of it have\r\n\tever been published since. Using\
+    \ their theoretical results, we implement\r\n\tgeneral and problem oriented algorithms\
+    \ considering recent advances\r\n\tin string matching. We introduce a new software\
+    \ which is orders of\r\n\tmagnitudes faster than current tools for building VOMCs,\
+    \ and is suitable\r\n\tfor large scale analysis. Along the way we show that the\
+    \ lazy suffix\r\n\ttree algorithm by Giegerich and others can compete with state-of-the-art\r\
+    \n\tsuffix array methods in terms of time and space under the type of\r\n\tconstraints\
+    \ we have analyzed in this work. "
+  bibtex: "@inproceedings{fu_mi_publications401,\n abstract = { Variable order Markov\
+    \ chains (VOMCs) are a flexible class of models        that extend the well-known\
+    \ Markov chains. They have been applied\nto a variety of problems in computational\
+    \ biology, e.g. protein family\nclassification. A linear time and space construction\
+    \ algorithm has\nbeen published in 2000 by Apostolico and Bejerano. However, neither\n\
+    a report of the actual running time nor an implementation of it have\never been\
+    \ published since. Using their theoretical results, we implement\ngeneral and\
+    \ problem oriented algorithms considering recent advances\nin string matching.\
+    \ We introduce a new software which is orders of\nmagnitudes faster than current\
+    \ tools for building VOMCs, and is suitable\nfor large scale analysis. Along the\
+    \ way we show that the lazy suffix\ntree algorithm by Giegerich and others can\
+    \ compete with state-of-the-art\nsuffix array methods in terms of time and space\
+    \ under the type of\nconstraints we have analyzed in this work. },\n author =\
+    \ {M. H. Schulz and D. Weese and T. Rausch and A. D{\\\"o}ring and K. Reinert\
+    \ and M. Vingron},\n booktitle = {Proceedings of the 8th International Workshop\
+    \ in Algorithms in Bioinformatics       (WABI'08)},\n pages = {306--317},\n publisher\
+    \ = {Springer Verlag},\n title = {Fast and Adaptive Variable Order Markov Chain\
+    \ Construction},\n url = {http://publications.imp.fu-berlin.de/401/},\n year =\
+    \ {2008}\n}\n\n"
+  creators:
+  - name:
+      family: Schulz
+      given: M. H.
+      honourific: null
+      lineage: null
+  - name:
       family: Weese
       given: D.
-      honourific:
+      honourific: null
+      lineage: null
   - name:
-      lineage:
       family: Rausch
       given: T.
-      honourific:
+      honourific: null
+      lineage: null
   - name:
-      family: Döring
-      honourific:
+      family: "D\xF6ring"
       given: A.
-      lineage:
+      honourific: null
+      lineage: null
   - name:
       family: Reinert
       given: K.
-      honourific:
-      lineage:
+      honourific: null
+      lineage: null
   - name:
-      lineage:
       family: Vingron
       given: M.
-      honourific:
-  userid: 1
-  rev_number: 5
-  publisher: Springer Verlag
-  type: conference_item
-  title: Fast and Adaptive Variable Order Markov Chain Construction
-  status_changed: '2009-03-11 11:27:27'
-  abstract: " Variable order Markov chains (VOMCs) are a flexible class of modelsthat
-    extend the well-known Markov chains. They have been appliedto a variety
-    of problems in computational biology, e.g. protein familyclassification.
-    A linear time and space construction algorithm hasbeen published in 2000
-    by Apostolico and Bejerano. However, neithera report of the actual running
-    time nor an implementation of it haveever been published since. Using their
-    theoretical results, we implementgeneral and problem oriented algorithms
-    considering recent advancesin string matching. We introduce a new software
-    which is orders ofmagnitudes faster than current tools for building VOMCs,
-    and is suitablefor large scale analysis. Along the way we show that the
-    lazy suffixtree algorithm by Giegerich and others can compete with state-of-the-artsuffix
-    array methods in terms of time and space under the type ofconstraints we
-    have analyzed in this work. "
-  eprintid: 401
-  refereed: 'TRUE'
-  metadata_visibility: show
-  full_text_status: none
-  item_issues_count: 0
+      honourific: null
+      lineage: null
+  date: 2008
+  datestamp: '2009-04-15 07:15:58'
   dir: disk0/00/00/04/01
-  eprint_status: archive
   divisions:
   - group_algbioinf
-  subjects:
-  - G400
+  eprint_status: archive
+  eprintid: 401
+  event_title: "Proceedings of the 8th International Workshop in Algorithms in Bioinformatics\t\
+    (WABI'08)"
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications401
+  lastmod: '2009-04-15 07:16:23'
+  metadata_visibility: show
   pagerange: 306-317
-  date: 2008
-- official_url: http://bioinformatics.oxfordjournals.org/content/30/17/i356.abstract
-  ispublished: pub
-  lastmod: '2017-03-03 14:41:37'
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1451
-  creators:
-  - name:
-      given: M. H.
-      honourific:
-      family: Schulz
-      lineage:
-  - name:
-      honourific:
-      given: D.
-      family: Weese
-      lineage:
-  - name:
-      given: M.
-      honourific:
-      family: Holtgrewe
-      lineage:
-  - name:
-      honourific:
-      given: V.
-      family: Dimitrova
-      lineage:
-  - name:
-      lineage:
-      given: S.
-      honourific:
-      family: Niu
-  - name:
-      given: K.
-      honourific:
-      family: Reinert
-      lineage:
-  - name:
-      lineage:
-      family: Richard
-      given: H.
-      honourific:
-  documents:
-  - pos: 1
-    eprintid: 1451
-    security: public
-    format: application/pdf
-    main: Bioinformatics-2014-Schulz-i356-63.pdf
-    uri: http://publications.imp.fu-berlin.de/id/document/619
-    docid: 619
-    formatdesc: Main Article
-    content: supplemental
-    mime_type: application/pdf
-    relation:
-    - uri: "/id/document/1277"
-      type: http://eprints.org/relation/hasVolatileVersion
-    - type: http://eprints.org/relation/haspreviewThumbnailVersion
-      uri: "/id/document/1277"
-    - uri: "/id/document/1277"
-      type: http://eprints.org/relation/hasVersion
-    language: en
-    files:
-    - mime_type: application/pdf
-      uri: http://publications.imp.fu-berlin.de/id/file/18114
-      filesize: 472369
-      fileid: 18114
-      filename: Bioinformatics-2014-Schulz-i356-63.pdf
-      objectid: 619
-      datasetid: document
-      mtime: '2017-03-03 14:41:37'
-    rev_number: 8
-  - relation:
-    - type: http://eprints.org/relation/hasVersion
-      uri: "/id/document/1278"
-    - uri: "/id/document/1278"
-      type: http://eprints.org/relation/hasVolatileVersion
-    - type: http://eprints.org/relation/haspreviewThumbnailVersion
-      uri: "/id/document/1278"
-    files:
-    - fileid: 18117
-      objectid: 620
-      filename: fiona_supplement.pdf
-      datasetid: document
-      mtime: '2017-03-03 14:41:37'
-      uri: http://publications.imp.fu-berlin.de/id/file/18117
-      mime_type: application/pdf
-      filesize: 249703
-    language: en
-    rev_number: 6
-    pos: 2
-    eprintid: 1451
-    security: public
-    format: application/pdf
-    main: fiona_supplement.pdf
-    uri: http://publications.imp.fu-berlin.de/id/document/620
-    docid: 620
-    mime_type: application/pdf
-    formatdesc: Supplemental Material
-  publication: Bioinformatics
-  datestamp: '2014-08-26 14:02:44'
-  title: 'Fiona: a parallel and automatic strategy for read error correction'
-  abstract: 'Motivation: Automatic error correction of high-throughput sequencing
-    data can have a dramatic impact on the amount of usable base pairs and their quality.
-    It has been shown that the performance of tasks such as de novo genome assembly
-    and SNP calling can be dramatically improved after read error correction. While
-    a large number of methods specialized for correcting substitution errors as found
-    in Illumina data exist, few methods for the correction of indel errors, common
-    to technologies like 454 or Ion Torrent, have been proposed.Results: We present
-    Fiona, a new stand-alone read errorâ��correction method. Fiona provides a new
-    statistical approach for sequencing error detection and optimal error correction
-    and estimates its parameters automatically. Fiona is able to correct substitution,
-    insertion and deletion errors and can be applied to any sequencing technology.
-    It uses an efficient implementation of the partial suffix array to detect read
-    overlaps with different seed lengths in parallel. We tested Fiona on several real
-    datasets from a variety of organisms with different read lengths and compared
-    its performance with state-of-the-art methods. Fiona shows a constantly higher
-    correction accuracy over a broad range of datasets from 454 and Ion Torrent sequencers,
-    without compromise in speed.Conclusion: Fiona is an accurate parameter-free read
-    errorâ��correction method that can be run on inexpensive hardware and can make
-    use of multicore parallelization whenever available. Fiona was implemented using
-    the SeqAn library for sequence analysis and is publicly available for download
-    at http://www.seqan.de/projects/fiona.Contact: mschulz@mmci.uni-saarland.de or
-    hugues.richard@upmc.frSupplementary information: Supplementary data are available
-    at Bioinformatics online.'
-  status_changed: '2014-08-26 14:06:03'
-  userid: 30
-  rev_number: 18
-  type: article
-  eprintid: 1451
+  publisher: Springer Verlag
   refereed: 'TRUE'
-  number: 17
-  item_issues_count: 0
-  metadata_visibility: show
-  full_text_status: public
-  date_type: published
-  eprint_status: archive
-  dir: disk0/00/00/14/51
-  date: 2014
-  pagerange: i356-i363
-  subjects:
-  - C
-  - G
-  divisions:
-  - group_algbioinf
-  volume: 30
-- status_changed: '2009-04-14 14:56:57'
-  abstract: "Liquid chromatography coupled to mass spectrometry (LC-MS) has becomea
-    major tool for the study of biological processes. High-throughputLC-MS experimentsare
-    frequently conducted in modern laboratories,generating an enormous amountof
-    data per day. A manual inspectionis therefore no longer a feasible task.
-    Consequently, there is aneed for computational tools that can rapidly provide
-    informationaboutmass, elution time, and abundance of the compounds in a
-    LC-MS sample.Wepresent an algorithm for the detection and quantification
-    of peptidesin LC-MS data. Our approach is flexible and independent of the
-    MStechnology in use. It is basedon a combination of the sweep lineparadigm
-    with a novel wavelet function tailoredto detect isotopicpatterns of peptides.
-    We propose a simple voting schema to usetheredundant information in consecutive
-    scans for an accurate determinationofmonoisotopic masses and charge states.
-    By explicitly modeling theinstrument inaccuracy, we are also able to cope
-    with data sets ofdifferent quality and resolution.We evaluate our technique
-    on datafrom different instruments and show that we canrapidly estimate mass,centroid
-    of retention time and abundance of peptides in a sound algorithmicframework.
-    Finally, we compare the performance of our method to severalother techniques
-    on three data sets of varying complexity."
-  title: Computational Quantification of Peptides from LC-MS data
-  type: article
   rev_number: 5
-  userid: 1
-  creators:
-  - name:
-      lineage:
-      given: O.
-      honourific:
-      family: Schulz-Trieglaff
-  - name:
-      honourific:
-      given: R.
-      family: Hussong
-      lineage:
-  - name:
-      family: Gröpl
-      given: C.
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      given: A.
-      honourific:
-      family: Hildebrandt
-  - name:
-      lineage:
-      family: Hildebrandt
-      honourific:
-      given: A.
-  - name:
-      lineage:
-      given: Ch.
-      honourific:
-      family: Huber
-  - name:
-      given: K.
-      honourific:
-      family: Reinert
-      lineage:
-  publication: Journal of Computational Biology
-  datestamp: '2009-04-14 14:09:23'
-  lastmod: '2009-04-14 14:56:57'
-  ispublished: pub
-  uri: http://publications.imp.fu-berlin.de/id/eprint/406
-  official_url: http://dx.doi.org/10.1089/cmb.2007.0117
-  keywords: "computational mass spectrometry, liquid chromatography - massspectrometry,quantification,
-    wavelets"
-  date: 2008
-  pagerange: 685-704
-  volume: 15
-  divisions:
-  - group_algbioinf
+  status_changed: '2009-03-11 11:27:27'
   subjects:
   - G400
-  eprint_status: archive
-  dir: disk0/00/00/04/06
-  item_issues_count: 0
-  full_text_status: none
-  metadata_visibility: show
-  number: 7
-  eprintid: 406
-  refereed: 'TRUE'
-- eprint_status: archive
-  dir: disk0/00/00/04/07
-  date: 2007
-  pagerange: 473-487
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  refereed: 'TRUE'
-  eprintid: 407
-  item_issues_count: 0
-  metadata_visibility: show
-  full_text_status: none
-  creators:
-  - name:
-      family: Schulz-Trieglaff
-      honourific:
-      given: O.
-      lineage:
-  - name:
-      given: R.
-      honourific:
-      family: Hussong
-      lineage:
-  - name:
-      lineage:
-      family: Gröpl
-      given: C.
-      honourific:
-  - name:
-      family: Hildebrandt
-      honourific:
-      given: A.
-      lineage:
-  - name:
-      family: Reinert
-      given: K.
-      honourific:
-      lineage:
-  datestamp: '2009-04-14 14:18:25'
-  title: "A Fast and Accurate Algorithm for the Quantification of Peptidesfrom Mass
-    Spectrometry data"
-  status_changed: '2009-03-11 11:27:31'
-  userid: 1
-  rev_number: 3
+  title: Fast and Adaptive Variable Order Markov Chain Construction
   type: conference_item
-  lastmod: '2009-04-14 14:18:25'
-  ispublished: pub
-  uri: http://publications.imp.fu-berlin.de/id/eprint/407
-  event_title: "Proceedings of the Eleventh Annual International Conference on Researchin
-    Computational Molecular Biology (RECOMB 2007)"
-- uri: http://publications.imp.fu-berlin.de/id/eprint/408
-  ispublished: pub
-  lastmod: '2009-04-14 14:14:37'
-  official_url: http://dx.doi.org/10.1186/1471-2105-9-423
-  keywords: algorithm, benchmark, lc-ms-ms, massspec, metabolomics, proteomics
-  rev_number: 3
-  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/401
   userid: 1
-  status_changed: '2009-03-11 11:27:31'
-  abstract: "BACKGROUND: Mass Spectrometry coupled to Liquid Chromatography (LC-MS)is
-    commonly used to analyze the protein content of biological samplesin large
-    scale studies. The data resulting from an LC-MS experimentis huge, highly
-    complex and noisy. Accordingly, it has sparked newdevelopments in Bioinformatics,
-    especially in the fields of algorithmdevelopment, statistics and software
-    engineering. In a quantitativelabel-free mass spectrometry experiment, crucial
-    steps are the detectionof peptide features in the mass spectra and the alignment
-    of samplesby correcting for shifts in retention time. At the moment, it
-    isdifficult to compare the plethora of algorithms for these tasks.So
-    far, curated benchmark data exists only for peptide identificationalgorithms
-    but no data that represents a ground truth for the evaluationof feature
-    detection, alignment and filtering algorithms. RESULTS:We present LC-MSsim,
-    a simulation software for LC-ESI-MS experiments.It simulates ESI spectra
-    on the MS level. It reads a list of proteinsfrom a FASTA file and digests
-    the protein mixture using a user-definedenzyme. The software creates an
-    LC-MS data set using a predictorfor the retention time of the peptides and
-    a model for peak shapesand elution profiles of the mass spectral peaks.
-    Our software alsooffers the possibility to add contaminants, to change the
-    backgroundnoise level and includes a model for the detectability of peptidesin
-    mass spectra. After the simulation, LC-MSsim writes the simulateddata to
-    public XML formats (mzXML or mzData). The software also storesthe positions
-    (monoisotopic m/z and retention time) and ion countsof the simulated ions
-    in separate files. CONCLUSIONS: LC-MSsim generatessimulated LC-MS data sets
-    and incorporates models for peak shapesand contaminations. Algorithm developers
-    can match the results offeature detection and alignment algorithms against
-    the simulatedion lists and meaningful error rates can be computed. We anticipatethat
-    LC-MSsim will be useful to the wider community to perform benchmarkstudies
-    and comparisons between computational tools."
-  title: "LC-MSsim - a simulation software for liquid chromatography massspectrometry
-    data"
-  publication: BMC Bioinformatics
-  datestamp: '2009-04-14 14:14:37'
+- bibtex: "@misc{fu_mi_publications402,\n author = {O. Schulz-Trieglaff},\n keywords\
+    \ = {petri nets, Gillespie algorithm},\n title = {Modelling the Randomness in\
+    \ Biological Systems},\n url = {http://publications.imp.fu-berlin.de/402/},\n\
+    \ year = {2005}\n}\n\n"
   creators:
   - name:
-      lineage:
       family: Schulz-Trieglaff
-      honourific:
       given: O.
-  - name:
-      honourific:
-      given: N.
-      family: Pfeifer
-      lineage:
-  - name:
-      lineage:
-      family: Gröpl
-      honourific:
-      given: C.
-  - name:
-      given: O.
-      honourific:
-      family: Kohlbacher
-      lineage:
-  - name:
-      family: Reinert
-      honourific:
-      given: K.
-      lineage:
-  full_text_status: none
-  metadata_visibility: show
-  item_issues_count: 0
-  number: 423
-  eprintid: 408
-  refereed: 'TRUE'
-  volume: 9
-  subjects:
-  - G400
-  divisions:
-  - group_algbioinf
-  date: 2008
-  dir: disk0/00/00/04/08
-  eprint_status: archive
-- dir: disk0/00/00/04/02
-  eprint_status: archive
-  subjects:
-  - G400
-  divisions:
-  - group_algbioinf
+      honourific: null
+      lineage: null
   date: 2005
-  refereed: 'TRUE'
+  datestamp: '2017-03-03 14:40:15'
+  dir: disk0/00/00/04/02
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
   eprintid: 402
   full_text_status: none
-  metadata_visibility: show
+  ispublished: pub
   item_issues_count: 0
-  datestamp: '2017-03-03 14:40:15'
-  creators:
-  - name:
-      lineage:
-      family: Schulz-Trieglaff
-      honourific:
-      given: O.
-  type: other
-  rev_number: 3
-  userid: 1
-  status_changed: '2009-03-11 11:27:28'
-  title: Modelling the Randomness in Biological Systems
+  key: fu_mi_publications402
   keywords: petri nets, Gillespie algorithm
-  uri: http://publications.imp.fu-berlin.de/id/eprint/402
-  ispublished: pub
   lastmod: '2017-03-03 14:40:15'
-- item_issues_count: 0
-  full_text_status: none
   metadata_visibility: show
-  eprintid: 403
   refereed: 'TRUE'
-  date: 2005
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  eprint_status: archive
-  dir: disk0/00/00/04/03
-  lastmod: '2017-03-03 14:40:15'
-  ispublished: pub
-  note: "Extended abstract for talk given at Dagstuhl Seminar 05471 on ComputationalProteomics,
-    20.-25. November 2005"
-  event_title: Computational Proteomics
-  uri: http://publications.imp.fu-berlin.de/id/eprint/403
-  official_url: http://www.dagstuhl.de/05471/
+  rev_number: 3
   status_changed: '2009-03-11 11:27:28'
-  title: Software Platforms for Computational Proteomics
-  rev_number: 3
-  publisher: Dagstuhl Online Publication Server (DROPS)
-  type: conference_item
+  subjects:
+  - G400
+  title: Modelling the Randomness in Biological Systems
+  type: other
+  uri: http://publications.imp.fu-berlin.de/id/eprint/402
   userid: 1
+- bibtex: "@inproceedings{fu_mi_publications403,\n author = {O. Schulz-Trieglaff},\n\
+    \ booktitle = {Computational Proteomics},\n note = {Extended abstract for talk\
+    \ given at Dagstuhl Seminar 05471 on Computational Proteomics, 20.-25. November\
+    \ 2005},\n publisher = {Dagstuhl Online Publication Server (DROPS)},\n title =\
+    \ {Software Platforms for Computational Proteomics},\n url = {http://publications.imp.fu-berlin.de/403/},\n\
+    \ year = {2005}\n}\n\n"
   creators:
   - name:
-      lineage:
-      given: O.
-      honourific:
       family: Schulz-Trieglaff
+      given: O.
+      honourific: null
+      lineage: null
+  date: 2005
   datestamp: '2017-03-03 14:40:15'
-- lastmod: '2020-04-16 11:47:46'
-  ispublished: pub
-  uri: http://publications.imp.fu-berlin.de/id/eprint/2434
-  official_url: http://doi.org/10.1371/journal.pcbi.1007208
-  title: 'Where did you come from, where did you go: Refining metagenomic analysis
-    tools for horizontal gene transfer characterisation'
-  abstract: "Horizontal gene transfer (HGT) has changed the way we regard evolution.
-    Instead of waiting for the next generation to establish new traits, especially
-    bacteria are able to take a shortcut via HGT that enables them to pass on genes
-    from one individual to another, even across species boundaries. The tool Daisy
-    offers the first HGT detection approach based on read mapping that provides complementary
-    evidence compared to existing methods. However, Daisy relies on the acceptor and
-    donor organism involved in the HGT being known. We introduce DaisyGPS, a mapping-based
-    pipeline that is able to identify acceptor and donor reference candidates of an
-    HGT event based on sequencing reads. Acceptor and donor identification is akin
-    to species identification in metagenomic samples based on sequencing reads, a
-    problem addressed by metagenomic profiling tools. However, acceptor and donor
-    references have certain properties such that these methods cannot be directly
-    applied. DaisyGPS uses MicrobeGPS, a metagenomic profiling tool tailored towards
-    estimating the genomic distance between organisms in the sample and the reference
-    database. We enhance the underlying scoring system of MicrobeGPS to account for
-    the sequence patterns in terms of mapping coverage of an acceptor and donor involved
-    in an HGT event, and report a ranked list of reference candidates. These candidates
-    can then be further evaluated by tools like Daisy to establish HGT regions. We
-    successfully validated our approach on both simulated and real data, and show
-    its benefits in an investigation of an outbreak involving Methicillin-resistant
-    Staphylococcus aureus data.Author summaryEvolution is traditionally
-    viewed as a process where changes are only vertically inherited from parent to
-    offspring across generations. Many principles such as phylogenetic trees and even
-    the “tree of life” are based on that doctrine. The concept of horizontal gene
-    transfer changed the way we regard evolution completely. Horizontal gene transfer
-    is the movement of genetic information between distantly related organisms of
-    the same generation. Genome sequencing not only provided further evidence complementing
-    experimental evidence but also shed light onto the frequency and prominence of
-    this concept. Especially the rapid spread of antimicrobial resistance genes is
-    a prominent example for the impact that horizontal gene transfer can have for
-    public health. Next generation sequencing brought means for quick and relatively
-    cheap analysis of even complex metagenomic samples where horizontal gene transfer
-    is bound to happen frequently. Methods to directly detect and characterise horizontal
-    gene transfer from such sequencing data, however, are still lacking. We here provide
-    a method to identify organisms potentially involved in horizontal gene transfer
-    events to be used in downstream analysis that enables a characterisation of a
-    horizontal gene transfer event in terms of impact and prevalence."
-  status_changed: '2020-04-16 11:47:46'
-  userid: 132
-  type: article
-  publisher: Public Library of Science
-  rev_number: 11
-  creators:
-  - name:
-      honourific:
-      given: Enrico
-      family: Seiler
-      lineage:
-  - name:
-      given: Kathrin
-      honourific:
-      family: Trappe
-      lineage:
-  - name:
-      lineage:
-      family: Renard
-      honourific:
-      given: Bernhard Y.
-  datestamp: '2020-04-16 11:47:46'
-  publication: PLOS Computational Biology
-  id_number: doi:10.1371/journal.pcbi.1007208
-  metadata_visibility: show
+  dir: disk0/00/00/04/03
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 403
+  event_title: Computational Proteomics
   full_text_status: none
-  date_type: published
-  eprintid: 2434
-  refereed: 'TRUE'
-  number: 7
-  date: '2019-07-23'
-  pagerange: e1007208
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  volume: 15
-  eprint_status: archive
-  dir: disk0/00/00/24/34
-  issn: 1553-7358
-- official_url: http://nar.oxfordjournals.org/content/41/7/e78
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1161
-  lastmod: '2013-08-10 09:39:39'
   ispublished: pub
-  datestamp: '2012-09-12 08:48:19'
-  publication: Oxford Journals
-  creators:
-  - name:
-      lineage:
-      family: Siragusa
-      given: E.
-      honourific:
-  - name:
-      lineage:
-      honourific:
-      given: D.
-      family: Weese
-  - name:
-      lineage:
-      given: K.
-      honourific:
-      family: Reinert
-  userid: 30
-  publisher: Oxford University Press
-  type: article
-  rev_number: 19
-  title: Fast and accurate read mapping with approximate seeds and multiple backtracking
-  abstract: We present Masai, a read mapper representing the state-of-the-art in terms
-    of speed and accuracy. Our tool is an order of magnitude faster than RazerS 3
-    and mrFAST, 2–4 times faster and more accurate than Bowtie 2 and BWA. The novelties
-    of our read mapper are filtration with approximate seeds and a method for multiple
-    backtracking. Approximate seeds, compared with exact seeds, increase filtration
-    specificity while preserving sensitivity. Multiple backtracking amortizes the
-    cost of searching a large set of seeds by taking advantage of the repetitiveness
-    of next-generation sequencing data. Combined together, these two methods significantly
-    speed up approximate search on genomic data sets. Masai is implemented in C++
-    using the SeqAn library. The source code is distributed under the BSD license
-    and binaries for Linux, Mac OS X and Windows can be freely downloaded from http://www.seqan.de/projects/masai.
-  status_changed: '2013-08-10 09:39:39'
-  eprintid: 1161
-  refereed: 'TRUE'
-  number: 7
-  metadata_visibility: show
-  id_number: 10.1093/nar/gkt005
-  full_text_status: none
-  date_type: published
   item_issues_count: 0
-  dir: disk0/00/00/11/61
-  issn: Print ISSN 0305-1048; Online ISSN 1362-4962
-  eprint_status: archive
-  divisions:
-  - group_algbioinf
-  subjects:
-  - C
-  - G
-  volume: 41
-  date: '2013-01-28'
-  pagerange: e78
-- event_title: Proceedings of the Joint EDBT/ICDT 2013 Workshops
-  keywords: approximate seeds, backtracking, banded Myers bit-vector, banded dynamic
-    programming, filtration, radix tree, suffix tree
-  event_location: Genoa, Italy
-  abstract: We present in this paper scalable algorithms for optimal string similarity
-    search and join. Our methods are variations of those applied in Masai [15], our
-    recently published tool for mapping high-throughput DNA sequencing data with unpreceded
-    speed and accuracy. The key features of our approach are filtration with approximate
-    seeds and methods for multiple backtracking. Approximate seeds, compared to exact
-    seeds, increase filtration specificity while preserving sensitivity. Multiple
-    backtracking amortizes the cost of searching a large set of seeds. Combined together,
-    these two methods significantly speed up string similarity search and join operations.
-    Our tool is implemented in C++ and OpenMP using the SeqAn library. The source
-    code is distributed under the BSD license and can be freely downloaded from http://www.seqan.de/projects/edbt2013.
-  title: Scalable string similarity search/join with approximate seeds and multiple
-    backtracking
-  type: conference_item
-  userid: 132
-  creators:
-  - name:
-      lineage:
-      given: E.
-      honourific:
-      family: Siragusa
-  - name:
-      lineage:
-      family: Weese
-      given: D.
-      honourific:
-  - name:
-      lineage:
-      honourific:
-      given: K.
-      family: Reinert
-  datestamp: '2013-03-28 12:24:08'
-  related_url:
-  - url: http://dl.acm.org/citation.cfm?id=2457386&bnc=1
-  series: EDBT '13
-  full_text_status: none
-  eprintid: 1225
-  refereed: 'TRUE'
-  place_of_pub: New York, NY, USA
-  date: 2013
-  subjects:
-  - G400
-  ispublished: pub
-  lastmod: '2013-08-10 11:41:05'
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1225
-  official_url: http://doi.acm.org/10.1145/2457317.2457386
-  status_changed: '2013-08-10 11:41:05'
-  rev_number: 18
-  publisher: ACM
-  event_type: workshop
-  item_issues_count: 0
-  date_type: published
+  key: fu_mi_publications403
+  lastmod: '2017-03-03 14:40:15'
   metadata_visibility: show
-  pres_type: paper
-  pagerange: 370-374
-  divisions:
-  - group_algbioinf
-  eprint_status: archive
-  dir: disk0/00/00/12/25
-- userid: 30
-  type: article
-  publisher: Nature Publishing Group
-  rev_number: 20
-  title: Assessment of transcript reconstruction methods for RNA-seq
-  contact_email: david.weese@fu-berlin.de
-  abstract: We evaluated 25 protocol variants of 14 independent computational methods
-    for exon identification, transcript reconstruction and expression-level quantification
-    from RNA-seq data. Our results show that most algorithms are able to identify
-    discrete transcript components with high success rates but that assembly of complete
-    isoform structures poses a major challenge even when all constituent elements
-    are identified. Expression-level estimates also varied widely across methods,
-    even when based on similar transcript models. Consequently, the complexity of
-    higher eukaryotic genomes imposes severe limitations on transcript recall and
-    splice product discrimination that are likely to remain limiting factors for the
-    analysis of current-generation RNA-seq data.
-  status_changed: '2014-02-21 05:42:01'
-  documents:
-  - security: public
-    pos: 1
-    eprintid: 1380
-    uri: http://publications.imp.fu-berlin.de/id/document/595
-    main: nmeth.2714.pdf
-    docid: 595
-    mime_type: application/pdf
-    content: published
-    format: application/pdf
-    relation:
-    - type: http://eprints.org/relation/haspreviewThumbnailVersion
-      uri: "/id/document/1267"
-    - type: http://eprints.org/relation/hasVolatileVersion
-      uri: "/id/document/1267"
-    - uri: "/id/document/1267"
-      type: http://eprints.org/relation/hasVersion
-    language: en
-    files:
-    - fileid: 17299
-      objectid: 595
-      filename: nmeth.2714.pdf
-      datasetid: document
-      mtime: '2017-03-03 14:41:32'
-      mime_type: application/pdf
-      uri: http://publications.imp.fu-berlin.de/id/file/17299
-      filesize: 649888
-    rev_number: 4
-  publication: Nature Methods
-  datestamp: '2014-02-20 22:54:03'
-  creators:
-  - name:
-      lineage:
-      family: Steijger
-      given: T.
-      honourific:
-  - name:
-      given: J. F.
-      honourific:
-      family: Abril
-      lineage:
-  - name:
-      honourific:
-      given: P. G.
-      family: Engström
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: F.
-      family: Kokocinski
-  - name:
-      lineage:
-      family: The RGASP Consortium
-      honourific:
-      given:
-  - name:
-      lineage:
-      given: H.
-      honourific:
-      family: Richard
-  - name:
-      given: M. H.
-      honourific:
-      family: Schulz
-      lineage:
-  - name:
-      honourific:
-      given: D.
-      family: Weese
-      lineage:
-  - name:
-      family: Hubbard
-      honourific:
-      given: T.
-      lineage:
-  - name:
-      lineage:
-      family: Guigó
-      given: R.
-      honourific:
-  - name:
-      lineage:
-      given: J.
-      honourific:
-      family: Harrow
-  - name:
-      lineage:
-      given: P.
-      honourific:
-      family: Bertone
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1380
-  ispublished: pub
-  lastmod: '2017-03-03 14:41:32'
-  official_url: http://dx.doi.org/10.1038/nmeth.2714
-  divisions:
-  - group_algbioinf
-  subjects:
-  - C
-  - G400
-  volume: 10
-  date: '2013-11-03'
-  pagerange: 1177-1184
-  dir: disk0/00/00/13/80
-  eprint_status: archive
-  metadata_visibility: show
-  id_number: 10.1038/nmeth.2714
-  date_type: published
-  full_text_status: public
-  item_issues_count: 0
-  eprintid: 1380
+  note: "Extended abstract for talk given at Dagstuhl Seminar 05471 on Computational\t\
+    Proteomics, 20.-25. November 2005"
+  official_url: http://www.dagstuhl.de/05471/
+  publisher: Dagstuhl Online Publication Server (DROPS)
   refereed: 'TRUE'
-  number: 12
-- uri: http://publications.imp.fu-berlin.de/id/eprint/409
-  ispublished: pub
-  lastmod: '2009-04-14 14:16:52'
-  keywords: lc-ms-ms, massspec, proteomics
-  official_url: http://dx.doi.org/10.1186/1471-2105-9-163
-  userid: 1
-  type: article
   rev_number: 3
-  title: OpenMS - An open-source software framework for mass spectrometry
-  abstract: "BACKGROUND: Mass spectrometry is an essential analytical techniquefor
-    high-throughput analysis in proteomics and metabolomics. Thedevelopment
-    of new separation techniques, precise mass analyzersand experimental protocols
-    is a very active field of research. Thisleads to more complex experimental
-    setups yielding ever increasingamounts of data. Consequently, analysis of
-    the data is currentlyoften the bottleneck for experimental studies. Although
-    softwaretools for many data analysis tasks are available today, they areoften
-    hard to combine with each other or not flexible enough to allowfor rapid
-    prototyping of a new analysis workflow. RESULTS: We presentOpenMS, a software
-    framework for rapid application development inmass spectrometry. OpenMS
-    has been designed to be portable, easy-to-useand robust while offering a
-    rich functionality ranging from basicdata structures to sophisticated algorithms
-    for data analysis. Thishas already been demonstrated in several studies.
-    CONCLUSIONS: OpenMSis available under the Lesser GNU Public License (LGPL)
-    from theproject website at http://www.openms.de."
-  status_changed: '2009-03-11 11:27:32'
-  datestamp: '2009-04-14 14:16:52'
+  status_changed: '2009-03-11 11:27:28'
+  subjects:
+  - G400
+  title: Software Platforms for Computational Proteomics
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/403
+  userid: 1
+- abstract: "Liquid chromatography coupled to mass spectrometry (LC-MS) has become\t\
+    a major tool for the study of biological processes. High-throughput\r\n\tLC-MS\
+    \ experimentsare frequently conducted in modern laboratories,\r\n\tgenerating\
+    \ an enormous amountof data per day. A manual inspection\r\n\tis therefore no\
+    \ longer a feasible task. Consequently, there is a\r\n\tneed for computational\
+    \ tools that can rapidly provide informationabout\r\n\tmass, elution time, and\
+    \ abundance of the compounds in a LC-MS sample.\r\n\tWepresent an algorithm for\
+    \ the detection and quantification of peptides\r\n\tin LC-MS data. Our approach\
+    \ is flexible and independent of the MS\r\n\ttechnology in use. It is basedon\
+    \ a combination of the sweep line\r\n\tparadigm with a novel wavelet function\
+    \ tailoredto detect isotopic\r\n\tpatterns of peptides. We propose a simple voting\
+    \ schema to usethe\r\n\tredundant information in consecutive scans for an accurate\
+    \ determination\r\n\tofmonoisotopic masses and charge states. By explicitly modeling\
+    \ the\r\n\tinstrument inaccuracy, we are also able to cope with data sets of\r\
+    \n\tdifferent quality and resolution.We evaluate our technique on data\r\n\tfrom\
+    \ different instruments and show that we canrapidly estimate mass,\r\n\tcentroid\
+    \ of retention time and abundance of peptides in a sound algorithmic\r\n\tframework.\
+    \ Finally, we compare the performance of our method to several\r\n\tother techniques\
+    \ on three data sets of varying complexity."
+  bibtex: "@article{fu_mi_publications406,\n abstract = {Liquid chromatography coupled\
+    \ to mass spectrometry (LC-MS) has become       a major tool for the study of\
+    \ biological processes. High-throughput\nLC-MS experimentsare frequently conducted\
+    \ in modern laboratories,\ngenerating an enormous amountof data per day. A manual\
+    \ inspection\nis therefore no longer a feasible task. Consequently, there is a\n\
+    need for computational tools that can rapidly provide informationabout\nmass,\
+    \ elution time, and abundance of the compounds in a LC-MS sample.\nWepresent an\
+    \ algorithm for the detection and quantification of peptides\nin LC-MS data. Our\
+    \ approach is flexible and independent of the MS\ntechnology in use. It is basedon\
+    \ a combination of the sweep line\nparadigm with a novel wavelet function tailoredto\
+    \ detect isotopic\npatterns of peptides. We propose a simple voting schema to\
+    \ usethe\nredundant information in consecutive scans for an accurate determination\n\
+    ofmonoisotopic masses and charge states. By explicitly modeling the\ninstrument\
+    \ inaccuracy, we are also able to cope with data sets of\ndifferent quality and\
+    \ resolution.We evaluate our technique on data\nfrom different instruments and\
+    \ show that we canrapidly estimate mass,\ncentroid of retention time and abundance\
+    \ of peptides in a sound algorithmic\nframework. Finally, we compare the performance\
+    \ of our method to several\nother techniques on three data sets of varying complexity.},\n\
+    \ author = {O. Schulz-Trieglaff and R. Hussong and C. Gr{\\\"o}pl and A. Hildebrandt\
+    \ and A. Hildebrandt and Ch. Huber and K. Reinert},\n journal = {Journal of Computational\
+    \ Biology},\n keywords = {computational mass spectrometry, liquid chromatography\
+    \ - massspectrometry,  quantification, wavelets},\n number = {7},\n pages = {685--704},\n\
+    \ title = {Computational Quantification of Peptides from LC-MS data},\n url =\
+    \ {http://publications.imp.fu-berlin.de/406/},\n volume = {15},\n year = {2008}\n\
+    }\n\n"
+  creators:
+  - name:
+      family: Schulz-Trieglaff
+      given: O.
+      honourific: null
+      lineage: null
+  - name:
+      family: Hussong
+      given: R.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: Hildebrandt
+      given: A.
+      honourific: null
+      lineage: null
+  - name:
+      family: Hildebrandt
+      given: A.
+      honourific: null
+      lineage: null
+  - name:
+      family: Huber
+      given: Ch.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: 2008
+  datestamp: '2009-04-14 14:09:23'
+  dir: disk0/00/00/04/06
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 406
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications406
+  keywords: "computational mass spectrometry, liquid chromatography - massspectrometry,\t\
+    quantification, wavelets"
+  lastmod: '2009-04-14 14:56:57'
+  metadata_visibility: show
+  number: 7
+  official_url: http://dx.doi.org/10.1089/cmb.2007.0117
+  pagerange: 685-704
+  publication: Journal of Computational Biology
+  refereed: 'TRUE'
+  rev_number: 5
+  status_changed: '2009-04-14 14:56:57'
+  subjects:
+  - G400
+  title: Computational Quantification of Peptides from LC-MS data
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/406
+  userid: 1
+  volume: 15
+- bibtex: "@inproceedings{fu_mi_publications407,\n author = {O. Schulz-Trieglaff and\
+    \ R. Hussong and C. Gr{\\\"o}pl and A. Hildebrandt and K. Reinert},\n booktitle\
+    \ = {Proceedings of the Eleventh Annual International Conference on Research \
+    \    in Computational Molecular Biology (RECOMB 2007)},\n pages = {473--487},\n\
+    \ title = {A Fast and Accurate Algorithm for the Quantification of Peptides  \
+    \  from Mass Spectrometry data},\n url = {http://publications.imp.fu-berlin.de/407/},\n\
+    \ year = {2007}\n}\n\n"
+  creators:
+  - name:
+      family: Schulz-Trieglaff
+      given: O.
+      honourific: null
+      lineage: null
+  - name:
+      family: Hussong
+      given: R.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: Hildebrandt
+      given: A.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: 2007
+  datestamp: '2009-04-14 14:18:25'
+  dir: disk0/00/00/04/07
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 407
+  event_title: "Proceedings of the Eleventh Annual International Conference on Research\t\
+    in Computational Molecular Biology (RECOMB 2007)"
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications407
+  lastmod: '2009-04-14 14:18:25'
+  metadata_visibility: show
+  pagerange: 473-487
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:31'
+  subjects:
+  - G400
+  title: "A Fast and Accurate Algorithm for the Quantification of Peptides\tfrom Mass\
+    \ Spectrometry data"
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/407
+  userid: 1
+- abstract: "BACKGROUND: Mass Spectrometry coupled to Liquid Chromatography (LC-MS)\t\
+    is commonly used to analyze the protein content of biological samples\r\n\tin\
+    \ large scale studies. The data resulting from an LC-MS experiment\r\n\tis huge,\
+    \ highly complex and noisy. Accordingly, it has sparked new\r\n\tdevelopments\
+    \ in Bioinformatics, especially in the fields of algorithm\r\n\tdevelopment, statistics\
+    \ and software engineering. In a quantitative\r\n\tlabel-free mass spectrometry\
+    \ experiment, crucial steps are the detection\r\n\tof peptide features in the\
+    \ mass spectra and the alignment of samples\r\n\tby correcting for shifts in retention\
+    \ time. At the moment, it is\r\n\tdifficult to compare the plethora of algorithms\
+    \ for these tasks.\r\n\tSo far, curated benchmark data exists only for peptide\
+    \ identification\r\n\talgorithms but no data that represents a ground truth for\
+    \ the evaluation\r\n\tof feature detection, alignment and filtering algorithms.\
+    \ RESULTS:\r\n\tWe present LC-MSsim, a simulation software for LC-ESI-MS experiments.\r\
+    \n\tIt simulates ESI spectra on the MS level. It reads a list of proteins\r\n\t\
+    from a FASTA file and digests the protein mixture using a user-defined\r\n\tenzyme.\
+    \ The software creates an LC-MS data set using a predictor\r\n\tfor the retention\
+    \ time of the peptides and a model for peak shapes\r\n\tand elution profiles of\
+    \ the mass spectral peaks. Our software also\r\n\toffers the possibility to add\
+    \ contaminants, to change the background\r\n\tnoise level and includes a model\
+    \ for the detectability of peptides\r\n\tin mass spectra. After the simulation,\
+    \ LC-MSsim writes the simulated\r\n\tdata to public XML formats (mzXML or mzData).\
+    \ The software also stores\r\n\tthe positions (monoisotopic m/z and retention\
+    \ time) and ion counts\r\n\tof the simulated ions in separate files. CONCLUSIONS:\
+    \ LC-MSsim generates\r\n\tsimulated LC-MS data sets and incorporates models for\
+    \ peak shapes\r\n\tand contaminations. Algorithm developers can match the results\
+    \ of\r\n\tfeature detection and alignment algorithms against the simulated\r\n\
+    \tion lists and meaningful error rates can be computed. We anticipate\r\n\tthat\
+    \ LC-MSsim will be useful to the wider community to perform benchmark\r\n\tstudies\
+    \ and comparisons between computational tools."
+  bibtex: "@article{fu_mi_publications408,\n abstract = {BACKGROUND: Mass Spectrometry\
+    \ coupled to Liquid Chromatography (LC-MS)      is commonly used to analyze the\
+    \ protein content of biological samples\nin large scale studies. The data resulting\
+    \ from an LC-MS experiment\nis huge, highly complex and noisy. Accordingly, it\
+    \ has sparked new\ndevelopments in Bioinformatics, especially in the fields of\
+    \ algorithm\ndevelopment, statistics and software engineering. In a quantitative\n\
+    label-free mass spectrometry experiment, crucial steps are the detection\nof peptide\
+    \ features in the mass spectra and the alignment of samples\nby correcting for\
+    \ shifts in retention time. At the moment, it is\ndifficult to compare the plethora\
+    \ of algorithms for these tasks.\nSo far, curated benchmark data exists only for\
+    \ peptide identification\nalgorithms but no data that represents a ground truth\
+    \ for the evaluation\nof feature detection, alignment and filtering algorithms.\
+    \ RESULTS:\nWe present LC-MSsim, a simulation software for LC-ESI-MS experiments.\n\
+    It simulates ESI spectra on the MS level. It reads a list of proteins\nfrom a\
+    \ FASTA file and digests the protein mixture using a user-defined\nenzyme. The\
+    \ software creates an LC-MS data set using a predictor\nfor the retention time\
+    \ of the peptides and a model for peak shapes\nand elution profiles of the mass\
+    \ spectral peaks. Our software also\noffers the possibility to add contaminants,\
+    \ to change the background\nnoise level and includes a model for the detectability\
+    \ of peptides\nin mass spectra. After the simulation, LC-MSsim writes the simulated\n\
+    data to public XML formats (mzXML or mzData). The software also stores\nthe positions\
+    \ (monoisotopic m/z and retention time) and ion counts\nof the simulated ions\
+    \ in separate files. CONCLUSIONS: LC-MSsim generates\nsimulated LC-MS data sets\
+    \ and incorporates models for peak shapes\nand contaminations. Algorithm developers\
+    \ can match the results of\nfeature detection and alignment algorithms against\
+    \ the simulated\nion lists and meaningful error rates can be computed. We anticipate\n\
+    that LC-MSsim will be useful to the wider community to perform benchmark\nstudies\
+    \ and comparisons between computational tools.},\n author = {O. Schulz-Trieglaff\
+    \ and N. Pfeifer and C. Gr{\\\"o}pl and O. Kohlbacher and K. Reinert},\n journal\
+    \ = {BMC Bioinformatics},\n keywords = {algorithm, benchmark, lc-ms-ms, massspec,\
+    \ metabolomics, proteomics},\n number = {423},\n title = {LC-MSsim - a simulation\
+    \ software for liquid chromatography mass     spectrometry data},\n url = {http://publications.imp.fu-berlin.de/408/},\n\
+    \ volume = {9},\n year = {2008}\n}\n\n"
+  creators:
+  - name:
+      family: Schulz-Trieglaff
+      given: O.
+      honourific: null
+      lineage: null
+  - name:
+      family: Pfeifer
+      given: N.
+      honourific: null
+      lineage: null
+  - name:
+      family: "Gr\xF6pl"
+      given: C.
+      honourific: null
+      lineage: null
+  - name:
+      family: Kohlbacher
+      given: O.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: 2008
+  datestamp: '2009-04-14 14:14:37'
+  dir: disk0/00/00/04/08
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 408
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications408
+  keywords: algorithm, benchmark, lc-ms-ms, massspec, metabolomics, proteomics
+  lastmod: '2009-04-14 14:14:37'
+  metadata_visibility: show
+  number: 423
+  official_url: http://dx.doi.org/10.1186/1471-2105-9-423
   publication: BMC Bioinformatics
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:31'
+  subjects:
+  - G400
+  title: "LC-MSsim - a simulation software for liquid chromatography mass\tspectrometry\
+    \ data"
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/408
+  userid: 1
+  volume: 9
+- abstract: "BACKGROUND: Mass spectrometry is an essential analytical technique\t\
+    for high-throughput analysis in proteomics and metabolomics. The\r\n\tdevelopment\
+    \ of new separation techniques, precise mass analyzers\r\n\tand experimental protocols\
+    \ is a very active field of research. This\r\n\tleads to more complex experimental\
+    \ setups yielding ever increasing\r\n\tamounts of data. Consequently, analysis\
+    \ of the data is currently\r\n\toften the bottleneck for experimental studies.\
+    \ Although software\r\n\ttools for many data analysis tasks are available today,\
+    \ they are\r\n\toften hard to combine with each other or not flexible enough to\
+    \ allow\r\n\tfor rapid prototyping of a new analysis workflow. RESULTS: We present\r\
+    \n\tOpenMS, a software framework for rapid application development in\r\n\tmass\
+    \ spectrometry. OpenMS has been designed to be portable, easy-to-use\r\n\tand\
+    \ robust while offering a rich functionality ranging from basic\r\n\tdata structures\
+    \ to sophisticated algorithms for data analysis. This\r\n\thas already been demonstrated\
+    \ in several studies. CONCLUSIONS: OpenMS\r\n\tis available under the Lesser GNU\
+    \ Public License (LGPL) from the\r\n\tproject website at http://www.openms.de."
+  bibtex: "@article{fu_mi_publications409,\n abstract = {BACKGROUND: Mass spectrometry\
+    \ is an essential analytical technique  for high-throughput analysis in proteomics\
+    \ and metabolomics. The\ndevelopment of new separation techniques, precise mass\
+    \ analyzers\nand experimental protocols is a very active field of research. This\n\
+    leads to more complex experimental setups yielding ever increasing\namounts of\
+    \ data. Consequently, analysis of the data is currently\noften the bottleneck\
+    \ for experimental studies. Although software\ntools for many data analysis tasks\
+    \ are available today, they are\noften hard to combine with each other or not\
+    \ flexible enough to allow\nfor rapid prototyping of a new analysis workflow.\
+    \ RESULTS: We present\nOpenMS, a software framework for rapid application development\
+    \ in\nmass spectrometry. OpenMS has been designed to be portable, easy-to-use\n\
+    and robust while offering a rich functionality ranging from basic\ndata structures\
+    \ to sophisticated algorithms for data analysis. This\nhas already been demonstrated\
+    \ in several studies. CONCLUSIONS: OpenMS\nis available under the Lesser GNU Public\
+    \ License (LGPL) from the\nproject website at http://www.openms.de.},\n author\
+    \ = {M. Sturm and B. Andreas and C. Gr{\\\"o}pl and R. Hussong and E. Lange and\
+    \ N. Pfeifer and O. Schulz-Trieglaff and A. Zerck and K. Reinert and O. Kohlbacher},\n\
+    \ journal = {BMC Bioinformatics},\n keywords = {lc-ms-ms, massspec, proteomics},\n\
+    \ number = {163},\n title = {OpenMS - An open-source software framework for mass\
+    \ spectrometry},\n url = {http://publications.imp.fu-berlin.de/409/},\n volume\
+    \ = {9},\n year = {2008}\n}\n\n"
   creators:
   - name:
       family: Sturm
-      honourific:
       given: M.
-      lineage:
+      honourific: null
+      lineage: null
   - name:
-      lineage:
-      given: B.
-      honourific:
       family: Andreas
+      given: B.
+      honourific: null
+      lineage: null
   - name:
-      lineage:
-      family: Gröpl
-      honourific:
+      family: "Gr\xF6pl"
       given: C.
+      honourific: null
+      lineage: null
   - name:
       family: Hussong
-      honourific:
       given: R.
-      lineage:
+      honourific: null
+      lineage: null
   - name:
-      lineage:
       family: Lange
       given: E.
-      honourific:
+      honourific: null
+      lineage: null
   - name:
-      lineage:
-      honourific:
-      given: N.
       family: Pfeifer
+      given: N.
+      honourific: null
+      lineage: null
   - name:
-      lineage:
       family: Schulz-Trieglaff
       given: O.
-      honourific:
+      honourific: null
+      lineage: null
   - name:
-      lineage:
       family: Zerck
-      honourific:
       given: A.
+      honourific: null
+      lineage: null
   - name:
       family: Reinert
       given: K.
-      honourific:
-      lineage:
+      honourific: null
+      lineage: null
   - name:
-      lineage:
-      given: O.
-      honourific:
       family: Kohlbacher
-  metadata_visibility: show
-  full_text_status: none
-  item_issues_count: 0
-  eprintid: 409
-  refereed: 'TRUE'
-  number: 163
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  volume: 9
+      given: O.
+      honourific: null
+      lineage: null
   date: 2008
+  datestamp: '2009-04-14 14:16:52'
   dir: disk0/00/00/04/09
+  divisions:
+  - group_algbioinf
   eprint_status: archive
-- lastmod: '2014-12-10 15:11:44'
-  ispublished: pub
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1455
-  official_url: http://bioinformatics.oxfordjournals.org/content/early/2014/07/29/bioinformatics.btu431.full
-  abstract: "MOTIVATION:The landscape of structural variation (SV) including complex
-    duplication and translocation patterns is far from resolved. SV detection tools
-    usually exhibit low agreement, are often geared toward certain types or size ranges
-    of variation and struggle to correctly classify the type and exact size of SVs.RESULTS:We
-    present Gustaf (Generic mUlti-SpliT Alignment Finder), a sound generic multi-split
-    SV detection tool that detects and classifies deletions, inversions, dispersed
-    duplications and translocations of <span class='mathrm'>ge</span>30 bp. Our approach
-    is based on a generic multi-split alignment strategy that can identify SV breakpoints
-    with base pair resolution. We show that Gustaf correctly identifies SVs, especially
-    in the range from 30 to 100 bp, which we call the next-generation sequencing (NGS)
-    twilight zone of SVs, as well as larger SVs &gt;500 bp. Gustaf performs better
-    than similar tools in our benchmark and is furthermore able to correctly identify
-    size and location of dispersed duplications and translocations, which otherwise
-    might be wrongly classified, for example, as large deletions. Availability and
-    implementation: Project information, paper benchmark and source code are available
-    via http://www.seqan.de/projects/gustaf/.CONTACT:kathrin.trappe@fu-berlin.de."
-  status_changed: '2014-12-10 15:11:43'
-  title: 'Gustaf: Detecting and correctly classifying SVs in the NGS twilight zone'
-  type: article
-  publisher: Oxford University Press
-  rev_number: 12
-  userid: 29
-  creators:
-  - id:
-    name:
-      family: Trappe
-      honourific:
-      given: K.
-      lineage:
-  - id:
-    name:
-      lineage:
-      family: Emde
-      honourific:
-      given: A.-K.
-  - name:
-      lineage:
-      family: Ehrlich
-      given: H.-C.
-      honourific:
-    id:
-  - id: knut.reinert@fu-berlin.de
-    name:
-      family: Reinert
-      given: K.
-      honourific:
-      lineage:
-  publication: Bioinformatics
-  datestamp: '2014-09-30 11:00:30'
-  item_issues_count: 0
+  eprintid: 409
   full_text_status: none
-  date_type: published
-  metadata_visibility: show
-  number: 24
-  refereed: 'TRUE'
-  eprintid: 1455
-  pagerange: 3484-3490
-  date: '2014-07-14'
-  volume: 30
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G620
-  - G400
-  eprint_status: archive
-  issn: 1367-4803
-  dir: disk0/00/00/14/55
-- full_text_status: none
-  metadata_visibility: show
-  item_issues_count: 0
-  eprintid: 410
-  refereed: 'TRUE'
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  pagerange: 7-18
-  date: 2001
-  dir: disk0/00/00/04/10
-  eprint_status: archive
-  event_title: "IEEE 2001 Symposium on Parallel and Large-Data Visualization andGraphics"
-  uri: http://publications.imp.fu-berlin.de/id/eprint/410
-  lastmod: '2017-03-03 14:40:15'
   ispublished: pub
-  note: Keynote address
-  type: conference_item
+  item_issues_count: 0
+  key: fu_mi_publications409
+  keywords: lc-ms-ms, massspec, proteomics
+  lastmod: '2009-04-14 14:16:52'
+  metadata_visibility: show
+  number: 163
+  official_url: http://dx.doi.org/10.1186/1471-2105-9-163
+  publication: BMC Bioinformatics
+  refereed: 'TRUE'
   rev_number: 3
-  userid: 1
   status_changed: '2009-03-11 11:27:32'
-  title: Visualization Challenges for a New Cyberpharmaceutical Computing
-  datestamp: '2017-03-03 14:40:15'
+  subjects:
+  - G400
+  title: OpenMS - An open-source software framework for mass spectrometry
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/409
+  userid: 1
+  volume: 9
+- bibtex: "@inproceedings{fu_mi_publications410,\n author = {R. J. Turner and K. Chaturvedi\
+    \ and N. J. Edwards and A. L. Halpern and D. H. Huson and O. Kohlbacher and J.\
+    \ R. Miller and K. Reinert and K. A. Remington and R. Schwartz and B. Walenz and\
+    \ S. Yooseph and S. Istrail},\n booktitle = {IEEE 2001 Symposium on Parallel and\
+    \ Large-Data Visualization and    Graphics},\n note = {Keynote address},\n pages\
+    \ = {7--18},\n title = {Visualization Challenges for a New Cyberpharmaceutical\
+    \ Computing},\n url = {http://publications.imp.fu-berlin.de/410/},\n year = {2001}\n\
+    }\n\n"
   creators:
   - name:
-      given: R. J.
-      honourific:
       family: Turner
-      lineage:
+      given: R. J.
+      honourific: null
+      lineage: null
   - name:
-      honourific:
-      given: K.
       family: Chaturvedi
-      lineage:
+      given: K.
+      honourific: null
+      lineage: null
   - name:
       family: Edwards
       given: N. J.
-      honourific:
-      lineage:
+      honourific: null
+      lineage: null
   - name:
-      lineage:
-      given: A. L.
-      honourific:
       family: Halpern
+      given: A. L.
+      honourific: null
+      lineage: null
   - name:
       family: Huson
       given: D. H.
-      honourific:
-      lineage:
+      honourific: null
+      lineage: null
   - name:
-      lineage:
-      honourific:
-      given: O.
       family: Kohlbacher
+      given: O.
+      honourific: null
+      lineage: null
   - name:
       family: Miller
       given: J. R.
-      honourific:
-      lineage:
+      honourific: null
+      lineage: null
   - name:
-      lineage:
       family: Reinert
       given: K.
-      honourific:
+      honourific: null
+      lineage: null
   - name:
       family: Remington
-      honourific:
       given: K. A.
-      lineage:
+      honourific: null
+      lineage: null
   - name:
       family: Schwartz
       given: R.
-      honourific:
-      lineage:
+      honourific: null
+      lineage: null
   - name:
-      lineage:
-      given: B.
-      honourific:
       family: Walenz
+      given: B.
+      honourific: null
+      lineage: null
   - name:
-      lineage:
       family: Yooseph
       given: S.
-      honourific:
+      honourific: null
+      lineage: null
   - name:
-      given: S.
-      honourific:
       family: Istrail
-      lineage:
-- eprintid: 1976
-  refereed: 'TRUE'
-  number: 4
-  item_issues_count: 0
-  metadata_visibility: show
-  id_number: doi:10.1007/s00216-016-0013-z
-  full_text_status: none
-  date_type: published
-  eprint_status: archive
-  dir: disk0/00/00/19/76
-  issn: 1618-2642
-  date: 2017-02
-  pagerange: 989-997
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  volume: 409
-  official_url: http://dx.doi.org/10.1007/s00216-016-0013-z
-  ispublished: pub
-  lastmod: '2017-09-12 13:35:25'
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1976
-  creators:
-  - name:
-      family: Vatansever
-      honourific:
-      given: B.
-      lineage:
-  - name:
-      family: Muñoz
-      honourific:
-      given: A.
-      lineage:
-  - name:
-      lineage:
-      family: Klein
-      honourific:
-      given: C. L.
-  - name:
-      lineage:
-      honourific:
-      given: K.
-      family: Reinert
-  datestamp: '2016-11-03 11:34:05'
-  publication: Analytical and Bioanalytical Chemistry
-  title: Development and optimisation of a generic micro LC-ESI-MS method for the
-    qualitative and quantitative determination of 30-mer toxic gliadin peptides in
-    wheat flour for food analysis
-  abstract: We sometimes see manufactured bakery products on the market which are
-    labelled as being gluten free. Why is the content of such gluten proteins of importance
-    for the fabrication of bakery industry and for the products? The gluten proteins
-    represent up to 80 % of wheat proteins, and they are conventionally subdivided
-    into gliadins and glutenins. Gliadins belong to the proline and glutamine-rich
-    prolamin family. Its role in human gluten intolerance, as a consequence of its
-    harmful effects, is well documented in the scientific literature. The only known
-    therapy so far is a gluten-free diet, and hence, it is important to develop robust
-    and reliable analytical methods to quantitatively assess the presence of the identified
-    peptides causing the so-called coeliac disease. This work describes the development
-    of a new, fast and robust micro ion pair-LC-MS analytical method for the qualitative
-    and quantitative determination of 30-mer toxic gliadin peptides in wheat flour.
-    The use of RapiGest™ SF as a denaturation reagent prior to the enzymatic digestion
-    showed to shorten the measuring time. During the optimisation of the enzymatic
-    digestion step, the best 30-mer toxic peptide was identified from the maximum
-    recovery after 3 h of digestion time. The lower limit of quantification was determined
-    to be 0.25 ng/μL. The method has shown to be linear for the selected concentration
-    range of 0.25–3.0 ng/μL. The uncertainty related to reproducibility of measurement
-    procedure, excluding the extraction step, has shown to be 5.0 % (N = 12). Finally,
-    this method was successfully applied to the quantification of 30-mer toxic peptides
-    from commercial wheat flour with an overall uncertainty under reproducibility
-    conditions of 6.4 % including the extraction of the gliadin fraction. The results
-    were always expressed as the average of the values from all standard concentrations.
-    Subsequently, the final concentration of the 30-mer toxic peptide in the flour
-    was calculated and expressed in milligrams per gram unit. The determined, calculated
-    concentration of the 30-mer toxic peptide in the flour was found to be 1.29 ± 0.37
-    μg/g in flour (N = 25, sy = 545,075, f = 25 − 2 (t = 2.069), P = 95 %, two-sided).
-  status_changed: '2017-09-12 13:35:25'
-  userid: 132
-  type: article
-  publisher: Springer Berlin Heidelberg
-  rev_number: 13
-- eprint_status: archive
-  dir: disk0/00/00/04/11
-  pagerange: 1304-1351
+      given: S.
+      honourific: null
+      lineage: null
   date: 2001
-  volume: 291
+  datestamp: '2017-03-03 14:40:15'
+  dir: disk0/00/00/04/10
   divisions:
   - group_algbioinf
+  eprint_status: archive
+  eprintid: 410
+  event_title: "IEEE 2001 Symposium on Parallel and Large-Data Visualization and\t\
+    Graphics"
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications410
+  lastmod: '2017-03-03 14:40:15'
+  metadata_visibility: show
+  note: Keynote address
+  pagerange: 7-18
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:32'
   subjects:
   - G400
-  number: 5507
-  eprintid: 411
-  refereed: 'TRUE'
-  item_issues_count: 0
-  full_text_status: public
-  date_type: published
-  metadata_visibility: show
+  title: Visualization Challenges for a New Cyberpharmaceutical Computing
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/410
+  userid: 1
+- abstract: "A 2.91-billion base pair (bp) consensus sequence of the euchromatic portion\
+    \ of the human genome was generated by the whole-genome shotgun sequencing method.\
+    \ The 14.8-billion bp DNA sequence was generated over 9 months from 27,271,853\
+    \ high-quality sequence reads (5.11-fold coverage of the genome) from both ends\
+    \ of plasmid clones made from the DNA of five individuals. Two assembly strategies\u2014\
+    a whole-genome assembly and a regional chromosome assembly\u2014were used, each\
+    \ combining sequence data from Celera and the publicly funded genome effort. The\
+    \ public data were shredded into 550-bp segments to create a 2.9-fold coverage\
+    \ of those genome regions that had been sequenced, without including biases inherent\
+    \ in the cloning and assembly procedure used by the publicly funded group. This\
+    \ brought the effective cov- erage in the assemblies to eightfold, reducing the\
+    \ number and size of gaps in the final assembly over what would be obtained with\
+    \ 5.11-fold coverage. The two assembly strategies yielded very similar results\
+    \ that largely agree with independent mapping data. The assemblies effectively\
+    \ cover the euchromatic regions of the human chromosomes. More than 90% of the\
+    \ genome is in scaffold assemblies of 100,000 bp or more, and 25% of the genome\
+    \ is in scaffolds of 10 million bp or larger. Analysis of the genome sequence\
+    \ revealed 26,588 protein-encoding transcripts for which there was strong corroborating\
+    \ evidence and an additional"
+  bibtex: "@article{fu_mi_publications411,\n abstract = {A 2.91-billion base pair\
+    \ (bp) consensus sequence of the euchromatic portion of the human genome was generated\
+    \ by the whole-genome shotgun sequencing method. The 14.8-billion bp DNA sequence\
+    \ was generated over 9 months from 27,271,853 high-quality sequence reads (5.11-fold\
+    \ coverage of the genome) from both ends of plasmid clones made from the DNA of\
+    \ five individuals. Two assembly strategies{--}a whole-genome assembly and a regional\
+    \ chromosome assembly{--}were used, each combining sequence data from Celera and\
+    \ the publicly funded genome effort. The public data were shredded into 550-bp\
+    \ segments to create a 2.9-fold coverage of those genome regions that had been\
+    \ sequenced, without including biases inherent in the cloning and assembly procedure\
+    \ used by the publicly funded group. This brought the effective cov- erage in\
+    \ the assemblies to eightfold, reducing the number and size of gaps in the final\
+    \ assembly over what would be obtained with 5.11-fold coverage. The two assembly\
+    \ strategies yielded very similar results that largely agree with independent\
+    \ mapping data. The assemblies effectively cover the euchromatic regions of the\
+    \ human chromosomes. More than 90\\% of the genome is in scaffold assemblies of\
+    \ 100,000 bp or more, and 25\\% of the genome is in scaffolds of 10 million bp\
+    \ or larger. Analysis of the genome sequence revealed 26,588 protein-encoding\
+    \ transcripts for which there was strong corroborating evidence and an additional},\n\
+    \ author = {J. C. Venter and M. D. Adams and E. W. Myers and K. Reinert and .\
+    \ et al},\n journal = {Science},\n keywords = {ASSEMBLY},\n number = {5507},\n\
+    \ pages = {1304--1351},\n title = {The Sequence of the Human Genome},\n url =\
+    \ {http://publications.imp.fu-berlin.de/411/},\n volume = {291},\n year = {2001}\n\
+    }\n\n"
   creators:
   - name:
-      lineage:
-      given: J. C.
-      honourific:
       family: Venter
+      given: J. C.
+      honourific: null
+      lineage: null
   - name:
-      lineage:
       family: Adams
       given: M. D.
-      honourific:
+      honourific: null
+      lineage: null
   - name:
-      honourific:
-      given: E. W.
       family: Myers
-      lineage:
+      given: E. W.
+      honourific: null
+      lineage: null
   - name:
-      honourific:
-      given: K.
       family: Reinert
-      lineage:
+      given: K.
+      honourific: null
+      lineage: null
   - name:
-      lineage:
       family: et al
-      honourific:
-      given: "."
-  publication: Science
+      given: .
+      honourific: null
+      lineage: null
+  date: 2001
+  date_type: published
   datestamp: '2009-11-24 15:43:17'
+  dir: disk0/00/00/04/11
+  divisions:
+  - group_algbioinf
   documents:
-  - rev_number: 3
-    language: en
+  - docid: 241
+    eprintid: 411
     files:
     - datasetid: document
-      mtime: '2017-03-03 14:40:15'
       fileid: 5222
-      objectid: 241
       filename: Science_2001_VenterThe_sequence_of_the_human.pdf
-      uri: http://publications.imp.fu-berlin.de/id/file/5222
-      mime_type: application/pdf
       filesize: 3474439
+      mime_type: application/pdf
+      mtime: '2017-03-03 14:40:15'
+      objectid: 241
+      uri: http://publications.imp.fu-berlin.de/id/file/5222
+    format: application/pdf
+    language: en
+    main: Science_2001_VenterThe_sequence_of_the_human.pdf
+    mime_type: application/pdf
+    pos: 1
     relation:
     - type: http://eprints.org/relation/hasVersion
-      uri: "/id/document/1007"
-    - uri: "/id/document/1007"
-      type: http://eprints.org/relation/hasVolatileVersion
+      uri: /id/document/1007
+    - type: http://eprints.org/relation/hasVolatileVersion
+      uri: /id/document/1007
     - type: http://eprints.org/relation/haspreviewThumbnailVersion
-      uri: "/id/document/1007"
-    format: application/pdf
-    mime_type: application/pdf
-    uri: http://publications.imp.fu-berlin.de/id/document/241
-    main: Science_2001_VenterThe_sequence_of_the_human.pdf
-    docid: 241
-    eprintid: 411
-    pos: 1
+      uri: /id/document/1007
+    rev_number: 3
     security: public
-  abstract: A 2.91-billion base pair (bp) consensus sequence of the euchromatic portion
-    of the human genome was generated by the whole-genome shotgun sequencing method.
-    The 14.8-billion bp DNA sequence was generated over 9 months from 27,271,853 high-quality
-    sequence reads (5.11-fold coverage of the genome) from both ends of plasmid clones
-    made from the DNA of five individuals. Two assembly strategies—a whole-genome
-    assembly and a regional chromosome assembly—were used, each combining sequence
-    data from Celera and the publicly funded genome effort. The public data were shredded
-    into 550-bp segments to create a 2.9-fold coverage of those genome regions that
-    had been sequenced, without including biases inherent in the cloning and assembly
-    procedure used by the publicly funded group. This brought the effective cov- erage
-    in the assemblies to eightfold, reducing the number and size of gaps in the final
-    assembly over what would be obtained with 5.11-fold coverage. The two assembly
-    strategies yielded very similar results that largely agree with independent mapping
-    data. The assemblies effectively cover the euchromatic regions of the human chromosomes.
-    More than 90% of the genome is in scaffold assemblies of 100,000 bp or more, and
-    25% of the genome is in scaffolds of 10 million bp or larger. Analysis of the
-    genome sequence revealed 26,588 protein-encoding transcripts for which there was
-    strong corroborating evidence and an additional
-  status_changed: '2009-03-11 11:27:33'
-  title: The Sequence of the Human Genome
-  rev_number: 10
-  type: article
-  userid: 1
+    uri: http://publications.imp.fu-berlin.de/id/document/241
+  eprint_status: archive
+  eprintid: 411
+  full_text_status: public
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications411
   keywords: ASSEMBLY
   lastmod: '2017-03-03 14:40:15'
-  ispublished: pub
+  metadata_visibility: show
+  number: 5507
+  pagerange: 1304-1351
+  publication: Science
+  refereed: 'TRUE'
+  rev_number: 10
+  status_changed: '2009-03-11 11:27:33'
+  subjects:
+  - G400
+  title: The Sequence of the Human Genome
+  type: article
   uri: http://publications.imp.fu-berlin.de/id/eprint/411
-- rev_number: 7
-  type: article
-  userid: 132
-  abstract: "Quality control is increasingly recognized as a crucialaspect of
-    mass spectrometry based proteomics. Severalrecent papers discuss relevant
-    parameters for qualitycontrol and present applications to extract these from
-    theinstrumental raw data. What has been missing, however,is a standard
-    data exchange format for reporting theseperformance metrics. We therefore
-    developed the qcMLformat, an XML-based standard that follows the designprinciples
-    of the related mzML, mzIdentML, mzQuantML,and TraML standards from the HUPO-PSI
-    (ProteomicsStandards Initiative). In addition to the XML format, wealso
-    provide tools for the calculation of a wide range ofquality metrics as well
-    as a database format and interconversion tools, so that existing LIMS systems
-    can easily add relational storage of the quality control data to their existing
-    schema. We here describe the qcML specification, along with possible use cases
-    and an illustrative example of the subsequent analysis possibilities. All information
-    about qcML is available at http://code.google.com/p/qcml. Molecular & Cellular
-    Proteomics 13: 10.1074/mcp.M113.035907, 1905–1913, 2014."
-  status_changed: '2014-08-25 19:14:40'
-  title: 'qcML: An Exchange Format for Quality Control Metrics from Mass Spectrometry
-    Experiments'
-  publication: Molecular & Cellular Proteomics
-  datestamp: '2014-08-25 19:14:40'
+  userid: 1
+  volume: 291
+- abstract: " We propose a general approach for frequency based string mining,\twhich\
+    \ has many applications, e.g. in contrast data mining. Our contribution\n\tis\
+    \ a novel algorithm based on a deferred data structure. Despite\n\tits simplicity,\
+    \ our approach is up to 4 times faster and uses about\n\thalf the memory compared\
+    \ to the best-known algorithm of Fischer et\n\tal. Applications in various string\
+    \ domains, e.g. natural language,\n\tDNA or protein sequences, demonstrate the\
+    \ improvement of our algorithm."
+  bibtex: "@inproceedings{fu_mi_publications412,\n abstract = { We propose a general\
+    \ approach for frequency based string mining,   which has many applications, e.g.\
+    \ in contrast data mining. Our contribution\nis a novel algorithm based on a deferred\
+    \ data structure. Despite\nits simplicity, our approach is up to 4 times faster\
+    \ and uses about\nhalf the memory compared to the best-known algorithm of Fischer\
+    \ et\nal. Applications in various string domains, e.g. natural language,\nDNA\
+    \ or protein sequences, demonstrate the improvement of our algorithm.},\n author\
+    \ = {D. Weese and M. H. Schulz},\n booktitle = {Proceedings of the 8th Industrial\
+    \ Conference on Data Mining (ICDM'08)},\n editor = {P. Perner},\n month = {July},\n\
+    \ pages = {374--388},\n publisher = {Springer Verlag},\n title = {Efficient String\
+    \ Mining under Constraints via the Deferred Frequency        Index},\n url = {http://publications.imp.fu-berlin.de/412/},\n\
+    \ year = {2008}\n}\n\n"
   creators:
   - name:
-      family: Walzer
-      given: M.
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      family: Pernas
-      given: L. E.
-      honourific:
-  - name:
-      family: Nasso
-      given: S.
-      honourific:
-      lineage:
-  - name:
-      honourific:
-      given: W.
-      family: Bittremieux
-      lineage:
-  - name:
-      lineage:
-      family: Nahnsen
-      given: S.
-      honourific:
-  - name:
-      lineage:
-      given: P.
-      honourific:
-      family: Kelchtermans
-  - name:
-      family: Pichler
-      given: P.
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      family: van den Toorn
-      given: H. W. P.
-      honourific:
-  - name:
-      family: Staes
-      given: A.
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: J.
-      family: Vandenbussche
-  - name:
-      family: Mazanek
-      given: M.
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: T.
-      family: Taus
-  - name:
-      lineage:
-      family: Scheltema
-      given: R. A.
-      honourific:
-  - name:
-      honourific:
-      given: C. D.
-      family: Kelstrup
-      lineage:
-  - name:
-      family: Gatto
-      given: L.
-      honourific:
-      lineage:
-  - name:
-      family: van Breukelen
-      given: B.
-      honourific:
-      lineage:
-  - name:
-      family: Aiche
-      given: S.
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      family: Valkenborg
-      honourific:
+      family: Weese
       given: D.
+      honourific: null
+      lineage: null
   - name:
-      lineage:
-      honourific:
-      given: K.
-      family: Laukens
-  - name:
-      lineage:
-      family: Lilley
-      given: K. S.
-      honourific:
-  - name:
-      family: Olsen
-      given: J. V.
-      honourific:
-      lineage:
-  - name:
-      family: Heck
-      honourific:
-      given: A. J. R.
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: K.
-      family: Mechtler
-  - name:
-      given: R.
-      honourific:
-      family: Aebersold
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: K.
-      family: Gevaert
-  - name:
-      family: Vizcaino
-      honourific:
-      given: J. A.
-      lineage:
-  - name:
-      family: Hermjakob
-      given: H.
-      honourific:
-      lineage:
-  - name:
-      family: Kohlbacher
-      given: O.
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      family: Martens
-      honourific:
-      given: L.
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1449
-  ispublished: pub
-  lastmod: '2014-08-25 19:14:40'
-  official_url: http://dx.doi.org/10.1074/mcp.M113.035907
-  volume: 13
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  date: '2014-08-01'
-  pagerange: 1905-1913
-  issn: 1535-9476
-  dir: disk0/00/00/14/49
-  eprint_status: archive
-  full_text_status: none
-  date_type: published
-  metadata_visibility: show
-  id_number: doi:10.1074/mcp.M113.035907
-  item_issues_count: 0
-  number: 8
-  refereed: 'TRUE'
-  eprintid: 1449
-- metadata_visibility: show
-  date_type: published
-  full_text_status: none
-  item_issues_count: 0
-  eprintid: 1401
-  refereed: 'TRUE'
-  number: 1
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  volume: 43
-  date: 2014-03
-  dir: disk0/00/00/14/01
-  eprint_status: archive
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1401
-  lastmod: '2014-08-19 16:41:18'
-  ispublished: pub
-  official_url: http://www.sigmod.org/publications/sigmod-record/1403/index.html
-  userid: 132
-  type: article
-  rev_number: 11
-  title: State-of-the-art in String Similarity Search and Join
-  status_changed: '2014-08-19 16:41:18'
-  related_url:
-  - url: http://www2.informatik.hu-berlin.de/~wandelt/searchjoincompetition2013/
-  publication: SIGMOD Record
-  datestamp: '2014-03-18 16:51:01'
-  creators:
-  - id:
-    name:
-      family: Wandelt
-      honourific:
-      given: S.
-      lineage:
-  - name:
-      given: D.
-      honourific:
-      family: Deng
-      lineage:
-    id:
-  - id:
-    name:
-      lineage:
-      family: Gerdjikov
-      given: S.
-      honourific:
-  - id:
-    name:
-      lineage:
-      given: S.
-      honourific:
-      family: Mishra
-  - name:
-      family: Mitankin
-      given: P.
-      honourific:
-      lineage:
-    id:
-  - id:
-    name:
-      lineage:
-      family: Patil
-      honourific:
-      given: M.
-  - name:
-      lineage:
-      family: Siragusa
-      honourific:
-      given: E.
-    id: enrico.siragusa@fu-berlin.de
-  - id:
-    name:
-      lineage:
-      given: A.
-      honourific:
-      family: Tiskin
-  - name:
-      lineage:
-      family: Wang
-      given: W.
-      honourific:
-    id:
-  - id:
-    name:
-      lineage:
-      family: Wang
-      given: J.
-      honourific:
-  - name:
-      lineage:
-      given: U.
-      honourific:
-      family: Leser
-    id:
-- pagerange: 374-388
+      family: Schulz
+      given: M. H.
+      honourific: null
+      lineage: null
   date: 2008-07
+  datestamp: '2017-03-03 14:40:15'
+  dir: disk0/00/00/04/12
   divisions:
   - group_algbioinf
-  subjects:
-  - G400
-  eprint_status: archive
-  dir: disk0/00/00/04/12
-  item_issues_count: 0
-  full_text_status: none
-  metadata_visibility: show
-  eprintid: 412
-  refereed: 'TRUE'
   editors:
   - name:
       family: Perner
-      honourific:
       given: P.
-      lineage:
-  abstract: " We propose a general approach for frequency based string mining,which
-    has many applications, e.g. in contrast data mining. Our contributionis a
-    novel algorithm based on a deferred data structure. Despiteits simplicity,
-    our approach is up to 4 times faster and uses abouthalf the memory compared
-    to the best-known algorithm of Fischer etal. Applications in various string
-    domains, e.g. natural language,DNA or protein sequences, demonstrate the improvement
-    of our algorithm."
-  status_changed: '2009-03-11 11:27:34'
-  title: "Efficient String Mining under Constraints via the Deferred FrequencyIndex"
-  publisher: Springer Verlag
-  type: conference_item
-  rev_number: 3
-  userid: 1
-  creators:
-  - name:
-      given: D.
-      honourific:
-      family: Weese
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: M. H.
-      family: Schulz
-  datestamp: '2017-03-03 14:40:15'
-  lastmod: '2017-03-03 14:40:15'
-  ispublished: pub
-  uri: http://publications.imp.fu-berlin.de/id/eprint/412
+      honourific: null
+      lineage: null
+  eprint_status: archive
+  eprintid: 412
   event_title: Proceedings of the 8th Industrial Conference on Data Mining (ICDM'08)
-  official_url: http://www.springerlink.com/content/xr2q4w73m623xl52/
-- full_text_status: public
-  date_type: published
-  metadata_visibility: show
-  item_issues_count: 0
-  institution: Humboldt-University
-  eprintid: 457
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  date: '2006-05-02'
-  dir: disk0/00/00/04/57
-  eprint_status: archive
-  uri: http://publications.imp.fu-berlin.de/id/eprint/457
-  lastmod: '2017-03-03 14:40:19'
-  ispublished: pub
-  pages: 99
-  department: Computer Science
-  type: thesis
-  rev_number: 18
-  userid: 31
-  status_changed: '2009-05-06 09:48:11'
-  title: Entwurf und Implementierung eines generischen Substring-Index
-  datestamp: '2009-05-06 09:48:11'
-  thesis_type: other
-  documents:
-  - eprintid: 457
-    pos: 1
-    security: public
-    format: text/html
-    mime_type: application/pdf
-    main: weese06.pdf
-    uri: http://publications.imp.fu-berlin.de/id/document/183
-    docid: 183
-    files:
-    - fileid: 5704
-      filename: weese06.pdf
-      objectid: 183
-      datasetid: document
-      mtime: '2017-03-03 14:40:19'
-      uri: http://publications.imp.fu-berlin.de/id/file/5704
-      mime_type: application/pdf
-      filesize: 703072
-    language: en
-    relation:
-    - type: http://eprints.org/relation/hasVersion
-      uri: "/id/document/1022"
-    - type: http://eprints.org/relation/haspreviewThumbnailVersion
-      uri: "/id/document/1022"
-    - type: http://eprints.org/relation/hasVolatileVersion
-      uri: "/id/document/1022"
-    rev_number: 5
-  - content: accepted
-    mime_type: application/pdf
-    formatdesc: Diploma Thesis
-    uri: http://publications.imp.fu-berlin.de/id/document/184
-    main: weese06.pdf
-    docid: 184
-    format: application/pdf
-    security: public
-    license: cc_gnu_lgpl
-    eprintid: 457
-    pos: 2
-    rev_number: 4
-    files:
-    - mime_type: application/pdf
-      uri: http://publications.imp.fu-berlin.de/id/file/5707
-      filesize: 703072
-      fileid: 5707
-      objectid: 184
-      filename: weese06.pdf
-      datasetid: document
-      mtime: '2017-03-03 14:40:19'
-    language: en
-    relation:
-    - type: http://eprints.org/relation/hasVersion
-      uri: "/id/document/1023"
-    - uri: "/id/document/1023"
-      type: http://eprints.org/relation/haspreviewThumbnailVersion
-    - type: http://eprints.org/relation/hasVolatileVersion
-      uri: "/id/document/1023"
-  creators:
-  - id: weese@inf.fu-berlin.de
-    name:
-      lineage:
-      family: Weese
-      honourific:
-      given: D.
-- eprintid: 1288
-  institution: Freie Universität Berlin
-  item_issues_count: 0
-  metadata_visibility: show
-  date_type: published
-  full_text_status: public
-  eprint_status: archive
-  dir: disk0/00/00/12/88
-  date: '2013-06-05'
-  subjects:
-  - C
-  - G
-  divisions:
-  - group_algbioinf
-  keywords: HTS; full-text index; frequency string mining; read mapping; SeqAn
-  official_url: http://www.diss.fu-berlin.de/diss/receive/FUDISS_thesis_000000094456
-  department: Department of Mathematics and Computer Science
-  pages: 196
-  ispublished: pub
-  lastmod: '2017-03-03 14:41:25'
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1288
-  creators:
-  - id: david.weese@fu-berlin.de
-    name:
-      family: Weese
-      given: D.
-      honourific:
-      lineage:
-  documents:
-  - security: public
-    pos: 1
-    eprintid: 1288
-    docid: 554
-    uri: http://publications.imp.fu-berlin.de/id/document/554
-    main: thesis_weese12.pdf
-    mime_type: application/pdf
-    content: published
-    formatdesc: PhD Thesis
-    format: application/pdf
-    relation:
-    - type: http://eprints.org/relation/haspreviewThumbnailVersion
-      uri: "/id/document/1246"
-    - uri: "/id/document/1246"
-      type: http://eprints.org/relation/hasVolatileVersion
-    - type: http://eprints.org/relation/hasVersion
-      uri: "/id/document/1246"
-    language: en
-    files:
-    - uri: http://publications.imp.fu-berlin.de/id/file/16089
-      mime_type: application/pdf
-      filesize: 2839678
-      fileid: 16089
-      objectid: 554
-      filename: thesis_weese12.pdf
-      datasetid: document
-      mtime: '2017-03-03 14:41:25'
-    rev_number: 5
-  thesis_type: phd
-  datestamp: '2013-06-15 19:50:31'
-  title: Indices and Applications in High-Throughput Sequencing
-  status_changed: '2013-06-15 19:54:07'
-  abstract: "Recent advances in sequencing technology allow to produce billions of
-    base pairs per day in the form of reads of length 100 bp an longer and current
-    developments promise the personal $1,000 genome in a couple of years. The analysis
-    of these unprecedented amounts of data demands for efficient data structures and
-    algorithms. One such data structures is the substring index, that represents all
-    substrings or substrings up to a certain length contained in a given text.In
-    this thesis we propose 3 substring indices, which we extend to be applicable to
-    millions of sequences. We devise internal and external memory construction algorithms
-    and a uniform framework for accessing the generalized suffix tree. Additionally
-    we propose different index-based applications, e.g. exact and approximate pattern
-    matching and different repeat search algorithms.Second, we present the read
-    mapping tool RazerS, which aligns millions of single or paired-end reads of arbitrary
-    lengths to their potential genomic origin using either Hamming or edit distance.
-    Our tool can work either lossless or with a user-defined loss rate at higher speeds.
-    Given the loss rate, we present a novel approach that guarantees not to lose more
-    reads than specified. This enables the user to adapt to the problem at hand and
-    provides a seamless tradeoff between sensitivity and running time. We compare
-    RazerS with other state-of-the-art read mappers and show that it has the highest
-    sensitivity and a comparable performance on various real-world datasets.At
-    last, we propose a general approach for frequency based string mining, which has
-    many applications, e.g. in contrast data mining. Our contribution is a novel and
-    lightweight algorithm that is faster and uses less memory than the best available
-    algorithms. We show its applicability for mining multiple databases with a variety
-    of frequency constraints. As such, we use the notion of entropy from information
-    theory to generalize the emerging substring mining problem to multiple databases.
-    To demonstrate the improvement of our algorithm we compared to recent approaches
-    on real-world experiments of various string domains, e.g. natural language, DNA,
-    or protein sequences."
-  userid: 30
-  type: thesis
-  rev_number: 19
-- full_text_status: public
-  date_type: published
-  id_number: 10.1101/gr.088823.108
-  metadata_visibility: show
-  item_issues_count: 0
-  number: 9
-  eprintid: 453
-  refereed: 'TRUE'
-  volume: 19
-  subjects:
-  - G400
-  divisions:
-  - group_algbioinf
-  date: '2009-07-10'
-  pagerange: 1646-1654
-  dir: disk0/00/00/04/53
-  eprint_status: archive
-  uri: http://publications.imp.fu-berlin.de/id/eprint/453
-  lastmod: '2017-03-03 14:40:18'
-  ispublished: pub
-  official_url: http://genome.cshlp.org/content/19/9/1646.abstract
-  type: article
-  rev_number: 17
-  userid: 31
-  status_changed: '2009-10-28 12:38:26'
-  abstract: Second-generation sequencing technologies deliver DNA sequence data at
-    unprecedented high throughput. Common to most biological applications is a mapping
-    of the reads to an almost identical or highly similar reference genome. Due to
-    the large amounts of data, eﬃcient algorithms and implementations are crucial
-    for this task. We present an eﬃcient read mapping tool called RazerS. It allows
-    the user to align sequencing reads of arbitrary length using either the Hamming
-    distance or the edit distance. Our tool can work either lossless or with a user-deﬁned
-    loss rate at higher speeds. Given the loss rate, we present an approach that guarantees
-    not to lose more reads than speciﬁed. This enables the user to adapt to the problem
-    at hand and provides a seamless tradeoﬀ between sensitivity and running time.
-  title: RazerS - Fast Read Mapping with Sensitivity Control
-  datestamp: '2009-05-06 09:46:43'
-  publication: Genome Research
-  documents:
-  - rev_number: 4
-    language: en
-    files:
-    - datasetid: document
-      mtime: '2017-03-03 14:40:18'
-      fileid: 5640
-      filename: Genome_Research_2009_WeeseRazerS--fast_read_mapping_with_sensitivity.pdf
-      objectid: 236
-      uri: http://publications.imp.fu-berlin.de/id/file/5640
-      mime_type: application/pdf
-      filesize: 477177
-    relation:
-    - type: http://eprints.org/relation/hasVolatileVersion
-      uri: "/id/document/1020"
-    - uri: "/id/document/1020"
-      type: http://eprints.org/relation/haspreviewThumbnailVersion
-    - uri: "/id/document/1020"
-      type: http://eprints.org/relation/hasVersion
-    format: application/pdf
-    content: published
-    mime_type: application/pdf
-    main: Genome_Research_2009_WeeseRazerS--fast_read_mapping_with_sensitivity.pdf
-    uri: http://publications.imp.fu-berlin.de/id/document/236
-    docid: 236
-    eprintid: 453
-    pos: 1
-    security: public
-  creators:
-  - name:
-      lineage:
-      given: D.
-      honourific:
-      family: Weese
-  - name:
-      family: Emde
-      given: A.-K.
-      honourific:
-      lineage:
-  - name:
-      honourific:
-      given: T.
-      family: Rausch
-      lineage:
-  - name:
-      lineage:
-      family: Döring
-      given: A.
-      honourific:
-  - name:
-      honourific:
-      given: K.
-      family: Reinert
-      lineage:
-- official_url: http://bioinformatics.oxfordjournals.org/content/28/20/2592
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1159
-  lastmod: '2017-03-03 14:41:14'
-  ispublished: pub
-  documents:
-  - eprintid: 1159
-    pos: 1
-    security: public
-    format: application/pdf
-    content: published
-    mime_type: application/pdf
-    formatdesc: Main Article
-    docid: 569
-    uri: http://publications.imp.fu-berlin.de/id/document/569
-    main: razers3.pdf
-    files:
-    - filesize: 195431
-      uri: http://publications.imp.fu-berlin.de/id/file/14153
-      mime_type: application/pdf
-      filename: razers3.pdf
-      objectid: 569
-      fileid: 14153
-      mtime: '2017-03-03 14:41:14'
-      datasetid: document
-    language: en
-    relation:
-    - type: http://eprints.org/relation/haspreviewThumbnailVersion
-      uri: "/id/document/1225"
-    - uri: "/id/document/1225"
-      type: http://eprints.org/relation/hasVolatileVersion
-    - type: http://eprints.org/relation/hasVersion
-      uri: "/id/document/1225"
-    rev_number: 4
-  - rev_number: 4
-    files:
-    - datasetid: document
-      mtime: '2017-03-03 14:41:14'
-      fileid: 14156
-      filename: supplement.pdf
-      objectid: 570
-      mime_type: application/pdf
-      uri: http://publications.imp.fu-berlin.de/id/file/14156
-      filesize: 324632
-    language: en
-    relation:
-    - uri: "/id/document/1226"
-      type: http://eprints.org/relation/hasVersion
-    - uri: "/id/document/1226"
-      type: http://eprints.org/relation/haspreviewThumbnailVersion
-    - uri: "/id/document/1226"
-      type: http://eprints.org/relation/hasVolatileVersion
-    formatdesc: Supplemental Material
-    content: supplemental
-    mime_type: application/pdf
-    uri: http://publications.imp.fu-berlin.de/id/document/570
-    main: supplement.pdf
-    docid: 570
-    format: application/pdf
-    security: public
-    eprintid: 1159
-    pos: 2
-  datestamp: '2012-09-11 14:33:09'
-  publication: Bioinformatics
-  creators:
-  - name:
-      family: Weese
-      honourific:
-      given: D.
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: M.
-      family: Holtgrewe
-  - name:
-      honourific:
-      given: K.
-      family: Reinert
-      lineage:
-  userid: 30
-  publisher: Oxford University Press
-  rev_number: 26
-  type: article
-  title: 'RazerS 3: Faster, fully sensitive read mapping'
-  abstract: "Motivation: During the last years NGS sequencing has become a key technology
-    for many applications in the biomedical sciences. Throughput continues to increase
-    and new protocols provide longer reads than currently available. In almost all
-    applications, read mapping is a first step. Hence, it is crucial to have algorithms
-    and implementations that perform fast, with high sensitivity, and are able to
-    deal with long reads and a large absolute number of indels.Results: RazerS
-    is a read mapping program with adjustable sensitivity based on counting q-grams.
-    In this work we propose the successor RazerS 3 which now supports shared-memory
-    parallelism, an additional seed-based filter with adjustable sensitivity, a much
-    faster, banded version of the Myers’ bit-vector algorithm for verification, memory
-    saving measures and support for the SAM output format. This leads to a much improved
-    performance for mapping reads, in particular long reads with many errors. We extensively
-    compare RazerS 3 with other popular read mappers and show that its results are
-    often superior to them in terms of sensitivity while exhibiting practical and
-    often competetive run times. In addition, RazerS 3 works without a precomputed
-    index.Availability and Implementation: Source code and binaries are freely
-    available for download at http://www.seqan.de/projects/razers. RazerS 3 is implemented
-    in C++ and OpenMP under a GPL license using the SeqAn library and supports Linux,
-    Mac OS X, and Windows."
-  status_changed: '2013-08-10 09:35:00'
-  eprintid: 1159
-  refereed: 'TRUE'
-  number: 20
-  metadata_visibility: show
-  id_number: 10.1093/bioinformatics/bts505
-  date_type: published
-  full_text_status: public
-  item_issues_count: 0
-  dir: disk0/00/00/11/59
-  eprint_status: archive
-  subjects:
-  - C
-  - G
-  divisions:
-  - group_algbioinf
-  volume: 28
-  date: '2012-08-24'
-  pagerange: 2592-2599
-- publication: Toxicology in Vitro
-  datestamp: '2015-01-21 12:15:51'
-  creators:
-  - name:
-      lineage:
-      family: Wilmes
-      honourific:
-      given: Anja
-  - name:
-      lineage:
-      honourific:
-      given: Chris
-      family: Bielow
-  - name:
-      family: Ranninger
-      given: Christina
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      given: Patricia
-      honourific:
-      family: Bellwon
-  - name:
-      honourific:
-      given: Lydia
-      family: Aschauer
-      lineage:
-  - name:
-      lineage:
-      family: Limonciel
-      given: Alice
-      honourific:
-  - name:
-      lineage:
-      honourific:
-      given: Hubert
-      family: Chassaigne
-  - name:
-      lineage:
-      honourific:
-      given: Theresa
-      family: Kristl
-  - name:
-      given: Stephan
-      honourific:
-      family: Aiche
-      lineage:
-  - name:
-      family: Huber
-      honourific:
-      given: Christian G.
-      lineage:
-  - name:
-      lineage:
-      family: Guillou
-      honourific:
-      given: Claude
-  - name:
-      honourific:
-      given: Philipp
-      family: Hewitt
-      lineage:
-  - name:
-      lineage:
-      family: Leonard
-      given: Martin O.
-      honourific:
-  - name:
-      lineage:
-      given: Wolfgang
-      honourific:
-      family: Dekant
-  - name:
-      lineage:
-      family: Bois
-      given: Frederic
-      honourific:
-  - name:
-      family: Jennings
-      honourific:
-      given: Paul
-      lineage:
-  userid: 132
-  type: article
-  publisher: Elsevier B.V.
-  rev_number: 13
-  title: Mechanism of cisplatin proximal tubule toxicity revealed by integrating transcriptomics,
-    proteomics, metabolomics and biokinetics
-  abstract: Cisplatin is one of the most widely used chemotherapeutic agents for the
-    treatment of solid tumours. The major dose-limiting factor is nephrotoxicity,
-    in particular in the proximal tubule. Here, we use an integrated omics approach,
-    including transcriptomics, proteomics and metabolomics coupled to biokinetics
-    to identify cell stress response pathways induced by cisplatin. The human renal
-    proximal tubular cell line RPTEC/TERT1 was treated with sub-cytotoxic concentrations
-    of cisplatin (0.5 and 2μM) in a daily repeat dose treating regime for up to 14days.
-    Biokinetic analysis showed that cisplatin was taken up from the basolateral compartment,
-    transported to the apical compartment, and accumulated in cells over time. This
-    is in line with basolateral uptake of cisplatin via organic cation transporter
-    2 and bioactivation via gamma-glutamyl transpeptidase located on the apical side
-    of proximal tubular cells. Cisplatin affected several pathways including, p53
-    signalling, Nrf2 mediated oxidative stress response, mitochondrial processes,
-    mTOR and AMPK signalling. In addition, we identified novel pathways changed by
-    cisplatin, including eIF2 signalling, actin nucleation via the ARP/WASP complex
-    and regulation of cell polarization. In conclusion, using an integrated omic approach
-    together with biokinetics we have identified both novel and established mechanisms
-    of cisplatin toxicity.
-  status_changed: '2016-02-23 16:10:47'
-  official_url: http://dx.doi.org/10.1016/j.tiv.2014.10.006
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1488
-  ispublished: pub
-  lastmod: '2016-02-23 16:10:47'
-  dir: disk0/00/00/14/88
-  issn: 8872333
-  eprint_status: archive
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  volume: 30
-  date: '2015-12-25'
-  pagerange: 117-127
-  eprintid: 1488
-  refereed: 'TRUE'
-  number: 1, Part A
-  metadata_visibility: show
-  id_number: doi:10.1016/j.tiv.2014.10.006
-  date_type: published
   full_text_status: none
-  item_issues_count: 0
-- uri: http://publications.imp.fu-berlin.de/id/eprint/2430
-  lastmod: '2020-04-02 11:57:40'
   ispublished: pub
-  keywords: CRISPR-Cas9, Off-target detection, Variants, Genome editing
-  official_url: http://doi.org/10.1186/s12896-019-0535-5
-  userid: 132
-  type: article
-  rev_number: 5
-  title: 'VARSCOT: variant-aware detection and scoring enables sensitive and personalized
-    off-target detection for CRISPR-Cas9'
-  status_changed: '2020-04-02 11:57:40'
-  abstract: "BackgroundNatural variations in a genome can drastically alter
-    the CRISPR-Cas9 off-target landscape by creating or removing sites. Despite the
-    resulting potential side-effects from such unaccounted for sites, current off-target
-    detection pipelines are not equipped to include variant information. To address
-    this, we developed VARiant-aware detection and SCoring of Off-Targets (VARSCOT).ResultsVARSCOT
-    identifies only 0.6% of off-targets to be common between 4 individual genomes
-    and the reference, with an average of 82% of off-targets unique to an individual.
-    VARSCOT is the most sensitive detection method for off-targets, finding 40 to
-    70% more experimentally verified off-targets compared to other popular software
-    tools and its machine learning model allows for CRISPR-Cas9 concentration aware
-    off-target activity scoring.ConclusionsVARSCOT allows researchers
-    to take genomic variation into account when designing individual or population-wide
-    targeting strategies. VARSCOT is available from https://github.com/BauerLab/VARSCOT."
-  publication: BMC Biotechnology
-  datestamp: '2020-04-02 11:57:40'
-  creators:
-  - name:
-      honourific:
-      given: Laurence O. W.
-      family: Wilson
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: Sara
-      family: Hetzel
-  - name:
-      family: Pockrandt
-      given: Christopher
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      given: Knut
-      honourific:
-      family: Reinert
-  - name:
-      lineage:
-      family: Bauer
-      honourific:
-      given: Denis C.
-  metadata_visibility: show
-  id_number: doi:10.1186/s12896-019-0535-5
-  full_text_status: none
-  date_type: published
-  refereed: 'TRUE'
-  eprintid: 2430
-  number: 1
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  volume: 19
-  date: '2019-06-27'
-  dir: disk0/00/00/24/30
-  issn: 1472-6750
-  eprint_status: archive
-- divisions:
-  - group_algbioinf
-  volume: 6
-  date: 2005
-  pagerange: http://www.biomedcentral.com/1471-2105/6/285
-  dir: disk0/00/00/04/14
-  eprint_status: archive
-  metadata_visibility: show
-  full_text_status: none
   item_issues_count: 0
-  eprintid: 414
-  refereed: 'TRUE'
-  number: 285
-  userid: 1
-  type: article
-  rev_number: 3
-  title: "Transformation and other factors of the peptide mass spectormetrypairwise
-    peaklist comparison process"
-  status_changed: '2009-03-11 11:27:35'
-  publication: BMC Bioinformatics
-  datestamp: '2010-09-01 13:31:44'
-  creators:
-  - name:
-      lineage:
-      honourific:
-      given: E.
-      family: Wolski
-  - name:
-      lineage:
-      family: Lalowski
-      given: M.
-      honourific:
-  - name:
-      family: Martus
-      given: P.
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      honourific:
-      given: P.
-      family: Giavalisco
-  - name:
-      given: J.
-      honourific:
-      family: Gobom
-      lineage:
-  - name:
-      family: Sickmann
-      honourific:
-      given: A.
-      lineage:
-  - name:
-      family: Lehrach
-      given: H.
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      family: Reinert
-      honourific:
-      given: K.
-  uri: http://publications.imp.fu-berlin.de/id/eprint/414
-  ispublished: pub
-  lastmod: '2010-09-01 13:31:44'
-- eprintid: 413
-  refereed: 'TRUE'
-  number: 203
-  item_issues_count: 0
-  metadata_visibility: show
-  full_text_status: none
-  eprint_status: archive
-  dir: disk0/00/00/04/13
-  date: 2005
-  pagerange: http://www.biomedcentral.com/1471-2105/6/203
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  volume: 6
-  ispublished: pub
+  key: fu_mi_publications412
   lastmod: '2017-03-03 14:40:15'
-  uri: http://publications.imp.fu-berlin.de/id/eprint/413
+  metadata_visibility: show
+  official_url: http://www.springerlink.com/content/xr2q4w73m623xl52/
+  pagerange: 374-388
+  publisher: Springer Verlag
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:34'
+  subjects:
+  - G400
+  title: "Efficient String Mining under Constraints via the Deferred Frequency\tIndex"
+  type: conference_item
+  uri: http://publications.imp.fu-berlin.de/id/eprint/412
+  userid: 1
+- bibtex: "@article{fu_mi_publications413,\n author = {W. E. Wolski and M. Lalowski\
+    \ and P. Jungblut and K. Reinert},\n journal = {BMC Bioinformatics},\n number\
+    \ = {203},\n pages = {http://www.biomedcentral.com/1471--2105/6/203},\n title\
+    \ = {Calibration of mass spectrometric peptide mass fingerprint data without \
+    \    specific external or internal calibrants},\n url = {http://publications.imp.fu-berlin.de/413/},\n\
+    \ volume = {6},\n year = {2005}\n}\n\n"
   creators:
   - name:
-      lineage:
-      honourific:
-      given: W. E.
       family: Wolski
+      given: W. E.
+      honourific: null
+      lineage: null
   - name:
       family: Lalowski
       given: M.
-      honourific:
-      lineage:
+      honourific: null
+      lineage: null
   - name:
       family: Jungblut
       given: P.
-      honourific:
-      lineage:
+      honourific: null
+      lineage: null
   - name:
-      lineage:
-      honourific:
-      given: K.
       family: Reinert
-  publication: BMC Bioinformatics
+      given: K.
+      honourific: null
+      lineage: null
+  date: 2005
   datestamp: '2017-03-03 14:40:15'
-  title: "Calibration of mass spectrometric peptide mass fingerprint data withoutspecific
-    external or internal calibrants"
-  status_changed: '2009-03-11 11:27:34'
-  userid: 1
-  type: article
-  rev_number: 3
-- number: 18
-  eprintid: 415
-  refereed: 'TRUE'
-  date_type: published
-  full_text_status: none
-  metadata_visibility: show
-  item_issues_count: 0
-  dir: disk0/00/00/04/15
-  eprint_status: archive
-  volume: 4
-  subjects:
-  - G400
+  dir: disk0/00/00/04/13
   divisions:
   - group_algbioinf
-  pagerange: doi:10.1186/1477-5956
-  date: 2006
-  uri: http://publications.imp.fu-berlin.de/id/eprint/415
-  lastmod: '2010-09-01 13:22:44'
+  eprint_status: archive
+  eprintid: 413
+  full_text_status: none
   ispublished: pub
-  publication: Proteome Science
-  datestamp: '2009-03-11 12:37:50'
+  item_issues_count: 0
+  key: fu_mi_publications413
+  lastmod: '2017-03-03 14:40:15'
+  metadata_visibility: show
+  number: 203
+  pagerange: http://www.biomedcentral.com/1471-2105/6/203
+  publication: BMC Bioinformatics
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:34'
+  subjects:
+  - G400
+  title: "Calibration of mass spectrometric peptide mass fingerprint data without\t\
+    specific external or internal calibrants"
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/413
+  userid: 1
+  volume: 6
+- bibtex: "@article{fu_mi_publications414,\n author = {E. Wolski and M. Lalowski and\
+    \ P. Martus and P. Giavalisco and J. Gobom and A. Sickmann and H. Lehrach and\
+    \ K. Reinert},\n journal = {BMC Bioinformatics},\n number = {285},\n pages = {http://www.biomedcentral.com/1471--2105/6/285},\n\
+    \ title = {Transformation and other factors of the peptide mass spectormetry \
+    \  pairwise peaklist comparison process},\n url = {http://publications.imp.fu-berlin.de/414/},\n\
+    \ volume = {6},\n year = {2005}\n}\n\n"
   creators:
   - name:
-      lineage:
-      honourific:
-      given: W. E.
       family: Wolski
+      given: E.
+      honourific: null
+      lineage: null
   - name:
-      lineage:
+      family: Lalowski
+      given: M.
+      honourific: null
+      lineage: null
+  - name:
+      family: Martus
+      given: P.
+      honourific: null
+      lineage: null
+  - name:
+      family: Giavalisco
+      given: P.
+      honourific: null
+      lineage: null
+  - name:
+      family: Gobom
+      given: J.
+      honourific: null
+      lineage: null
+  - name:
+      family: Sickmann
+      given: A.
+      honourific: null
+      lineage: null
+  - name:
+      family: Lehrach
+      given: H.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: 2005
+  datestamp: '2010-09-01 13:31:44'
+  dir: disk0/00/00/04/14
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 414
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications414
+  lastmod: '2010-09-01 13:31:44'
+  metadata_visibility: show
+  number: 285
+  pagerange: http://www.biomedcentral.com/1471-2105/6/285
+  publication: BMC Bioinformatics
+  refereed: 'TRUE'
+  rev_number: 3
+  status_changed: '2009-03-11 11:27:35'
+  title: "Transformation and other factors of the peptide mass spectormetry\tpairwise\
+    \ peaklist comparison process"
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/414
+  userid: 1
+  volume: 6
+- bibtex: "@article{fu_mi_publications415,\n author = {W. E. Wolski and M. Farrow\
+    \ and A.-K. Emde and L. Maciej and H. Lehrach and K. Reinert},\n journal = {Proteome\
+    \ Science},\n number = {18},\n pages = {doi:10.1186/1477--5956},\n title = {Analytical\
+    \ model of peptide mass cluster centres with applications},\n url = {http://publications.imp.fu-berlin.de/415/},\n\
+    \ volume = {4},\n year = {2006}\n}\n\n"
+  creators:
+  - name:
+      family: Wolski
+      given: W. E.
+      honourific: null
+      lineage: null
+  - name:
       family: Farrow
       given: M.
-      honourific:
+      honourific: null
+      lineage: null
   - name:
-      honourific:
-      given: A.-K.
       family: Emde
-      lineage:
+      given: A.-K.
+      honourific: null
+      lineage: null
   - name:
       family: Maciej
       given: L.
-      honourific:
-      lineage:
+      honourific: null
+      lineage: null
   - name:
-      given: H.
-      honourific:
       family: Lehrach
-      lineage:
+      given: H.
+      honourific: null
+      lineage: null
   - name:
       family: Reinert
       given: K.
-      honourific:
-      lineage:
-  rev_number: 9
-  type: article
-  userid: 1
-  status_changed: '2009-03-11 12:37:50'
-  title: Analytical model of peptide mass cluster centres with applications
-- id_number: 'doi: 10.1186/1471-2105-14-56'
-  metadata_visibility: show
-  full_text_status: none
+      honourific: null
+      lineage: null
+  date: 2006
   date_type: published
-  item_issues_count: 0
-  eprintid: 1400
-  refereed: 'TRUE'
-  number: 1
-  subjects:
-  - G400
+  datestamp: '2009-03-11 12:37:50'
+  dir: disk0/00/00/04/15
   divisions:
   - group_algbioinf
-  volume: 14
-  pagerange: 56
-  date: '2013-02-18'
-  dir: disk0/00/00/14/00
-  issn: 1471-2105
   eprint_status: archive
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1400
-  lastmod: '2014-03-18 16:04:51'
+  eprintid: 415
+  full_text_status: none
   ispublished: pub
-  official_url: http://www.biomedcentral.com/1471-2105/14/56
-  userid: 132
-  publisher: BioMed Central
+  item_issues_count: 0
+  key: fu_mi_publications415
+  lastmod: '2010-09-01 13:22:44'
+  metadata_visibility: show
+  number: 18
+  pagerange: doi:10.1186/1477-5956
+  publication: Proteome Science
+  refereed: 'TRUE'
   rev_number: 9
+  status_changed: '2009-03-11 12:37:50'
+  subjects:
+  - G400
+  title: Analytical model of peptide mass cluster centres with applications
   type: article
-  title: Optimal precursor ion selection for LC-MALDI MS/MS
-  abstract: "BackgroundLiquid chromatography mass spectrometry (LC-MS) maps in
-    shotgun proteomics are often too complex to select every detected peptide signal
-    for fragmentation by tandem mass spectrometry (MS/MS). Standard methods for precursor
-    ion selection, commonly based on data dependent acquisition, select highly abundant
-    peptide signals in each spectrum. However, these approaches produce redundant
-    information and are biased towards high-abundance proteins.ResultsWe
-    present two algorithms for inclusion list creation that formulate precursor ion
-    selection as an optimization problem. Given an LC-MS map, the first approach maximizes
-    the number of selected precursors given constraints such as a limited number of
-    acquisitions per RT fraction. Second, we introduce a protein sequence-based inclusion
-    list that can be used to monitor proteins of interest. Given only the protein
-    sequences, we create an inclusion list that optimally covers the whole protein
-    set. Additionally, we propose an iterative precursor ion selection that aims at
-    reducing the redundancy obtained with data dependent LC-MS/MS. We overcome the
-    risk of erroneous assignments by including methods for retention time and proteotypicity
-    predictions. We show that our method identifies a set of proteins requiring fewer
-    precursors than standard approaches. Thus, it is well suited for precursor ion
-    selection in experiments with limited sample amount or analysis time.ConclusionsWe
-    present three approaches to precursor ion selection with LC-MALDI MS/MS. Using
-    a well-defined protein standard and a complex human cell lysate, we demonstrate
-    that our methods outperform standard approaches. Our algorithms are implemented
-    as part of OpenMS and are available under http://www.openms.de."
-  status_changed: '2014-03-18 16:04:51'
-  datestamp: '2014-03-18 15:56:36'
-  publication: BMC Bioinformatics
+  uri: http://publications.imp.fu-berlin.de/id/eprint/415
+  userid: 1
+  volume: 4
+- abstract: "This work presents a generalized approach for the fast structural alignment\
+    \ \r\nof thousands of macromolecular structures. The method uses string representations\
+    \ of a macromolecular structure and a hash table that stores n-grams of a certain\
+    \ size for searching. \r\nTo this end, macromolecular structure-to-string translators\
+    \ were implemented for protein and RNA structures. A query against the index is\
+    \ performed in two hierarchical steps to unite speed and precision. In the \uFB01\
+    rst step the query structure is translated into n-grams, and all target structures\
+    \ containing these n-grams are retrieved from the hash table. In the second \r\
+    \nstep all corresponding n-grams of the query and each target structure are subsequently\
+    \ aligned, and after each alignment a score is calculated based on the matching\
+    \ n-grams of query and target. The extendable framework enables the user to query\
+    \ and structurally align thousands of protein and RNA structures on a commodity\
+    \ machine and is available as \r\nopen source from http://la jolla.sf.net. "
+  bibtex: "@article{fu_mi_publications450,\n abstract = {This work presents a generalized\
+    \ approach for the fast structural alignment \nof thousands of macromolecular\
+    \ structures. The method uses string representations of a macromolecular structure\
+    \ and a hash table that stores n-grams of a certain size for searching. \nTo this\
+    \ end, macromolecular structure-to-string translators were implemented for protein\
+    \ and RNA structures. A query against the index is performed in two hierarchical\
+    \ steps to unite speed and precision. In the ?rst step the query structure is\
+    \ translated into n-grams, and all target structures containing these n-grams\
+    \ are retrieved from the hash table. In the second \nstep all corresponding n-grams\
+    \ of the query and each target structure are subsequently aligned, and after each\
+    \ alignment a score is calculated based on the matching n-grams of query and target.\
+    \ The extendable framework enables the user to query and structurally align thousands\
+    \ of protein and RNA structures on a commodity machine and is available as \n\
+    open source from http://la jolla.sf.net. },\n author = {R. A. Bauer and K. Rother\
+    \ and P. Moor and K. Reinert and T. Steinke and J. M. Bujnicki and R. Preissner},\n\
+    \ journal = {Algorithms and Molecular Sciences},\n number = {2},\n pages = {692--709},\n\
+    \ publisher = {MDPI},\n title = {Fast Structural Alignment of Biomolecules Using\
+    \ a Hash Table, N-Grams and String Descriptors},\n url = {http://publications.imp.fu-berlin.de/450/},\n\
+    \ volume = {2},\n year = {2009}\n}\n\n"
+  creators:
+  - id: ra.bauer@fu-berlin.de
+    name:
+      family: Bauer
+      given: R. A.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Rother
+      given: K.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Moor
+      given: P.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Steinke
+      given: T.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Bujnicki
+      given: J. M.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Preissner
+      given: R.
+      honourific: null
+      lineage: null
+  date: 2009
+  date_type: published
+  datestamp: '2009-04-03 08:57:21'
+  dir: disk0/00/00/04/50
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 450
+  full_text_status: none
+  id_number: 10.3390/a2020692
+  ispublished: pub
+  issn: 1999-4893
+  item_issues_count: 0
+  key: fu_mi_publications450
+  lastmod: '2010-09-01 13:28:41'
+  metadata_visibility: show
+  number: 2
+  official_url: http://www.mdpi.com/1999-4893/2/2/692
+  pagerange: 692-709
+  publication: Algorithms and Molecular Sciences
+  publisher: MDPI
+  refereed: 'TRUE'
+  rev_number: 12
+  status_changed: '2009-10-28 12:51:35'
+  subjects:
+  - G
+  title: Fast Structural Alignment of Biomolecules Using a Hash Table, N-Grams and
+    String Descriptors
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/450
+  userid: 29
+  volume: 2
+- abstract: "Second-generation sequencing technologies deliver DNA sequence data at\
+    \ unprecedented high throughput. Common to most biological applications is a mapping\
+    \ of the reads to an almost identical or highly similar reference genome. Due\
+    \ to the large amounts of data, e\uFB03cient algorithms and implementations are\
+    \ crucial for this task. We present an e\uFB03cient read mapping tool called RazerS.\
+    \ It allows the user to align sequencing reads of arbitrary length using either\
+    \ the Hamming distance or the edit distance. Our tool can work either lossless\
+    \ or with a user-de\uFB01ned loss rate at higher speeds. Given the loss rate,\
+    \ we present an approach that guarantees not to lose more reads than speci\uFB01\
+    ed. This enables the user to adapt to the problem at hand and provides a seamless\
+    \ tradeo\uFB00 between sensitivity and running time."
+  bibtex: "@article{fu_mi_publications453,\n abstract = {Second-generation sequencing\
+    \ technologies deliver DNA sequence data at unprecedented high throughput. Common\
+    \ to most biological applications is a mapping of the reads to an almost identical\
+    \ or highly similar reference genome. Due to the large amounts of data, e?cient\
+    \ algorithms and implementations are crucial for this task. We present an e?cient\
+    \ read mapping tool called RazerS. It allows the user to align sequencing reads\
+    \ of arbitrary length using either the Hamming distance or the edit distance.\
+    \ Our tool can work either lossless or with a user-de?ned loss rate at higher\
+    \ speeds. Given the loss rate, we present an approach that guarantees not to lose\
+    \ more reads than speci?ed. This enables the user to adapt to the problem at hand\
+    \ and provides a seamless tradeo? between sensitivity and running time.},\n author\
+    \ = {D. Weese and A.-K. Emde and T. Rausch and A. D{\\\"o}ring and K. Reinert},\n\
+    \ journal = {Genome Research},\n month = {July},\n number = {9},\n pages = {1646--1654},\n\
+    \ title = {RazerS - Fast Read Mapping with Sensitivity Control},\n url = {http://publications.imp.fu-berlin.de/453/},\n\
+    \ volume = {19},\n year = {2009}\n}\n\n"
   creators:
   - name:
-      given: A.
-      honourific:
-      family: Zerck
-      lineage:
-    id:
+      family: Weese
+      given: D.
+      honourific: null
+      lineage: null
   - name:
-      lineage:
-      family: Nordhoff
-      honourific:
-      given: E.
-    id: nordhoff@molgen.mpg.de
-  - id: lehrach@molgen.mpg.de
-    name:
-      given: H.
-      honourific:
-      family: Lehrach
-      lineage:
+      family: Emde
+      given: A.-K.
+      honourific: null
+      lineage: null
+  - name:
+      family: Rausch
+      given: T.
+      honourific: null
+      lineage: null
+  - name:
+      family: "D\xF6ring"
+      given: A.
+      honourific: null
+      lineage: null
   - name:
       family: Reinert
-      honourific:
       given: K.
-      lineage:
-    id: knut.reinert@fu-berlin.de
-- status_changed: '2009-10-28 12:43:45'
-  abstract: Currently, the precursor ion selection strategies in LC-MS mainly choose
+      honourific: null
+      lineage: null
+  date: '2009-07-10'
+  date_type: published
+  datestamp: '2009-05-06 09:46:43'
+  dir: disk0/00/00/04/53
+  divisions:
+  - group_algbioinf
+  documents:
+  - content: published
+    docid: 236
+    eprintid: 453
+    files:
+    - datasetid: document
+      fileid: 5640
+      filename: Genome_Research_2009_WeeseRazerS--fast_read_mapping_with_sensitivity.pdf
+      filesize: 477177
+      mime_type: application/pdf
+      mtime: '2017-03-03 14:40:18'
+      objectid: 236
+      uri: http://publications.imp.fu-berlin.de/id/file/5640
+    format: application/pdf
+    language: en
+    main: Genome_Research_2009_WeeseRazerS--fast_read_mapping_with_sensitivity.pdf
+    mime_type: application/pdf
+    pos: 1
+    relation:
+    - type: http://eprints.org/relation/hasVolatileVersion
+      uri: /id/document/1020
+    - type: http://eprints.org/relation/haspreviewThumbnailVersion
+      uri: /id/document/1020
+    - type: http://eprints.org/relation/hasVersion
+      uri: /id/document/1020
+    rev_number: 4
+    security: public
+    uri: http://publications.imp.fu-berlin.de/id/document/236
+  eprint_status: archive
+  eprintid: 453
+  full_text_status: public
+  id_number: 10.1101/gr.088823.108
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications453
+  lastmod: '2017-03-03 14:40:18'
+  metadata_visibility: show
+  number: 9
+  official_url: http://genome.cshlp.org/content/19/9/1646.abstract
+  pagerange: 1646-1654
+  publication: Genome Research
+  refereed: 'TRUE'
+  rev_number: 17
+  status_changed: '2009-10-28 12:38:26'
+  subjects:
+  - G400
+  title: RazerS - Fast Read Mapping with Sensitivity Control
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/453
+  userid: 31
+  volume: 19
+- abstract: BACKGROUND:The use of novel algorithmic techniques is pivotal to many
+    important problems in life science. For example the sequencing of the human genome
+    [1] would not have been possible without advanced assembly algorithms. However,
+    owing to the high speed of technological progress and the urgent need for bioinformatics
+    tools, there is a widening gap between state-of-the-art algorithmic techniques
+    and the actual algorithmic components of tools that are in widespread use.RESULTS:To
+    remedy this trend we propose the use of SeqAn, a library of efficient data types
+    and algorithms for sequence analysis in computational biology. SeqAn comprises
+    implementations of existing, practical state-of-the-art algorithmic components
+    to provide a sound basis for algorithm testing and development. In this paper
+    we describe the design and content of SeqAn and demonstrate its use by giving
+    two examples. In the first example we show an application of SeqAn as an experimental
+    platform by comparing different exact string matching algorithms. The second example
+    is a simple version of the well-known MUMmer tool rewritten in SeqAn. Results
+    indicate that our implementation is very efficient and versatile to use.CONCLUSION:We
+    anticipate that SeqAn greatly simplifies the rapid development of new bioinformatics
+    tools by providing a collection of readily usable, well-designed algorithmic components
+    which are fundamental for the field of sequence analysis. This leverages not only
+    the implementation of new algorithms, but also enables a sound analysis and comparison
+    of existing algorithms.
+  bibtex: "@article{fu_mi_publications455,\n abstract = {BACKGROUND:The use of novel\
+    \ algorithmic techniques is pivotal to many important problems in life science.\
+    \ For example the sequencing of the human genome [1] would not have been possible\
+    \ without advanced assembly algorithms. However, owing to the high speed of technological\
+    \ progress and the urgent need for bioinformatics tools, there is a widening gap\
+    \ between state-of-the-art algorithmic techniques and the actual algorithmic components\
+    \ of tools that are in widespread use.RESULTS:To remedy this trend we propose\
+    \ the use of SeqAn, a library of efficient data types and algorithms for sequence\
+    \ analysis in computational biology. SeqAn comprises implementations of existing,\
+    \ practical state-of-the-art algorithmic components to provide a sound basis for\
+    \ algorithm testing and development. In this paper we describe the design and\
+    \ content of SeqAn and demonstrate its use by giving two examples. In the first\
+    \ example we show an application of SeqAn as an experimental platform by comparing\
+    \ different exact string matching algorithms. The second example is a simple version\
+    \ of the well-known MUMmer tool rewritten in SeqAn. Results indicate that our\
+    \ implementation is very efficient and versatile to use.CONCLUSION:We anticipate\
+    \ that SeqAn greatly simplifies the rapid development of new bioinformatics tools\
+    \ by providing a collection of readily usable, well-designed algorithmic components\
+    \ which are fundamental for the field of sequence analysis. This leverages not\
+    \ only the implementation of new algorithms, but also enables a sound analysis\
+    \ and comparison of existing algorithms.},\n author = {A. D{\\\"o}ring and D.\
+    \ Weese and T. Rausch and K. Reinert},\n journal = {BMC Bioinformatics},\n number\
+    \ = {1},\n pages = {11},\n title = {SeqAn -- An efficient, generic C++ library\
+    \ for sequence analysis},\n url = {http://publications.imp.fu-berlin.de/455/},\n\
+    \ volume = {9},\n year = {2008}\n}\n\n"
+  creators:
+  - name:
+      family: "D\xF6ring"
+      given: A.
+      honourific: null
+      lineage: null
+  - name:
+      family: Weese
+      given: D.
+      honourific: null
+      lineage: null
+  - name:
+      family: Rausch
+      given: T.
+      honourific: null
+      lineage: null
+  - name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: 2008
+  date_type: published
+  datestamp: '2009-04-15 07:21:49'
+  dir: disk0/00/00/04/55
+  divisions:
+  - group_algbioinf
+  documents:
+  - docid: 237
+    eprintid: 455
+    files:
+    - datasetid: document
+      fileid: 5656
+      filename: "BMC_Bioinformatics_2008_D\xF6ringAn_efficient_generic_C++_library.pdf"
+      filesize: 565980
+      mime_type: application/pdf
+      mtime: '2017-03-03 14:40:19'
+      objectid: 237
+      uri: http://publications.imp.fu-berlin.de/id/file/5656
+    format: application/pdf
+    language: en
+    main: "BMC_Bioinformatics_2008_D\xF6ringAn_efficient_generic_C++_library.pdf"
+    mime_type: application/pdf
+    pos: 1
+    relation:
+    - type: http://eprints.org/relation/haspreviewThumbnailVersion
+      uri: /id/document/1021
+    - type: http://eprints.org/relation/hasVolatileVersion
+      uri: /id/document/1021
+    - type: http://eprints.org/relation/hasVersion
+      uri: /id/document/1021
+    rev_number: 3
+    security: public
+    uri: http://publications.imp.fu-berlin.de/id/document/237
+  eprint_status: archive
+  eprintid: 455
+  full_text_status: public
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications455
+  lastmod: '2017-03-03 14:40:19'
+  metadata_visibility: show
+  number: 1
+  official_url: http://www.biomedcentral.com/1471-2105/9/11
+  pagerange: 11
+  publication: BMC Bioinformatics
+  refereed: 'TRUE'
+  rev_number: 11
+  status_changed: '2009-04-15 07:21:49'
+  title: SeqAn -- An efficient, generic C++ library for sequence analysis
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/455
+  userid: 30
+  volume: 9
+- abstract: Currently, the precursor ion selection strategies in LC-MS mainly choose
     the most prominent peptide signals for MS/MS analysis. Consequently, high abundant
     proteins are identified by MS/MS of many peptides whereas proteins of lower abundance
     might elude identification. We present a novel, iterative and result-driven approach
@@ -11030,356 +13523,810 @@
     different strategies for precursor ion selection on an existing dataset we compare
     our method to existing result-driven strategies and evaluate its performance with
     regard to mass accuracy, database size, and sample complexity.
-  title: An iterative strategy for precursor ion selection for LC-MS/MS based shotgun
-    proteomics
-  publisher: American Chemical Society
-  type: article
-  rev_number: 21
-  userid: 29
+  bibtex: "@article{fu_mi_publications456,\n abstract = {Currently, the precursor\
+    \ ion selection strategies in LC-MS mainly choose the most prominent peptide signals\
+    \ for MS/MS analysis. Consequently, high abundant proteins are identified by MS/MS\
+    \ of many peptides whereas proteins of lower abundance might elude identification.\
+    \ We present a novel, iterative and result-driven approach for precursor ion selection\
+    \ that significantly increases the efficiency of an MS/MS analysis by decreasing\
+    \ data redundancy and analysis time. By simulating different strategies for precursor\
+    \ ion selection on an existing dataset we compare our method to existing result-driven\
+    \ strategies and evaluate its performance with regard to mass accuracy, database\
+    \ size, and sample complexity.},\n author = {A. Zerck and E. Nordhoff and A. Reseman\
+    \ and E. Mirgorodskaya and D. Suckau and K. Reinert and H. Lehrach and J. Gobom},\n\
+    \ journal = {Journal of Proteome Research},\n month = {April},\n publisher = {American\
+    \ Chemical Society},\n title = {An iterative strategy for precursor ion selection\
+    \ for LC-MS/MS based shotgun proteomics},\n url = {http://publications.imp.fu-berlin.de/456/},\n\
+    \ year = {2009}\n}\n\n"
   creators:
   - id: zerck@molgen.mpg.de
     name:
-      lineage:
       family: Zerck
       given: A.
-      honourific:
+      honourific: null
+      lineage: null
   - id: nordhoff@molgen.mpg.de
     name:
-      lineage:
       family: Nordhoff
       given: E.
-      honourific:
-  - id:
+      honourific: null
+      lineage: null
+  - id: null
     name:
-      lineage:
       family: Reseman
-      honourific:
       given: A.
-  - name:
+      honourific: null
+      lineage: null
+  - id: null
+    name:
       family: Mirgorodskaya
       given: E.
-      honourific:
-      lineage:
-    id:
-  - name:
+      honourific: null
+      lineage: null
+  - id: null
+    name:
       family: Suckau
       given: D.
-      honourific:
-      lineage:
-    id:
+      honourific: null
+      lineage: null
   - id: knut.reinert@fu-berlin.de
     name:
-      honourific:
-      given: K.
       family: Reinert
-      lineage:
+      given: K.
+      honourific: null
+      lineage: null
   - id: lehrach@molgen.mpg.de
     name:
-      lineage:
       family: Lehrach
       given: H.
-      honourific:
-  - id:
+      honourific: null
+      lineage: null
+  - id: null
     name:
       family: Gobom
       given: J.
-      honourific:
-      lineage:
-  datestamp: '2009-06-02 23:02:45'
-  publication: Journal of Proteome Research
-  lastmod: '2010-09-01 13:27:23'
-  ispublished: pub
-  uri: http://publications.imp.fu-berlin.de/id/eprint/456
-  official_url: http://pubs.acs.org/doi/abs/10.1021/pr800835x
+      honourific: null
+      lineage: null
   date: '2009-04-30'
+  date_type: published
+  datestamp: '2009-06-02 23:02:45'
+  dir: disk0/00/00/04/56
   divisions:
   - group_algbioinf
+  eprint_status: archive
+  eprintid: 456
+  full_text_status: none
+  id_number: ' 10.1021/pr800835x'
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications456
+  lastmod: '2010-09-01 13:27:23'
+  metadata_visibility: show
+  official_url: http://pubs.acs.org/doi/abs/10.1021/pr800835x
+  publication: Journal of Proteome Research
+  publisher: American Chemical Society
+  refereed: 'TRUE'
+  rev_number: 21
+  status_changed: '2009-10-28 12:43:45'
   subjects:
   - C790
   - C730
   - G490
-  eprint_status: archive
-  dir: disk0/00/00/04/56
-  item_issues_count: 0
-  date_type: published
-  full_text_status: none
-  id_number: " 10.1021/pr800835x"
-  metadata_visibility: show
-  eprintid: 456
-  refereed: 'TRUE'
-- eprintid: 2128
-  refereed: 'TRUE'
-  number: 24
-  id_number: doi:10.1002/jssc.201600749
-  metadata_visibility: show
-  full_text_status: none
-  date_type: published
-  eprint_status: archive
-  dir: disk0/00/00/21/28
-  issn: 16159306
-  pagerange: 4756-4764
-  date: '2016-11-28'
-  divisions:
-  - group_algbioinf
-  subjects:
-  - G400
-  volume: 39
-  official_url: http://doi.org/10.1002/jssc.201600749
-  ispublished: pub
-  lastmod: '2017-11-22 13:19:29'
-  uri: http://publications.imp.fu-berlin.de/id/eprint/2128
-  creators:
-  - name:
-      lineage:
-      given: Martin
-      honourific:
-      family: Zühlke
-  - name:
-      lineage:
-      honourific:
-      given: Daniel
-      family: Riebe
-  - name:
-      family: Beitz
-      honourific:
-      given: Toralf
-      lineage:
-  - name:
-      honourific:
-      given: Hans-Gerd
-      family: Löhmannsröben
-      lineage:
-  - name:
-      honourific:
-      given: Sandro
-      family: Andreotti
-      lineage:
-  - name:
-      lineage:
-      family: Reinert
-      honourific:
-      given: Knut
-  - name:
-      given: Karl
-      honourific:
-      family: Zenichowski
-      lineage:
-  - name:
-      family: Diener
-      honourific:
-      given: Marc
-      lineage:
-  datestamp: '2017-11-22 13:04:29'
-  publication: Journal of Separation Science
-  title: 'High-performance liquid chromatography with electrospray ionization ion
-    mobility spectrometry: Characterization, data management, and applications'
-  abstract: The combination of high-performance liquid chromatography and electrospray
-    ionization ion mobility spectrometry facilitates the two-dimensional separation
-    of complex mixtures in the retention and drift time plane. The ion mobility spectrometer
-    presented here was optimized for flow rates customarily used in high-performance
-    liquid chromatography between 100 and 1500 μL/min. The characterization of the
-    system with respect to such parameters as the peak capacity of each time dimension
-    and of the 2D spectrum was carried out based on a separation of a pesticide mixture
-    containing 24 substances. While the total ion current chromatogram is coarsely
-    resolved, exhibiting coelutions for a number of compounds, all substances can
-    be separately detected in the 2D plane due to the orthogonality of the separations
-    in retention and drift dimensions. Another major advantage of the ion mobility
-    detector is the identification of substances based on their characteristic mobilities.
-    Electrospray ionization allows the detection of substances lacking a chromophore.
-    As an example, the separation of a mixture of 18 amino acids is presented. A software
-    built upon the free mass spectrometry package OpenMS was developed for processing
-    the extensive 2D data. The different processing steps are implemented as separate
-    modules which can be arranged in a graphic workflow facilitating automated processing
-    of data.
-  status_changed: '2017-11-22 13:04:29'
-  userid: 132
-  publisher: Wiley
+  title: An iterative strategy for precursor ion selection for LC-MS/MS based shotgun
+    proteomics
   type: article
-  rev_number: 6
-- metadata_visibility: show
-  full_text_status: none
+  uri: http://publications.imp.fu-berlin.de/id/eprint/456
+  userid: 29
+- bibtex: "@phdthesis{fu_mi_publications457,\n author = {D. Weese},\n month = {May},\n\
+    \ school = {Humboldt-University},\n title = {Entwurf und Implementierung eines\
+    \ generischen Substring-Index},\n url = {http://publications.imp.fu-berlin.de/457/},\n\
+    \ year = {2006}\n}\n\n"
+  creators:
+  - id: weese@inf.fu-berlin.de
+    name:
+      family: Weese
+      given: D.
+      honourific: null
+      lineage: null
+  date: '2006-05-02'
   date_type: published
-  item_issues_count: 0
-  event_type: workshop
-  pres_type: paper
-  eprintid: 1441
-  refereed: 'TRUE'
-  subjects:
-  - G400
+  datestamp: '2009-05-06 09:48:11'
+  department: Computer Science
+  dir: disk0/00/00/04/57
   divisions:
   - group_algbioinf
-  date: 2013
-  dir: disk0/00/00/14/41
+  documents:
+  - docid: 183
+    eprintid: 457
+    files:
+    - datasetid: document
+      fileid: 5704
+      filename: weese06.pdf
+      filesize: 703072
+      mime_type: application/pdf
+      mtime: '2017-03-03 14:40:19'
+      objectid: 183
+      uri: http://publications.imp.fu-berlin.de/id/file/5704
+    format: text/html
+    language: en
+    main: weese06.pdf
+    mime_type: application/pdf
+    pos: 1
+    relation:
+    - type: http://eprints.org/relation/hasVersion
+      uri: /id/document/1022
+    - type: http://eprints.org/relation/haspreviewThumbnailVersion
+      uri: /id/document/1022
+    - type: http://eprints.org/relation/hasVolatileVersion
+      uri: /id/document/1022
+    rev_number: 5
+    security: public
+    uri: http://publications.imp.fu-berlin.de/id/document/183
+  - content: accepted
+    docid: 184
+    eprintid: 457
+    files:
+    - datasetid: document
+      fileid: 5707
+      filename: weese06.pdf
+      filesize: 703072
+      mime_type: application/pdf
+      mtime: '2017-03-03 14:40:19'
+      objectid: 184
+      uri: http://publications.imp.fu-berlin.de/id/file/5707
+    format: application/pdf
+    formatdesc: Diploma Thesis
+    language: en
+    license: cc_gnu_lgpl
+    main: weese06.pdf
+    mime_type: application/pdf
+    pos: 2
+    relation:
+    - type: http://eprints.org/relation/hasVersion
+      uri: /id/document/1023
+    - type: http://eprints.org/relation/haspreviewThumbnailVersion
+      uri: /id/document/1023
+    - type: http://eprints.org/relation/hasVolatileVersion
+      uri: /id/document/1023
+    rev_number: 4
+    security: public
+    uri: http://publications.imp.fu-berlin.de/id/document/184
   eprint_status: archive
-  event_dates: 3-5 June 2013
-  event_title: IWSG (International Workshop on Science Gateways)
-  uri: http://publications.imp.fu-berlin.de/id/eprint/1441
-  lastmod: '2014-08-19 14:26:35'
+  eprintid: 457
+  full_text_status: public
+  institution: Humboldt-University
   ispublished: pub
-  event_location: Zurich, Switzerland
-  official_url: http://www.informatik.uni-trier.de/~ley/db/conf/iwsg/iwsg2013.html
-  userid: 132
-  rev_number: 17
-  type: conference_item
-  title: 'From the Desktop to the Grid: conversion of KNIME Workflows to gUSE'
-  abstract: "The Konstanz Information Miner is a user-friendlygraphical workflow
-    designer with a broad user base in industry and academia. Its broad range of embedded
-    tools and its powerful data mining and visualization tools render it ideal for
-    scientific workflows. It is thus used more and more in a broad range of applications.
-    However, the free version typically runs on a desktop computer, restricting users
-    if they want to tap into computing power. The grid and cloud User Support Environment
-    is a free and open source project created for parallelized and distributed systems,
-    but the creation of workflows with the included components has a steeper learning
-    curve.In this work we suggest an easy to implement solutioncombining the
-    ease-of-use of the Konstanz Information Minerwith the computational power
-    of distributed computing infrastructures. We present a solution permitting the
-    conversion of workflows between the two platforms. This enables a convenient development,
-    debugging, and maintenance of scientific workflows on the desktop. These workflows
-    can then be deployed on a cloud or grid, thus permitting large-scale computation.To
-    achieve our goals, we relied on a Common Tool DescriptionXML file format which
-    describes the execution of arbitraryprograms in a structured and easily readable
-    and parseable way. In order to integrate external programs into we employed the
-    Generic KNIME Nodes extension."
-  status_changed: '2014-08-19 14:26:35'
-  contact_email: stephan.aiche@fu-berlin.de
-  datestamp: '2014-08-19 14:26:35'
+  item_issues_count: 0
+  key: fu_mi_publications457
+  lastmod: '2017-03-03 14:40:19'
+  metadata_visibility: show
+  pages: 99
+  rev_number: 18
+  status_changed: '2009-05-06 09:48:11'
+  subjects:
+  - G400
+  thesis_type: other
+  title: Entwurf und Implementierung eines generischen Substring-Index
+  type: thesis
+  uri: http://publications.imp.fu-berlin.de/id/eprint/457
+  userid: 31
+- abstract: 'Motivation: Deep sequencing has become the method of choice for determining
+    the small RNA content of a cell. Mapping the sequenced reads onto their reference
+    genome serves as the basis for all further analyses, namely for identification
+    and quantification. A method frequently used is Mega BLAST followed by several
+    filtering steps, even though it is slow and inefficient for this task. Also, none
+    of the currently available short read aligners has established itself for the
+    particular task of small RNA mapping.  Results: We present MicroRazerS, a tool
+    optimized for mapping small RNAs onto a reference genome. It is an order of magnitude
+    faster than Mega BLAST and comparable in speed to other short read mapping tools.
+    In addition, it is more sensitive and easy to handle and adjust.  Availability:
+    MicroRazerS is part of the SeqAn C++ library and can be downloaded from http://www.seqan.de/projects/MicroRazerS.html.  Contact:
+    emde@inf.fu-berlin.de, grunert@molgen.mpg.de'
+  bibtex: "@article{fu_mi_publications792,\n abstract = {Motivation: Deep sequencing\
+    \ has become the method of choice for determining the small RNA content of a cell.\
+    \ Mapping the sequenced reads onto their reference genome serves as the basis\
+    \ for all further analyses, namely for identification and quantification. A method\
+    \ frequently used is Mega BLAST followed by several filtering steps, even though\
+    \ it is slow and inefficient for this task. Also, none of the currently available\
+    \ short read aligners has established itself for the particular task of small\
+    \ RNA mapping.  Results: We present MicroRazerS, a tool optimized for mapping\
+    \ small RNAs onto a reference genome. It is an order of magnitude faster than\
+    \ Mega BLAST and comparable in speed to other short read mapping tools. In addition,\
+    \ it is more sensitive and easy to handle and adjust.  Availability: MicroRazerS\
+    \ is part of the SeqAn C++ library and can be downloaded from http://www.seqan.de/projects/MicroRazerS.html.\
+    \  Contact: emde@inf.fu-berlin.de, grunert@molgen.mpg.de},\n author = {A.-K. Emde\
+    \ and M. Grunert and D. Weese and K. Reinert and S. R. Sperling},\n journal =\
+    \ {Bioinformatics},\n month = {January},\n number = {1},\n pages = {123--124},\n\
+    \ publisher = {Oxford University Press},\n title = {MicroRazerS: Rapid alignment\
+    \ of small RNA reads},\n url = {http://publications.imp.fu-berlin.de/792/},\n\
+    \ volume = {26},\n year = {2010}\n}\n\n"
   creators:
   - name:
-      family: de la Garza
-      given: L.
-      honourific:
-      lineage:
-    id:
+      family: Emde
+      given: A.-K.
+      honourific: null
+      lineage: null
   - name:
-      family: Krüger
-      given: J.
-      honourific:
-      lineage:
-    id:
-  - name:
-      lineage:
-      family: Schärfe
-      honourific:
-      given: Ch.
-    id:
-  - id:
-    name:
-      lineage:
-      family: Röttig
-      honourific:
+      family: Grunert
       given: M.
-  - id:
-    name:
-      lineage:
-      family: Aiche
-      honourific:
-      given: S.
+      honourific: null
+      lineage: null
+  - name:
+      family: Weese
+      given: D.
+      honourific: null
+      lineage: null
   - name:
       family: Reinert
-      honourific:
       given: K.
-      lineage:
-    id: knut.reinert@fu-berlin.de
+      honourific: null
+      lineage: null
   - name:
-      lineage:
-      family: Kohlbacher
-      honourific:
-      given: O.
-    id:
-- id_number: doi:10.1186/s12859-016-0978-9
-  metadata_visibility: show
+      family: Sperling
+      given: S. R.
+      honourific: null
+      lineage: null
+  date: '2010-01-01'
   date_type: published
-  full_text_status: none
-  refereed: 'TRUE'
-  eprintid: 2130
-  number: 1
+  datestamp: '2009-11-10 13:22:54'
+  dir: disk0/00/00/07/92
   divisions:
   - group_algbioinf
+  eprint_status: archive
+  eprintid: 792
+  full_text_status: none
+  id_number: 'doi:10.1093/bioinformatics/btp601 '
+  ispublished: pub
+  issn: 1367-4803
+  item_issues_count: 0
+  key: fu_mi_publications792
+  lastmod: '2010-09-01 13:04:47'
+  metadata_visibility: show
+  number: 1
+  official_url: http://bioinformatics.oxfordjournals.org/cgi/content/full/26/1/123
+  pagerange: 123-124
+  publication: Bioinformatics
+  publisher: Oxford University Press
+  refereed: 'TRUE'
+  related_url:
+  - url: http://bioinformatics.oxfordjournals.org/cgi/content/abstract/btp601v1
+  - url: http://bioinformatics.oxfordjournals.org/cgi/content/short/26/1/123
+  rev_number: 18
+  status_changed: '2010-08-23 12:05:14'
+  subjects:
+  - C
+  - G
+  title: 'MicroRazerS: Rapid alignment of small RNA reads'
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/792
+  userid: 30
+  volume: 26
+- abstract: "Before the SeqAn project, there was clearly a lack of available implementations\
+    \ in sequence analysis, even for standard tasks. Implementations of needed algorithmic\
+    \ components were either unavailable or hard to access in third-party monolithic\
+    \ software products. Addressing these concerns, the developers of SeqAn created\
+    \ a comprehensive, easy-to-use, open source C++ library of efficient algorithms\
+    \ and data structures for the analysis of biological sequences. Written by the\
+    \ founders of this project, Biological Sequence Analysis Using the SeqAn C++ Library\
+    \ covers the SeqAn library, its documentation, and the supporting infrastructure.\r\
+    \n\r\n\r\nThe first part of the book describes the general library design. It\
+    \ introduces biological sequence analysis problems, discusses the benefit of using\
+    \ software libraries, summarizes the design principles and goals of SeqAn, details\
+    \ the main programming techniques used in SeqAn, and demonstrates the application\
+    \ of these techniques in various examples. Focusing on the components provided\
+    \ by SeqAn, the second part explores basic functionality, sequence data structures,\
+    \ alignments, pattern and motif searching, string indices, and graphs. The last\
+    \ part illustrates applications of SeqAn to genome alignment, consensus sequence\
+    \ in assembly projects, suffix array construction, and more.\r\n\r\n\r\nThis handy\
+    \ book describes a user-friendly library of efficient data types and algorithms\
+    \ for sequence analysis in computational biology. SeqAn enables not only the implementation\
+    \ of new algorithms, but also the sound analysis and comparison of existing algorithms.\r\
+    \n"
+  bibtex: "@book{fu_mi_publications825,\n abstract = {Before the SeqAn project, there\
+    \ was clearly a lack of available implementations in sequence analysis, even for\
+    \ standard tasks. Implementations of needed algorithmic components were either\
+    \ unavailable or hard to access in third-party monolithic software products. Addressing\
+    \ these concerns, the developers of SeqAn created a comprehensive, easy-to-use,\
+    \ open source C++ library of efficient algorithms and data structures for the\
+    \ analysis of biological sequences. Written by the founders of this project, Biological\
+    \ Sequence Analysis Using the SeqAn C++ Library covers the SeqAn library, its\
+    \ documentation, and the supporting infrastructure.\n\n\nThe first part of the\
+    \ book describes the general library design. It introduces biological sequence\
+    \ analysis problems, discusses the benefit of using software libraries, summarizes\
+    \ the design principles and goals of SeqAn, details the main programming techniques\
+    \ used in SeqAn, and demonstrates the application of these techniques in various\
+    \ examples. Focusing on the components provided by SeqAn, the second part explores\
+    \ basic functionality, sequence data structures, alignments, pattern and motif\
+    \ searching, string indices, and graphs. The last part illustrates applications\
+    \ of SeqAn to genome alignment, consensus sequence in assembly projects, suffix\
+    \ array construction, and more.\n\n\nThis handy book describes a user-friendly\
+    \ library of efficient data types and algorithms for sequence analysis in computational\
+    \ biology. SeqAn enables not only the implementation of new algorithms, but also\
+    \ the sound analysis and comparison of existing algorithms.},\n address = {Boca\
+    \ Raton, USA},\n author = {A. Gogol-D{\\\"o}ring and K. Reinert},\n number = {1},\n\
+    \ publisher = {CRC Press},\n series = {Chapman \\& Hall/CRC Mathematical \\& Computational\
+    \ Biology },\n title = {Biological Sequence Analysis using the SeqAn C++ Library},\n\
+    \ url = {http://publications.imp.fu-berlin.de/825/},\n year = {2010}\n}\n\n"
+  creators:
+  - id: andreas.doering@mdc-berlin.de
+    name:
+      family: "Gogol-D\xF6ring"
+      given: A.
+      honourific: null
+      lineage: null
+  - id: knut.reinert@fu-berlin.de
+    name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  date: 2010
+  date_type: published
+  datestamp: '2010-03-04 12:10:11'
+  dir: disk0/00/00/08/25
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 825
+  full_text_status: none
+  isbn: 9781420076233
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications825
+  lastmod: '2010-09-01 13:26:25'
+  metadata_visibility: show
+  number: 1
+  official_url: http://crcpress.com/product/isbn/9781420076233
+  pages: 311
+  place_of_pub: Boca Raton, USA
+  publisher: CRC Press
+  refereed: 'FALSE'
+  rev_number: 11
+  series: 'Chapman & Hall/CRC Mathematical & Computational Biology '
+  status_changed: '2010-03-04 12:10:11'
   subjects:
   - G400
-  volume: 17
-  date: '2016-03-12'
-  dir: disk0/00/00/21/30
-  issn: 1471-2105
-  eprint_status: archive
-  uri: http://publications.imp.fu-berlin.de/id/eprint/2130
-  lastmod: '2017-11-22 13:42:20'
-  ispublished: pub
-  official_url: http://doi.org/10.1186/s12859-016-0978-9
+  title: Biological Sequence Analysis using the SeqAn C++ Library
+  type: book
+  uri: http://publications.imp.fu-berlin.de/id/eprint/825
   userid: 132
-  publisher: Springer Nature
-  type: article
-  rev_number: 5
-  title: 'From the desktop to the grid: scalable bioinformatics via workflow conversion'
-  status_changed: '2017-11-22 13:42:20'
-  abstract: "BackgroundReproducibility is one of the tenets of the scientific
-    method. Scientific experiments often comprise complex data flows, selection of
-    adequate parameters, and analysis and visualization of intermediate and end results.
-    Breaking down the complexity of such experiments into the joint collaboration
-    of small, repeatable, well defined tasks, each with well defined inputs, parameters,
-    and outputs, offers the immediate benefit of identifying bottlenecks, pinpoint
-    sections which could benefit from parallelization, among others. Workflows rest
-    upon the notion of splitting complex work into the joint effort of several manageable
-    tasks.There are several engines that give users the ability to design
-    and execute workflows. Each engine was created to address certain problems of
-    a specific community, therefore each one has its advantages and shortcomings.
-    Furthermore, not all features of all workflow engines are royalty-free —an aspect
-    that could potentially drive away members of the scientific community.ResultsWe
-    have developed a set of tools that enables the scientific community to benefit
-    from workflow interoperability. We developed a platform-free structured representation
-    of parameters, inputs, outputs of command-line tools in so-called Common Tool
-    Descriptor documents. We have also overcome the shortcomings and combined the
-    features of two royalty-free workflow engines with a substantial user community:
-    the Konstanz Information Miner, an engine which we see as a formidable workflow
-    editor, and the Grid and User Support Environment, a web-based framework able
-    to interact with several high-performance computing resources. We have thus created
-    a free and highly accessible way to design workflows on a desktop computer and
-    execute them on high-performance computing resources.ConclusionsOur
-    work will not only reduce time spent on designing scientific workflows, but also
-    make executing workflows on remote high-performance computing resources more accessible
-    to technically inexperienced users. We strongly believe that our efforts not only
-    decrease the turnaround time to obtain scientific results but also have a positive
-    impact on reproducibility, thus elevating the quality of obtained scientific results."
-  publication: BMC Bioinformatics
-  datestamp: '2017-11-22 13:42:20'
+- abstract: "In electrospray ionization mass spectrometry (ESI\u2212MS), peptide and\
+    \ protein ions are usually observed in multiple charge states. Moreover, adduction\
+    \ of the multiply charged species with other ions frequently results in quite\
+    \ complex signal patterns for a single analyte, which significantly complicates\
+    \ the derivation of quantitative information from the mass spectra. Labeling strategies\
+    \ targeting the MS1 level further aggravate this situation, as multiple biological\
+    \ states such as healthy or diseased must be represented simultaneously. We developed\
+    \ an integer linear programming (ILP) approach, which can cluster signals belonging\
+    \ to the same peptide or protein. The algorithm is general in that it models all\
+    \ possible shifts of signals along the m/z axis. These shifts can be induced by\
+    \ different charge states of the compound, the presence of adducts (e.g., potassium\
+    \ or sodium), and/or a fixed mass label (e.g., from ICAT or nicotinic acid labeling),\
+    \ or any combination of the above. We show that our approach can be used to infer\
+    \ more features in labeled data sets, correct wrong charge assignments even in\
+    \ high-resolution MS, improve mass precision, and cluster charged species in different\
+    \ charge states and several adduct types."
+  bibtex: "@article{fu_mi_publications895,\n abstract = {In electrospray ionization\
+    \ mass spectrometry (ESI?MS), peptide and protein ions are usually observed in\
+    \ multiple charge states. Moreover, adduction of the multiply charged species\
+    \ with other ions frequently results in quite complex signal patterns for a single\
+    \ analyte, which significantly complicates the derivation of quantitative information\
+    \ from the mass spectra. Labeling strategies targeting the MS1 level further aggravate\
+    \ this situation, as multiple biological states such as healthy or diseased must\
+    \ be represented simultaneously. We developed an integer linear programming (ILP)\
+    \ approach, which can cluster signals belonging to the same peptide or protein.\
+    \ The algorithm is general in that it models all possible shifts of signals along\
+    \ the m/z axis. These shifts can be induced by different charge states of the\
+    \ compound, the presence of adducts (e.g., potassium or sodium), and/or a fixed\
+    \ mass label (e.g., from ICAT or nicotinic acid labeling), or any combination\
+    \ of the above. We show that our approach can be used to infer more features in\
+    \ labeled data sets, correct wrong charge assignments even in high-resolution\
+    \ MS, improve mass precision, and cluster charged species in different charge\
+    \ states and several adduct types.},\n author = {C. Bielow and S. Ruzek and C.\
+    \ Huber and K. Reinert},\n journal = {J. Proteome Res.},\n month = {March},\n\
+    \ note = {online publication complete, printed publication to be expected},\n\
+    \ number = {5},\n pages = {2688--2695},\n publisher = {ACS Publications},\n title\
+    \ = {Optimal Decharging and Clustering of Charge Ladders Generated in ESI?MS},\n\
+    \ url = {http://publications.imp.fu-berlin.de/895/},\n volume = {9},\n year =\
+    \ {2010}\n}\n\n"
   creators:
-  - name:
-      lineage:
-      family: de la Garza
-      given: Luis
-      honourific:
-  - name:
-      family: Veit
-      given: Johannes
-      honourific:
-      lineage:
-  - name:
-      lineage:
-      family: Szolek
-      given: Andras
-      honourific:
-  - name:
-      lineage:
-      given: Marc
-      honourific:
-      family: Röttig
-  - name:
-      lineage:
-      honourific:
-      given: Stephan
-      family: Aiche
-  - name:
-      lineage:
-      honourific:
-      given: Sandra
-      family: Gesing
-  - name:
-      lineage:
+  - id: bielow@mi.fu-berlin.de
+    name:
+      family: Bielow
+      given: C.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Ruzek
+      given: S.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Huber
+      given: C.
+      honourific: null
+      lineage: null
+  - id: knut.reinert@fu-berlin.de
+    name:
       family: Reinert
-      given: Knut
-      honourific:
-  - name:
-      lineage:
-      given: Oliver
-      honourific:
-      family: Kohlbacher
+      given: K.
+      honourific: null
+      lineage: null
+  date: '2010-03-04'
+  date_type: published
+  datestamp: '2010-04-14 11:06:56'
+  dir: disk0/00/00/08/95
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 895
+  full_text_status: none
+  id_number: 10.1021/pr100177k
+  ispublished: pub
+  issn: 1535-3893
+  item_issues_count: 0
+  key: fu_mi_publications895
+  lastmod: '2010-09-01 13:25:48'
+  metadata_visibility: show
+  note: online publication complete, printed publication to be expected
+  number: 5
+  official_url: http://pubs.acs.org/doi/abs/10.1021/pr100177k
+  pagerange: 2688-2695
+  publication: J. Proteome Res.
+  publisher: ACS Publications
+  refereed: 'TRUE'
+  rev_number: 10
+  status_changed: '2010-04-14 11:06:56'
+  subjects:
+  - G400
+  title: "Optimal Decharging and Clustering of Charge Ladders Generated in ESI\u2212\
+    MS"
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/895
+  userid: 168
+  volume: 9
+- abstract: We present a simple randomized data structure for two-dimensional point
+    sets that allows fast nearest neighbor queries in many cases. An implementation
+    outperforms several previous implementations for commonly used benchmarks.
+  bibtex: "@article{fu_mi_publications926,\n abstract = {We present a simple randomized\
+    \ data structure for two-dimensional point sets that allows fast nearest neighbor\
+    \ queries in many cases. An implementation outperforms several previous implementations\
+    \ for commonly used benchmarks.},\n author = {M. Birn and M. Holtgrewe and P.\
+    \ Sanders and J. Singler},\n journal = {2010 Proceedings of the Twelfth Workshop\
+    \ on Algorithm Engineering and Experiments (ALENEX)},\n pages = {43--54},\n publisher\
+    \ = {ACM SIAM},\n title = {Simple and Fast Nearest Neighbor Search},\n url = {http://publications.imp.fu-berlin.de/926/},\n\
+    \ year = {2010}\n}\n\n"
+  creators:
+  - id: marcelbirn@gmx.de
+    name:
+      family: Birn
+      given: M.
+      honourific: null
+      lineage: null
+  - id: holtgrewe@ira.uka.de
+    name:
+      family: Holtgrewe
+      given: M.
+      honourific: null
+      lineage: null
+  - id: 'sanders@kit.edu '
+    name:
+      family: Sanders
+      given: P.
+      honourific: null
+      lineage: null
+  - id: 'singler@kit.edu '
+    name:
+      family: Singler
+      given: J.
+      honourific: null
+      lineage: null
+  date: 2010
+  date_type: published
+  datestamp: '2010-08-23 12:48:49'
+  dir: disk0/00/00/09/26
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 926
+  full_text_status: none
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications926
+  lastmod: '2010-09-01 13:33:56'
+  metadata_visibility: show
+  official_url: http://www.siam.org/proceedings/alenex/2010/alenex10.php
+  pagerange: 43-54
+  publication: 2010 Proceedings of the Twelfth Workshop on Algorithm Engineering and
+    Experiments (ALENEX)
+  publisher: ACM SIAM
+  refereed: 'TRUE'
+  rev_number: 8
+  status_changed: '2010-08-23 12:48:49'
+  subjects:
+  - G400
+  title: Simple and Fast Nearest Neighbor Search
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/926
+  userid: 167
+- abstract: We describe an approach to parallel graph partitioning that scales to
+    hundreds of processors and produces a high solution quality. For example, for
+    many instances from Walshaw's benchmark collection we improve the best known partitioning.
+    We use the well known framework of multi-level graph partitioning. All components
+    are implemented by scalable parallel algorithms. Quality improvements compared
+    to previous systems are due to better prioritization of edges to be contracted,
+    better approximation algorithms for identifying matchings, better local search
+    heuristics, and perhaps most notably, a parallelization of the FM local search
+    algorithm that works more locally than previous approaches.
+  bibtex: "@article{fu_mi_publications930,\n abstract = {We describe an approach to\
+    \ parallel graph partitioning that scales to hundreds of processors and produces\
+    \ a high solution quality. For example, for many instances from Walshaw's benchmark\
+    \ collection we improve the best known partitioning. We use the well known framework\
+    \ of multi-level graph partitioning. All components are implemented by scalable\
+    \ parallel algorithms. Quality improvements compared to previous systems are due\
+    \ to better prioritization of edges to be contracted, better approximation algorithms\
+    \ for identifying matchings, better local search heuristics, and perhaps most\
+    \ notably, a parallelization of the FM local search algorithm that works more\
+    \ locally than previous approaches.},\n author = {M. Holtgrewe and P. Sanders\
+    \ and C. Schulz},\n journal = {2010 IEEE International Symposium on Parallel \\\
+    & Distributed Processing (IPDPS)},\n month = {April},\n pages = {1--12},\n title\
+    \ = {Engineering a scalable high quality graph partitioner},\n url = {http://publications.imp.fu-berlin.de/930/},\n\
+    \ year = {2010}\n}\n\n"
+  creators:
+  - id: holtgrewe@ira.uka.de
+    name:
+      family: Holtgrewe
+      given: M.
+      honourific: null
+      lineage: null
+  - id: sanders@kit.edu
+    name:
+      family: Sanders
+      given: P.
+      honourific: null
+      lineage: null
+  - id: c_schulz@ira.uka.de
+    name:
+      family: Schulz
+      given: C.
+      honourific: null
+      lineage: null
+  date: 2010-04
+  date_type: published
+  datestamp: '2010-08-23 12:49:46'
+  dir: disk0/00/00/09/30
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 930
+  full_text_status: none
+  id_number: '10.1109/IPDPS.2010.5470485 '
+  ispublished: pub
+  issn: '1530-2075 '
+  item_issues_count: 0
+  key: fu_mi_publications930
+  lastmod: '2010-09-01 13:33:27'
+  metadata_visibility: show
+  official_url: http://ieeexplore.ieee.org/xpl/freeabs_all.jsp?arnumber=5470485
+  pagerange: 1-12
+  publication: 2010 IEEE International Symposium on Parallel & Distributed Processing
+    (IPDPS)
+  refereed: 'TRUE'
+  rev_number: 7
+  status_changed: '2010-08-23 12:49:46'
+  subjects:
+  - G400
+  title: Engineering a scalable high quality graph partitioner
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/930
+  userid: 167
+- abstract: Adeno-associated virus type 2 (AAV) is known to establish latency by preferential
+    integration in human chromosome 19q13.42. The AAV non-structural protein Rep appears
+    to target a site called AAVS1 by simultaneously binding to Rep-binding sites (RBS)
+    present on the AAV genome and within AAVS1. In the absence of Rep, as is the case
+    with AAV vectors, chromosomal integration is rare and random. For a genome-wide
+    survey of wildtype AAV integration a linker-selection-mediated (LSM)-PCR strategy
+    was designed to retrieve AAV-chromosomal junctions. DNA sequence determination
+    revealed wildtype AAV integration sites scattered over the entire human genome.
+    The bioinformatic analysis of these integration sites compared to those of rep-deficient
+    AAV vectors revealed a highly significant overrepresentation of integration events
+    near to consensus RBS. Integration hotspots included AAVS1 with 10% of total events.
+    Novel hotspots near consensus RBS were identified on chromosome 5p13.3 denoted
+    AAVS2 and on chromsome 3p24.3 denoted AAVS3. AAVS2 displayed seven independent
+    junctions clustered within only 14 bp of a consensus RBS which proved to bind
+    Rep in vitro similar to the RBS in AAVS3. Expression of Rep in the presence of
+    rep-deficient AAV vectors shifted targeting preferences from random integration
+    back to the neighbourhood of consensus RBS at hotspots and numerous additional
+    sites in the human genome. In summary, targeted AAV integration is not as specific
+    for AAVS1 as previously assumed. Rather, Rep targets AAV to integrate into open
+    chromatin regions in the reach of various, consensus RBS homologues in the human
+    genome.
+  bibtex: "@article{fu_mi_publications935,\n abstract = {Adeno-associated virus type\
+    \ 2 (AAV) is known to establish latency by preferential integration in human chromosome\
+    \ 19q13.42. The AAV non-structural protein Rep appears to target a site called\
+    \ AAVS1 by simultaneously binding to Rep-binding sites (RBS) present on the AAV\
+    \ genome and within AAVS1. In the absence of Rep, as is the case with AAV vectors,\
+    \ chromosomal integration is rare and random. For a genome-wide survey of wildtype\
+    \ AAV integration a linker-selection-mediated (LSM)-PCR strategy was designed\
+    \ to retrieve AAV-chromosomal junctions. DNA sequence determination revealed wildtype\
+    \ AAV integration sites scattered over the entire human genome. The bioinformatic\
+    \ analysis of these integration sites compared to those of rep-deficient AAV vectors\
+    \ revealed a highly significant overrepresentation of integration events near\
+    \ to consensus RBS. Integration hotspots included AAVS1 with 10\\% of total events.\
+    \ Novel hotspots near consensus RBS were identified on chromosome 5p13.3 denoted\
+    \ AAVS2 and on chromsome 3p24.3 denoted AAVS3. AAVS2 displayed seven independent\
+    \ junctions clustered within only 14 bp of a consensus RBS which proved to bind\
+    \ Rep in vitro similar to the RBS in AAVS3. Expression of Rep in the presence\
+    \ of rep-deficient AAV vectors shifted targeting preferences from random integration\
+    \ back to the neighbourhood of consensus RBS at hotspots and numerous additional\
+    \ sites in the human genome. In summary, targeted AAV integration is not as specific\
+    \ for AAVS1 as previously assumed. Rather, Rep targets AAV to integrate into open\
+    \ chromatin regions in the reach of various, consensus RBS homologues in the human\
+    \ genome.},\n author = {D. H{\\\"u}ser and A. Gogol-D{\\\"o}ring and T. Lutter\
+    \ and S. Weger and K. Winter and E.-M. Hammer and T. Cathomen and K. Reinert and\
+    \ R. Heilbronn},\n journal = {PLoS Pathogens},\n month = {July},\n number = {7},\n\
+    \ pages = {e1000985},\n title = {Integration Preferences of Wildtype AAV-2 for\
+    \ Consensus Rep-Binding Sites at Numerous Loci in the Human Genome},\n url = {http://publications.imp.fu-berlin.de/935/},\n\
+    \ volume = {6},\n year = {2010}\n}\n\n"
+  creators:
+  - id: null
+    name:
+      family: "H\xFCser"
+      given: D.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: "Gogol-D\xF6ring"
+      given: A.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Lutter
+      given: T.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Weger
+      given: S.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Winter
+      given: K.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Hammer
+      given: E.-M.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Cathomen
+      given: T.
+      honourific: null
+      lineage: null
+  - id: knut.reinert@fu-berlin.de
+    name:
+      family: Reinert
+      given: K.
+      honourific: null
+      lineage: null
+  - id: null
+    name:
+      family: Heilbronn
+      given: R.
+      honourific: null
+      lineage: null
+  date: '2010-07-08'
+  date_type: published
+  datestamp: '2010-08-26 11:10:39'
+  dir: disk0/00/00/09/35
+  divisions:
+  - group_algbioinf
+  eprint_status: archive
+  eprintid: 935
+  full_text_status: none
+  id_number: doi:10.1371/journal.ppat.1000985
+  ispublished: pub
+  issn: 1553-7374
+  item_issues_count: 0
+  key: fu_mi_publications935
+  lastmod: '2010-11-18 13:44:27'
+  metadata_visibility: show
+  number: 7
+  official_url: http://dx.doi.org/10.1371/journal.ppat.1000985
+  pagerange: e1000985
+  publication: PLoS Pathogens
+  refereed: 'TRUE'
+  rev_number: 11
+  status_changed: '2010-11-18 13:44:27'
+  subjects:
+  - G400
+  title: Integration Preferences of Wildtype AAV-2 for Consensus Rep-Binding Sites
+    at Numerous Loci in the Human Genome
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/935
+  userid: 132
+  volume: 6
+- abstract: We present a read simulator software for Illumina, 454 and Sanger reads.
+    Its features include position specific error rates and base quality values. For
+    Illumina reads, we give a comprehensive analysis with empirical data for the error
+    and quality model. For the other technologies, we use models from the literature.
+    It has been written with performance in mind and can sample reads from large genomes.
+    The C++ source code is extensible, and freely available under the GPL/LGPL.
+  bibtex: "@article{fu_mi_publications962,\n abstract = {We present a read simulator\
+    \ software for Illumina, 454 and Sanger reads. Its features include position specific\
+    \ error rates and base quality values. For Illumina reads, we give a comprehensive\
+    \ analysis with empirical data for the error and quality model. For the other\
+    \ technologies, we use models from the literature. It has been written with performance\
+    \ in mind and can sample reads from large genomes. The C++ source code is extensible,\
+    \ and freely available under the GPL/LGPL.},\n author = {M. Holtgrewe},\n journal\
+    \ = {Technical Report FU Berlin},\n month = {October},\n title = {Mason ? A Read\
+    \ Simulator for Second Generation Sequencing Data},\n url = {http://publications.imp.fu-berlin.de/962/},\n\
+    \ year = {2010}\n}\n\n"
+  creators:
+  - id: manuel.holtgrewe@fu-berlin.de
+    name:
+      family: Holtgrewe
+      given: M.
+      honourific: null
+      lineage: null
+  date: 2010-10
+  datestamp: '2011-10-08 13:21:08'
+  dir: disk0/00/00/09/62
+  divisions:
+  - group_algbioinf
+  documents:
+  - content: submitted
+    docid: 509
+    eprintid: 962
+    files:
+    - datasetid: document
+      fileid: 11200
+      filename: mason201009.pdf
+      filesize: 338345
+      mime_type: application/pdf
+      mtime: '2017-03-03 14:40:55'
+      objectid: 509
+      uri: http://publications.imp.fu-berlin.de/id/file/11200
+    format: application/pdf
+    language: en
+    main: mason201009.pdf
+    mime_type: application/pdf
+    pos: 2
+    relation:
+    - type: http://eprints.org/relation/hasVersion
+      uri: /id/document/1165
+    - type: http://eprints.org/relation/haspreviewThumbnailVersion
+      uri: /id/document/1165
+    - type: http://eprints.org/relation/hasVolatileVersion
+      uri: /id/document/1165
+    rev_number: 4
+    security: public
+    uri: http://publications.imp.fu-berlin.de/id/document/509
+  eprint_status: archive
+  eprintid: 962
+  full_text_status: public
+  ispublished: pub
+  item_issues_count: 0
+  key: fu_mi_publications962
+  lastmod: '2017-03-03 14:40:55'
+  metadata_visibility: show
+  publication: Technical Report FU Berlin
+  refereed: 'FALSE'
+  rev_number: 19
+  status_changed: '2011-10-08 14:32:15'
+  subjects:
+  - G400
+  title: "Mason \u2013 A Read Simulator for Second Generation Sequencing Data"
+  type: article
+  uri: http://publications.imp.fu-berlin.de/id/eprint/962
+  userid: 167

--- a/_includes/cite.html
+++ b/_includes/cite.html
@@ -1,8 +1,14 @@
-{%- assign cite = site.data.publications | where: "id", include.cite | first -%}
+{%- assign cite = site.data.publications | where: "datestamp", include.cite | first -%}
 {%- if cite -%}
-    {{ cite.author }}
-    {%- if cite.doi -%}
-    , <a href="https://doi.org/{{ cite.doi }}">“{{ cite.title }}”</a>
+    {%- for creator in cite.creators -%}
+        {{creator.name.given}} {{creator.name.family}},
+    {% endfor %}
+    {%- for editor in cite.editors -%}
+        {{editor.name.given}} {{editor.name.family}},
+    {% endfor %}
+
+    {%- if cite.official_url -%}
+     <a href="https://doi.org/{{ cite.official_url }}">“{{ cite.title }}”</a>
     {%- else -%}
     , “{{ cite.title }}”
     {%- endif -%}
@@ -23,8 +29,8 @@
     , p. {{ cite.pages }}
     {%- endif -%}
 
-    {%- if cite.year -%}
-    , {{ cite.year }}
+    {%- if cite.date -%}
+    , {{ cite.date }}
     {%- endif -%}
     .
 {%- else -%}

--- a/_includes/cite.html
+++ b/_includes/cite.html
@@ -8,7 +8,7 @@
     {% endfor %}
 
     {%- if cite.official_url -%}
-     <a href="https://doi.org/{{ cite.official_url }}">“{{ cite.title }}”</a>
+     <a href="{{ cite.official_url }}">“{{ cite.title }}”</a>
     {%- else -%}
     , “{{ cite.title }}”
     {%- endif -%}
@@ -33,6 +33,73 @@
     , {{ cite.date }}
     {%- endif -%}
     .
+    <details class="citation-details">
+        <summary class="citation">cite this publication</summary>
+        {%- if cite.type == "article" -%}
+        @article{ {{cite.uri | slice: 46, 60 | remove: "/"}}-Fu-Berlin
+
+        {%- elsif cite.type == "book" -%}
+        @book{ {{cite.uri | slice: 46, 60 | remove: "/"}}-Fu-Berlin
+
+        {%- elsif cite.type == "book_section" -%}
+        @incollection{ {{{cite.uri | slice: 46, 60 | remove: "/"}}-Fu-Berlin
+
+        {%- elsif cite.monograph_type == "documentation" -%}
+        @manual{ {{cite.uri | slice: 46, 60 | remove: "/"}}-Fu-Berlin
+
+        {%- elsif cite.monograph_type == "technical_report" -%}
+        @techreport{ {{cite.uri | slice: 46, 60 | remove: "/"}}-Fu-Berlin
+
+        {%- elsif cite.thesis_type == "phd" -%}
+        @phdthesis{ {{cite.uri | slice: 46, 60 | remove: "/"}}-Fu-Berlin
+
+        {%- elsif cite.ispublished == "unpub" -%}
+        @unpublished{ {{{cite.uri | slice: 46, 60 | remove: "/"}}-Fu-Berlin
+
+        {%- else -%}
+        @misc{ {{{cite.uri | slice: 46, 60 | remove: "/"}}-Fu-Berlin
+        {%- endif -%}
+
+        {%- if cite.title -%}
+        ,<br>title = { {{cite.title}} }
+        {%- endif -%}
+        ,<br>year = { {{cite.date | truncate: 4, ''}} }
+        {%- assign string_date = cite.date | upcase -%}
+        {%- if string_date.size > 4 -%}
+        ,<br>month = { {{cite.date | slice: 5, 2 }} }
+        {%- endif -%}
+        {%- if cite.book_title -%}
+        ,<br>booktitle = { {{cite.book_title}} }
+        {%- endif -%}
+        {%- if cite.volume -%}
+        ,<br>volume = { {{cite.volume}} }
+        {%- endif -%}
+        {%- if cite.publisher -%}
+        ,<br>publisher = { {{cite.publisher}} }
+        {%- endif -%}
+        {%- if cite.publication -%}
+        ,<br>journal = { {{cite.publication}} }
+        {%- endif -%}
+        {%- if cite.pagerange -%}
+        ,<br>page = { {{cite.pagerange}} }
+        {%- elsif cite.pages -%}
+        ,<br>page = { {{cite.pages}} }
+        {%- endif -%}
+        {%- if cite.creators -%}
+        ,<br>author = { {%- for creator in cite.creators -%}
+                        {{creator.name.given}} {{creator.name.family}} and
+                    {% endfor %} }
+        {%- endif -%}
+        {%- if cite.editors -%}
+        ,<br>editor = { {%- for editor in cite.editors -%}
+                        {{editor.name.given}} {{editor.name.family}} and
+                    {% endfor %} }
+        {%- endif -%}
+        {%- if cite.abstract -%}
+        ,<br>abstract = { {{cite.abstract }} }
+        {%- endif -%}
+        }
+    </details>
 {%- else -%}
 ERROR: no citation found
 {%- endif -%}

--- a/_includes/cite.html
+++ b/_includes/cite.html
@@ -1,4 +1,4 @@
-{%- assign cite = site.data.publications | where: "datestamp", include.cite | first -%}
+{%- assign cite = site.data.publications | where: "key", include.cite | first -%}
 {%- if cite -%}
     {%- for creator in cite.creators -%}
         {{creator.name.given}} {{creator.name.family}},
@@ -33,72 +33,11 @@
     , {{ cite.date }}
     {%- endif -%}
     .
-    <details class="citation-details">
+    <details>
         <summary class="citation">cite this publication</summary>
-        {%- if cite.type == "article" -%}
-        @article{ {{cite.uri | slice: 46, 60 | remove: "/"}}-Fu-Berlin
-
-        {%- elsif cite.type == "book" -%}
-        @book{ {{cite.uri | slice: 46, 60 | remove: "/"}}-Fu-Berlin
-
-        {%- elsif cite.type == "book_section" -%}
-        @incollection{ {{{cite.uri | slice: 46, 60 | remove: "/"}}-Fu-Berlin
-
-        {%- elsif cite.monograph_type == "documentation" -%}
-        @manual{ {{cite.uri | slice: 46, 60 | remove: "/"}}-Fu-Berlin
-
-        {%- elsif cite.monograph_type == "technical_report" -%}
-        @techreport{ {{cite.uri | slice: 46, 60 | remove: "/"}}-Fu-Berlin
-
-        {%- elsif cite.thesis_type == "phd" -%}
-        @phdthesis{ {{cite.uri | slice: 46, 60 | remove: "/"}}-Fu-Berlin
-
-        {%- elsif cite.ispublished == "unpub" -%}
-        @unpublished{ {{{cite.uri | slice: 46, 60 | remove: "/"}}-Fu-Berlin
-
-        {%- else -%}
-        @misc{ {{{cite.uri | slice: 46, 60 | remove: "/"}}-Fu-Berlin
-        {%- endif -%}
-
-        {%- if cite.title -%}
-        ,<br>title = { {{cite.title}} }
-        {%- endif -%}
-        ,<br>year = { {{cite.date | truncate: 4, ''}} }
-        {%- assign string_date = cite.date | upcase -%}
-        {%- if string_date.size > 4 -%}
-        ,<br>month = { {{cite.date | slice: 5, 2 }} }
-        {%- endif -%}
-        {%- if cite.book_title -%}
-        ,<br>booktitle = { {{cite.book_title}} }
-        {%- endif -%}
-        {%- if cite.volume -%}
-        ,<br>volume = { {{cite.volume}} }
-        {%- endif -%}
-        {%- if cite.publisher -%}
-        ,<br>publisher = { {{cite.publisher}} }
-        {%- endif -%}
-        {%- if cite.publication -%}
-        ,<br>journal = { {{cite.publication}} }
-        {%- endif -%}
-        {%- if cite.pagerange -%}
-        ,<br>page = { {{cite.pagerange}} }
-        {%- elsif cite.pages -%}
-        ,<br>page = { {{cite.pages}} }
-        {%- endif -%}
-        {%- if cite.creators -%}
-        ,<br>author = { {%- for creator in cite.creators -%}
-                        {{creator.name.given}} {{creator.name.family}} and
-                    {% endfor %} }
-        {%- endif -%}
-        {%- if cite.editors -%}
-        ,<br>editor = { {%- for editor in cite.editors -%}
-                        {{editor.name.given}} {{editor.name.family}} and
-                    {% endfor %} }
-        {%- endif -%}
-        {%- if cite.abstract -%}
-        ,<br>abstract = { {{cite.abstract }} }
-        {%- endif -%}
-        }
+        <div class="citation-body">
+            {{cite.bibtex | strip | newline_to_br }}
+        </div>
     </details>
 {%- else -%}
 ERROR: no citation found

--- a/_includes/cite.html
+++ b/_includes/cite.html
@@ -35,9 +35,9 @@
     .
     <details>
         <summary class="citation">cite this publication</summary>
-        ```bibtex
+        {% highlight bibtex -%}
         {{cite.bibtex | strip }}
-        ```
+        {%- endhighlight %}
     </details>
 {%- else -%}
 ERROR: no citation found

--- a/_includes/cite.html
+++ b/_includes/cite.html
@@ -35,9 +35,9 @@
     .
     <details>
         <summary class="citation">cite this publication</summary>
-        <div class="citation-body">
-            {{cite.bibtex | strip | newline_to_br }}
-        </div>
+        ```bibtex
+        {{cite.bibtex | strip }}
+        ```
     </details>
 {%- else -%}
 ERROR: no citation found

--- a/_includes/cite.html
+++ b/_includes/cite.html
@@ -33,10 +33,10 @@
     , {{ cite.date }}
     {%- endif -%}
     .
-    <details>
+    <details markdown="0">
         <summary class="citation">cite this publication</summary>
         {% highlight bibtex -%}
-        {{cite.bibtex | strip }}
+        {{ cite.bibtex | strip }}
         {%- endhighlight %}
     </details>
 {%- else -%}

--- a/_includes/cite.html
+++ b/_includes/cite.html
@@ -10,7 +10,7 @@
     {%- if cite.official_url -%}
      <a href="{{ cite.official_url }}">“{{ cite.title }}”</a>
     {%- else -%}
-    , “{{ cite.title }}”
+    “{{ cite.title }}”
     {%- endif -%}
 
     {%- if cite.journal -%}
@@ -33,7 +33,7 @@
     , {{ cite.date }}
     {%- endif -%}
     .
-    <details markdown="0">
+    <details>
         <summary class="citation">cite this publication</summary>
         {% highlight bibtex -%}
         {{ cite.bibtex | strip }}

--- a/_sass/minima/custom-styles.scss
+++ b/_sass/minima/custom-styles.scss
@@ -36,8 +36,3 @@
 .citation{
     color: grey;
 }
-.citation-body{
-    background: lightgrey;
-    border-radius: 10px;
-    padding: 1em;
-}

--- a/_sass/minima/custom-styles.scss
+++ b/_sass/minima/custom-styles.scss
@@ -32,4 +32,12 @@
 .person:hover{
     background-color: #fede09;
     transition: 0.2s;
+.citation{
+    color: grey;
+    background: white;
+}
+
+.citation-details{
+    background: grey;
+    border-radius: 5px;
 }

--- a/_sass/minima/custom-styles.scss
+++ b/_sass/minima/custom-styles.scss
@@ -32,12 +32,12 @@
 .person:hover{
     background-color: #fede09;
     transition: 0.2s;
+}
 .citation{
     color: grey;
-    background: white;
 }
-
-.citation-details{
-    background: grey;
-    border-radius: 5px;
+.citation-body{
+    background: lightgrey;
+    border-radius: 10px;
+    padding: 1em;
 }

--- a/process_publications.py
+++ b/process_publications.py
@@ -1,0 +1,31 @@
+import bibtexparser
+import json
+import yaml
+
+json_file = "_data/publications.json"
+yml_file = "_data/publications.yml"
+bib_file = "_data/publications.bib"
+
+# parse the bibtex file
+with open(bib_file) as bibtex_file:
+    bib = bibtexparser.load(bibtex_file)
+
+# parse the json file
+with open(json_file) as js_file:
+    js = json.load(js_file)
+
+for entry in js:
+    # replace the keys
+    entry["key"] = "fu_mi_publications" + str(entry["eprintid"])
+    # extract the corresponding bibtex entry
+    temp_entry = bib.entries_dict[entry["key"]]
+    # create new temporary database
+    temp_db = bibtexparser.bibdatabase.BibDatabase()
+    # Insert temporary entry into temporary Database
+    temp_db.entries = [temp_entry]
+    # insert bibtex string into the json entry
+    entry["bibtex"] = bibtexparser.dumps(temp_db)
+    del temp_db, temp_entry
+# write sorted entries to yml
+with open( yml_file, 'w') as out_file:
+    documents = yaml.dump(sorted(js, key=lambda x: x['key']), out_file, explicit_start=True)


### PR DESCRIPTION
…and formatted correctly.
Since the file served by http://publications.imp.fu-berlin.de/cgi/exportview/divisions/group=5Falgbioinf/JSON/group=5Falgbioinf.js is in .json format and does not contain fields like year, id or author, several changes had to be done:
- The year is taken from the date property which is truncated after the first four digits.
- The publications file has yet to be automatically fetched from the FU publicaitions page as json file and translated into a yml file. 
- The datestamp now acts as the unique key of every publication and needs to be passed in single quotes.