### PR TITLE
[FIX] ruby>3 needs webrick as dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ gemspec
 gem "jekyll", ENV["JEKYLL_VERSION"] if ENV["JEKYLL_VERSION"]
 gem "kramdown-parser-gfm" if ENV["JEKYLL_VERSION"] == "~> 3.9"
 gem 'jekyll-redirect-from'
+gem 'webrick'


### PR DESCRIPTION
Split-off from https://github.com/seqan/www.seqan.de/pull/85

Current version produces an error when running `JEKYLL_ENV=vercel bundle exec jekyll serve`

Error:
```
Configuration file: /home/gene/Lehre/Forschung/code/www.seqan.de/_config.yml
 Theme Config file: /home/gene/Lehre/Forschung/code/www.seqan.de/_config.yml
            Source: /home/gene/Lehre/Forschung/code/www.seqan.de
       Destination: /home/gene/Lehre/Forschung/code/www.seqan.de/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
       Jekyll Feed: Generating feed for posts
                    done in 4.432 seconds.
 Auto-regeneration: enabled for '/home/gene/Lehre/Forschung/code/www.seqan.de'
                    ------------------------------------------------
      Jekyll 4.2.1   Please append `--trace` to the `serve` command 
                     for any additional information or backtrace. 
                    ------------------------------------------------
/home/gene/Lehre/Forschung/code/www.seqan.de/vendor/bundle/ruby/3.0.0/gems/jekyll-4.2.1/lib/jekyll/commands/serve/servlet.rb:3:in `require': cannot load such file -- webrick (LoadError)
....
```

This PR adds webrick to the gemfile