### PR TITLE
[FIX] Add Legal notice.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -32,6 +32,8 @@
       </div>
       <div class="footer-col">
         <p>{{ site.description | escape }}</p>
+        <h3>LEGAL NOTICE</h3>
+        <p><a href="https://www.fu-berlin.de/redaktion/impressum/index.html">Impressum</a></p>
       </div>
     </div>
 


### PR DESCRIPTION
Linking to the impresses of the FU, as done on the old website and the landing page.
Resolves: https://github.com/seqan/www.seqan.de/issues/20 